### PR TITLE
feat: stabilizer-based symmetry propagation for general permutation groups

### DIFF
--- a/.aicrowd/superpowers/plans/2026-04-14-stabilizer-propagation.md
+++ b/.aicrowd/superpowers/plans/2026-04-14-stabilizer-propagation.md
@@ -1,0 +1,1189 @@
+# Stabilizer-Based Symmetry Propagation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix slice/reduce symmetry propagation to correctly handle general permutation groups (C_k, D_k, etc.) using stabilizer subgroups instead of assuming S_k.
+
+**Architecture:** Add `pointwise_stabilizer`, `setwise_stabilizer`, and `restrict` methods to `PermutationGroup`. Rewrite `propagate_symmetry_slice`, `propagate_symmetry_reduce`, and `intersect_symmetry` to operate on `list[PermutationGroup]` instead of `list[tuple[int, ...]]`. Update callers in `SymmetricTensor.__getitem__` and `_pointwise.py`.
+
+**Tech Stack:** Python, numpy, pytest
+
+**Spec:** `.aicrowd/superpowers/specs/2026-04-14-stabilizer-propagation-design.md`
+
+---
+
+### Task 1: Add `pointwise_stabilizer` to `PermutationGroup`
+
+**Files:**
+- Modify: `src/whest/_perm_group.py:244-475` (PermutationGroup class)
+- Test: `tests/test_perm_group.py`
+
+- [ ] **Step 1: Write failing tests for pointwise_stabilizer**
+
+Add to `tests/test_perm_group.py`:
+
+```python
+class TestPointwiseStabilizer:
+    def test_s3_fix_one_point(self):
+        """S_3 fixing point 2 → {id, (0 1)} = S_2."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({2})
+        assert stab.order() == 2
+        assert stab.degree == 3
+        # The surviving elements fix point 2
+        for elem in stab.elements():
+            assert elem(2) == 2
+
+    def test_c3_fix_one_point(self):
+        """C_3 fixing any single point → trivial group."""
+        g = PermutationGroup.cyclic(3)
+        for pt in range(3):
+            stab = g.pointwise_stabilizer({pt})
+            assert stab.order() == 1
+
+    def test_c4_fix_two_points(self):
+        """C_4 fixing {1,3} pointwise → only identity."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.pointwise_stabilizer({1, 3})
+        assert stab.order() == 1
+
+    def test_s4_fix_two_points(self):
+        """S_4 fixing {0,1} pointwise → S_2 on {2,3}."""
+        g = PermutationGroup.symmetric(4)
+        stab = g.pointwise_stabilizer({0, 1})
+        assert stab.order() == 2
+        for elem in stab.elements():
+            assert elem(0) == 0
+            assert elem(1) == 1
+
+    def test_fix_empty_set(self):
+        """Fixing empty set returns the full group."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.pointwise_stabilizer(set())
+        assert stab.order() == g.order()
+
+    def test_fix_all_points(self):
+        """Fixing all points returns trivial group."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({0, 1, 2})
+        assert stab.order() == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_perm_group.py::TestPointwiseStabilizer -v`
+Expected: FAIL with `AttributeError: 'PermutationGroup' object has no attribute 'pointwise_stabilizer'`
+
+- [ ] **Step 3: Implement pointwise_stabilizer**
+
+Add to `PermutationGroup` class in `src/whest/_perm_group.py`, after the `orbit` method (after line 372):
+
+```python
+def pointwise_stabilizer(self, fixed: set[int]) -> PermutationGroup:
+    """Subgroup of elements that fix every point in *fixed*.
+
+    Parameters
+    ----------
+    fixed : set of int
+        Group-local indices that must map to themselves.
+
+    Returns
+    -------
+    PermutationGroup
+        The pointwise stabilizer subgroup (same degree).
+    """
+    if not fixed:
+        return PermutationGroup(*self._generators, axes=self._axes)
+    surviving = [g for g in self.elements() if all(g(p) == p for p in fixed)]
+    if not surviving:
+        surviving = [Permutation.identity(self._degree)]
+    return PermutationGroup(*surviving, axes=self._axes)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_perm_group.py::TestPointwiseStabilizer -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_perm_group.py tests/test_perm_group.py
+git commit -m "feat: add pointwise_stabilizer to PermutationGroup"
+```
+
+---
+
+### Task 2: Add `setwise_stabilizer` to `PermutationGroup`
+
+**Files:**
+- Modify: `src/whest/_perm_group.py:244-475` (PermutationGroup class)
+- Test: `tests/test_perm_group.py`
+
+- [ ] **Step 1: Write failing tests for setwise_stabilizer**
+
+Add to `tests/test_perm_group.py`:
+
+```python
+class TestSetwiseStabilizer:
+    def test_c4_setwise_13(self):
+        """C_4 setwise stabilizer of {1,3} → {id, rot²} = C_2."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.setwise_stabilizer({1, 3})
+        assert stab.order() == 2
+        for elem in stab.elements():
+            assert {elem(1), elem(3)} == {1, 3}
+
+    def test_c3_setwise_any_pair(self):
+        """C_3 setwise stabilizer of any 2-element subset → trivial."""
+        g = PermutationGroup.cyclic(3)
+        stab = g.setwise_stabilizer({0, 1})
+        assert stab.order() == 1
+
+    def test_s3_setwise_pair(self):
+        """S_3 setwise stabilizer of {0,1} → {id, (0 1)} = S_2."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.setwise_stabilizer({0, 1})
+        assert stab.order() == 2
+        for elem in stab.elements():
+            assert {elem(0), elem(1)} == {0, 1}
+
+    def test_s4_setwise_pair(self):
+        """S_4 setwise stabilizer of {0,1} has order 12.
+
+        Elements that map {0,1}→{0,1}: 2 choices for {0,1} × 2! for {2,3} = nope.
+        Actually: pick where 0,1 go (2 options: stay or swap) × permute {2,3}
+        freely (2!) = 4. Wait — any elem that maps {0,1}→{0,1} can also
+        permute 2,3 freely. So 2 × 2! × ... no.
+        Setwise stab of {0,1} in S_4: elements mapping {0,1}→{0,1}.
+        Choose image of {0,1}: 2! ways. Choose image of {2,3}: 2! ways.
+        Total: 2! × 2! = 4.
+        """
+        g = PermutationGroup.symmetric(4)
+        stab = g.setwise_stabilizer({0, 1})
+        assert stab.order() == 4
+
+    def test_empty_set(self):
+        """Setwise stabilizer of empty set is the full group."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.setwise_stabilizer(set())
+        assert stab.order() == g.order()
+
+    def test_full_set(self):
+        """Setwise stabilizer of the full set is the full group."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.setwise_stabilizer({0, 1, 2})
+        assert stab.order() == g.order()
+
+    def test_d4_setwise(self):
+        """D_4 setwise stabilizer of {0,2} (opposite corners of square)."""
+        g = PermutationGroup.dihedral(4)
+        stab = g.setwise_stabilizer({0, 2})
+        # D_4 has 8 elements. Elements mapping {0,2}→{0,2}:
+        # id(0→0,2→2), rot²(0→2,2→0), refl across 0-2 diagonal, refl across 1-3 diagonal
+        assert stab.order() == 4
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_perm_group.py::TestSetwiseStabilizer -v`
+Expected: FAIL with `AttributeError: 'PermutationGroup' object has no attribute 'setwise_stabilizer'`
+
+- [ ] **Step 3: Implement setwise_stabilizer**
+
+Add to `PermutationGroup` class in `src/whest/_perm_group.py`, after `pointwise_stabilizer`:
+
+```python
+def setwise_stabilizer(self, subset: set[int]) -> PermutationGroup:
+    """Subgroup of elements that map *subset* to itself as a set.
+
+    Parameters
+    ----------
+    subset : set of int
+        Group-local indices. The subgroup consists of elements g where
+        {g(x) for x in subset} == subset.
+
+    Returns
+    -------
+    PermutationGroup
+        The setwise stabilizer subgroup (same degree).
+    """
+    if not subset or subset == set(range(self._degree)):
+        return PermutationGroup(*self._generators, axes=self._axes)
+    frozen = frozenset(subset)
+    surviving = [
+        g for g in self.elements()
+        if frozenset(g(x) for x in frozen) == frozen
+    ]
+    if not surviving:
+        surviving = [Permutation.identity(self._degree)]
+    return PermutationGroup(*surviving, axes=self._axes)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_perm_group.py::TestSetwiseStabilizer -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_perm_group.py tests/test_perm_group.py
+git commit -m "feat: add setwise_stabilizer to PermutationGroup"
+```
+
+---
+
+### Task 3: Add `restrict` to `PermutationGroup`
+
+**Files:**
+- Modify: `src/whest/_perm_group.py:244-475` (PermutationGroup class)
+- Test: `tests/test_perm_group.py`
+
+- [ ] **Step 1: Write failing tests for restrict**
+
+Add to `tests/test_perm_group.py`:
+
+```python
+class TestRestrict:
+    def test_s3_restrict_to_pair(self):
+        """S_3 pointwise-stabilizer of {2}, restricted to {0,1} → S_2."""
+        g = PermutationGroup.symmetric(3, axes=(10, 20, 30))
+        stab = g.pointwise_stabilizer({2})
+        r = stab.restrict((0, 1))
+        assert r.degree == 2
+        assert r.order() == 2
+        assert r.axes == (10, 20)
+
+    def test_c4_setwise_restrict(self):
+        """C_4 setwise-stabilizer of {1,3}, restricted to {0,2} → C_2."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        stab = g.setwise_stabilizer({1, 3})
+        r = stab.restrict((0, 2))
+        assert r.degree == 2
+        assert r.order() == 2
+        assert r.axes == (0, 2)
+        # The non-identity element swaps 0↔1 (re-indexed from 0↔2)
+        elems = r.elements()
+        non_id = [e for e in elems if not e.is_identity]
+        assert len(non_id) == 1
+        assert non_id[0](0) == 1 and non_id[0](1) == 0
+
+    def test_restrict_preserves_identity(self):
+        """Restricting a trivial group gives a trivial group."""
+        g = PermutationGroup.cyclic(3)
+        stab = g.pointwise_stabilizer({0, 1, 2})  # trivial
+        r = stab.restrict((0, 1))
+        assert r.degree == 2
+        assert r.order() == 1
+
+    def test_restrict_single_point(self):
+        """Restricting to a single point gives degree-1 trivial group."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({1, 2})
+        r = stab.restrict((0,))
+        assert r.degree == 1
+        assert r.order() == 1
+
+    def test_restrict_no_axes(self):
+        """Restrict works when group has no axes metadata."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({2})
+        r = stab.restrict((0, 1))
+        assert r.degree == 2
+        assert r.order() == 2
+        assert r.axes is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_perm_group.py::TestRestrict -v`
+Expected: FAIL with `AttributeError: 'PermutationGroup' object has no attribute 'restrict'`
+
+- [ ] **Step 3: Implement restrict**
+
+Add to `PermutationGroup` class in `src/whest/_perm_group.py`, after `setwise_stabilizer`:
+
+```python
+def restrict(self, kept: tuple[int, ...]) -> PermutationGroup:
+    """Project permutations onto *kept* positions, re-indexing to 0..len(kept)-1.
+
+    Precondition: the group must already stabilize *kept* setwise
+    (every element maps the set of kept positions to itself).
+
+    Parameters
+    ----------
+    kept : tuple of int
+        Group-local indices to keep, in the desired output order.
+
+    Returns
+    -------
+    PermutationGroup
+        Group of degree ``len(kept)`` with projected permutations.
+        ``axes`` is updated to select the corresponding entries from
+        the original ``axes`` tuple (or None if original had no axes).
+    """
+    new_degree = len(kept)
+    if new_degree == 0:
+        raise ValueError("kept must be non-empty")
+
+    # Map old group-local index → new index
+    old_to_new = {old: new for new, old in enumerate(kept)}
+
+    projected: set[Permutation] = set()
+    for g in self.elements():
+        new_arr = [old_to_new[g(k)] for k in kept]
+        projected.add(Permutation(new_arr))
+
+    new_axes: tuple[int, ...] | None = None
+    if self._axes is not None:
+        new_axes = tuple(self._axes[k] for k in kept)
+
+    gens = list(projected) if projected else [Permutation.identity(new_degree)]
+    return PermutationGroup(*gens, axes=new_axes)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_perm_group.py::TestRestrict -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_perm_group.py tests/test_perm_group.py
+git commit -m "feat: add restrict to PermutationGroup"
+```
+
+---
+
+### Task 4: Rewrite `propagate_symmetry_slice` to use `PermutationGroup`
+
+**Files:**
+- Modify: `src/whest/_symmetric.py:225-363` (propagate_symmetry_slice)
+- Test: `tests/test_symmetric_coverage.py`
+
+- [ ] **Step 1: Write failing tests for the new behavior**
+
+Add to `tests/test_symmetric_coverage.py`. These tests use general groups and verify the stabilizer logic produces correct results:
+
+```python
+from whest._perm_group import PermutationGroup
+
+
+class TestPropagateSliceGeneralGroups:
+    """Test propagate_symmetry_slice with non-S_k groups."""
+
+    def test_c3_slice_one_axis_no_symmetry(self):
+        """C_3 on {0,1,2}, slice axis 2 → no symmetry survives."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), 0))
+        assert result is None
+
+    def test_c4_slice_two_axes_c2_survives(self):
+        """C_4 on {0,1,2,3}, slice axes {1,3} → C_2 on output {0,1}."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        # T[:, 0, :, 0] → removes axes 1 and 3
+        result = propagate_symmetry_slice([g], (5, 5, 5, 5), (slice(None), 0, slice(None), 0))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].degree == 2
+        assert result[0].order() == 2  # C_2
+        assert result[0].axes == (0, 1)  # re-indexed from (0, 2)
+
+    def test_s3_slice_one_axis_s2_survives(self):
+        """S_3 on {0,1,2}, slice axis 2 → S_2 on {0,1}. Same as old behavior."""
+        g = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), 0))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 2  # S_2
+
+    def test_d4_slice_one_axis(self):
+        """D_4 on {0,1,2,3}, slice axis 0 → pointwise stab of {0}, restricted."""
+        g = PermutationGroup.dihedral(4, axes=(0, 1, 2, 3))
+        result = propagate_symmetry_slice([g], (5, 5, 5, 5), (0, slice(None), slice(None), slice(None)))
+        assert result is not None
+        assert len(result) == 1
+        # D_4 pointwise stab of {0}: elements fixing 0.
+        # D_4 on square vertices 0,1,2,3:
+        #   id(0→0), rot(0→1), rot²(0→2), rot³(0→3),
+        #   refl_02(0→0), refl_13(0→2), refl_01(0→1), refl_23(0→3)
+        # Wait — D_4 reflection: [0, 3, 2, 1] fixes 0. rot³*refl fixes 0?
+        # Let's just check the result is a valid subgroup
+        stab = result[0]
+        assert stab.degree == 3
+        # All elements of the restricted group should be valid permutations
+        for elem in stab.elements():
+            assert elem.size == 3
+
+    def test_multiple_groups_independent(self):
+        """Two independent groups, slice removes axis from one."""
+        g1 = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        g2 = PermutationGroup.symmetric(2, axes=(3, 4))
+        result = propagate_symmetry_slice(
+            [g1, g2], (5, 5, 5, 5, 5), (0, slice(None), slice(None), slice(None), slice(None))
+        )
+        # g1 loses axis 0 → C_3 pointwise stab of {0} → trivial, dropped
+        # g2 unaffected but re-indexed: (3,4) → (2,3)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 2  # S_2
+
+    def test_no_axes_removed_group_unchanged(self):
+        """Full slice preserves group unchanged."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), slice(None)))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestPropagateSliceGeneralGroups -v`
+Expected: FAIL (current function takes `list[tuple]`, not `list[PermutationGroup]`)
+
+- [ ] **Step 3: Rewrite propagate_symmetry_slice**
+
+Replace the function at `src/whest/_symmetric.py:225-363` with:
+
+```python
+def propagate_symmetry_slice(
+    groups: list[PermutationGroup],
+    shape: tuple[int, ...],
+    key,
+) -> list[PermutationGroup] | None:
+    """Compute new symmetry groups after ``__getitem__(key)``.
+
+    Parameters
+    ----------
+    groups : list of PermutationGroup
+        Each group has ``axes`` indicating which tensor dimensions it acts on.
+    shape : tuple of int
+        Original tensor shape.
+    key : indexing key
+        The slicing/indexing key.
+
+    Returns *None* if no symmetry survives (caller should return plain ndarray).
+    """
+    ndim = len(shape)
+
+    # Normalize key to a tuple.
+    if not isinstance(key, tuple):
+        key = (key,)
+
+    # Advanced indexing (ndarray / list) → bail out.
+    for k in key:
+        if isinstance(k, (np.ndarray, list)):
+            return None
+
+    # Expand Ellipsis.
+    expanded: list = []
+    ellipsis_seen = False
+    for k in key:
+        if k is Ellipsis:
+            if ellipsis_seen:
+                raise IndexError("only one Ellipsis allowed")
+            ellipsis_seen = True
+            n_newaxis_in_key = sum(1 for kk in key if kk is None)
+            n_explicit = len(key) - 1 - n_newaxis_in_key
+            n_fill = ndim - n_explicit
+            expanded.extend([slice(None)] * n_fill)
+        else:
+            expanded.append(k)
+    if not ellipsis_seen:
+        n_newaxis = sum(1 for k in expanded if k is None)
+        while len(expanded) - n_newaxis < ndim:
+            expanded.append(slice(None))
+    key_expanded = expanded
+
+    # Classify each original dim.
+    old_dim_idx = 0
+    dim_actions: dict[int, str | tuple] = {}
+
+    for k in key_expanded:
+        if k is None:
+            continue
+        if old_dim_idx >= ndim:
+            break
+        if isinstance(k, (int, np.integer)):
+            dim_actions[old_dim_idx] = "removed"
+            old_dim_idx += 1
+        elif isinstance(k, slice):
+            start, stop, step = k.indices(shape[old_dim_idx])
+            new_size = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
+            if new_size == shape[old_dim_idx]:
+                dim_actions[old_dim_idx] = "untouched"
+            else:
+                dim_actions[old_dim_idx] = ("resized", new_size)
+            old_dim_idx += 1
+        else:
+            return None
+
+    while old_dim_idx < ndim:
+        dim_actions[old_dim_idx] = "untouched"
+        old_dim_idx += 1
+
+    # Build old→new dim mapping.
+    removed_dims = {d for d, a in dim_actions.items() if a == "removed"}
+    old_to_new: dict[int, int | None] = {}
+    newaxis_positions: list[int] = []
+    orig_idx = 0
+    for k in key_expanded:
+        if k is None:
+            newaxis_positions.append(orig_idx)
+        else:
+            orig_idx += 1
+
+    new_idx = 0
+    for d in range(ndim):
+        while newaxis_positions and newaxis_positions[0] <= d:
+            newaxis_positions.pop(0)
+            new_idx += 1
+        if d in removed_dims:
+            old_to_new[d] = None
+        else:
+            old_to_new[d] = new_idx
+            new_idx += 1
+
+    # Process each group.
+    new_groups: list[PermutationGroup] = []
+    for group in groups:
+        axes = group.axes
+        if axes is None:
+            continue
+
+        # Map tensor axes to group-local indices.
+        # axes[i] is the tensor dim for group-local position i.
+        local_removed: set[int] = set()
+        local_kept: list[int] = []
+        for local_idx, tensor_dim in enumerate(axes):
+            action = dim_actions.get(tensor_dim, "untouched")
+            if action == "removed":
+                local_removed.add(local_idx)
+            else:
+                local_kept.append(local_idx)
+
+        if not local_kept:
+            continue
+
+        # Pointwise stabilizer: fix removed axes.
+        stab = group.pointwise_stabilizer(local_removed)
+
+        # Among surviving axes, check for size mismatches (resized vs untouched).
+        # Permutations can only swap axes of the same output size.
+        size_map: dict[int, int] = {}
+        for local_idx in local_kept:
+            tensor_dim = axes[local_idx]
+            action = dim_actions.get(tensor_dim, "untouched")
+            if isinstance(action, tuple) and action[0] == "resized":
+                size_map[local_idx] = action[1]
+            else:
+                size_map[local_idx] = shape[tensor_dim]
+
+        sizes = set(size_map.values())
+        if len(sizes) > 1:
+            # Need setwise stabilizer of each size-class partition.
+            for sz in sizes:
+                same_size = {li for li, s in size_map.items() if s == sz}
+                complement = set(local_kept) - same_size
+                if complement:
+                    stab = stab.setwise_stabilizer(same_size)
+
+        # Restrict to kept local indices.
+        kept_tuple = tuple(local_kept)
+        if len(kept_tuple) < 2:
+            continue
+
+        restricted = stab.restrict(kept_tuple)
+
+        if restricted.order() <= 1:
+            continue
+
+        # Remap axes to new tensor dim numbering.
+        new_axes = tuple(old_to_new[axes[k]] for k in kept_tuple)
+        if any(a is None for a in new_axes):
+            continue
+
+        final = PermutationGroup(*restricted.generators, axes=new_axes)
+        new_groups.append(final)
+
+    return new_groups if new_groups else None
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestPropagateSliceGeneralGroups -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_symmetric.py tests/test_symmetric_coverage.py
+git commit -m "feat: rewrite propagate_symmetry_slice for general permutation groups"
+```
+
+---
+
+### Task 5: Rewrite `propagate_symmetry_reduce` to use `PermutationGroup`
+
+**Files:**
+- Modify: `src/whest/_symmetric.py:366-411` (propagate_symmetry_reduce)
+- Test: `tests/test_symmetric_coverage.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_symmetric_coverage.py`:
+
+```python
+class TestPropagateReduceGeneralGroups:
+    """Test propagate_symmetry_reduce with non-S_k groups."""
+
+    def test_c4_reduce_13_c2_survives(self):
+        """C_4 on {0,1,2,3}, reduce axes {1,3} → C_2 on output {0,1}."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        result = propagate_symmetry_reduce([g], 4, (1, 3), keepdims=False)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 2  # C_2
+        assert result[0].axes == (0, 1)  # re-indexed from (0, 2)
+
+    def test_c3_reduce_one_axis_trivial(self):
+        """C_3 on {0,1,2}, reduce axis 2 → only identity survives → no group."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_reduce([g], 3, 2, keepdims=False)
+        assert result is None
+
+    def test_s3_reduce_one_axis_s2(self):
+        """S_3 on {0,1,2}, reduce axis 2 → S_2 on {0,1}. Matches old behavior."""
+        g = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        result = propagate_symmetry_reduce([g], 3, 2, keepdims=False)
+        assert result is not None
+        assert result[0].order() == 2
+
+    def test_reduce_none_returns_none(self):
+        """axis=None reduces everything → no symmetry."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_reduce([g], 3, None)
+        assert result is None
+
+    def test_c4_reduce_keepdims(self):
+        """C_4 on {0,1,2,3}, reduce axes {1,3} keepdims=True → C_2."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        result = propagate_symmetry_reduce([g], 4, (1, 3), keepdims=True)
+        assert result is not None
+        assert len(result) == 1
+        # Axes stay at their positions, but setwise stab of {1,3} → {id, rot²}
+        # restricted to {0,2}: C_2 with axes=(0,2)
+        assert result[0].order() == 2
+        assert result[0].axes == (0, 2)
+
+    def test_reduce_disjoint_axis(self):
+        """Reduce an axis not in the group → group unchanged, axes renumbered."""
+        g = PermutationGroup.cyclic(3, axes=(1, 2, 3))
+        result = propagate_symmetry_reduce([g], 4, 0, keepdims=False)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3  # C_3 unchanged
+        assert result[0].axes == (0, 1, 2)  # re-indexed from (1,2,3)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestPropagateReduceGeneralGroups -v`
+Expected: FAIL
+
+- [ ] **Step 3: Rewrite propagate_symmetry_reduce**
+
+Replace the function at `src/whest/_symmetric.py:366-411` with:
+
+```python
+def propagate_symmetry_reduce(
+    groups: list[PermutationGroup],
+    ndim: int,
+    axis: int | tuple[int, ...] | None,
+    keepdims: bool = False,
+) -> list[PermutationGroup] | None:
+    """Compute new symmetry groups after a reduction.
+
+    Parameters
+    ----------
+    groups : list of PermutationGroup
+        Each group has ``axes`` indicating which tensor dimensions it acts on.
+    ndim : int
+        Original tensor rank.
+    axis : int, tuple of int, or None
+        Axes being reduced.
+    keepdims : bool
+        Whether reduced dims are kept at size 1.
+
+    Returns *None* if no symmetry survives.
+    """
+    if axis is None:
+        return None
+
+    # Normalize axis.
+    if isinstance(axis, int):
+        axes_set = {axis % ndim}
+    else:
+        axes_set = {a % ndim for a in axis}
+
+    # Build old→new mapping (only needed when not keepdims).
+    old_to_new: dict[int, int] = {}
+    if not keepdims:
+        new_idx = 0
+        for d in range(ndim):
+            if d not in axes_set:
+                old_to_new[d] = new_idx
+                new_idx += 1
+    else:
+        old_to_new = {d: d for d in range(ndim)}
+
+    new_groups: list[PermutationGroup] = []
+    for group in groups:
+        grp_axes = group.axes
+        if grp_axes is None:
+            continue
+
+        # Map tensor axes to group-local indices.
+        local_reduced: set[int] = set()
+        local_kept: list[int] = []
+        for local_idx, tensor_dim in enumerate(grp_axes):
+            if tensor_dim in axes_set:
+                local_reduced.add(local_idx)
+            else:
+                local_kept.append(local_idx)
+
+        if not local_reduced:
+            # Group is entirely outside the reduced axes — just remap.
+            new_axes = tuple(old_to_new[grp_axes[i]] for i in range(group.degree))
+            new_groups.append(PermutationGroup(*group.generators, axes=new_axes))
+            continue
+
+        if not local_kept:
+            # All axes in this group are reduced — group vanishes from output.
+            continue
+
+        # Setwise stabilizer: elements mapping reduced axes among themselves.
+        stab = group.setwise_stabilizer(local_reduced)
+
+        # Restrict to kept local indices.
+        kept_tuple = tuple(local_kept)
+        if len(kept_tuple) < 2:
+            continue
+
+        restricted = stab.restrict(kept_tuple)
+        if restricted.order() <= 1:
+            continue
+
+        # Remap to new tensor axis numbering.
+        new_axes = tuple(old_to_new[grp_axes[k]] for k in kept_tuple)
+        final = PermutationGroup(*restricted.generators, axes=new_axes)
+        new_groups.append(final)
+
+    return new_groups if new_groups else None
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestPropagateReduceGeneralGroups -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_symmetric.py tests/test_symmetric_coverage.py
+git commit -m "feat: rewrite propagate_symmetry_reduce for general permutation groups"
+```
+
+---
+
+### Task 6: Rewrite `intersect_symmetry` to use `PermutationGroup`
+
+**Files:**
+- Modify: `src/whest/_symmetric.py:414-466` (intersect_symmetry)
+- Test: `tests/test_symmetric_coverage.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_symmetric_coverage.py`:
+
+```python
+class TestIntersectSymmetryGeneralGroups:
+    """Test intersect_symmetry with PermutationGroup objects."""
+
+    def test_same_group_returns_group(self):
+        """Intersecting a group with itself returns same group."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = intersect_symmetry([g], [g], (5, 5, 5), (5, 5, 5), (5, 5, 5))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3
+
+    def test_s3_intersect_c3(self):
+        """S_3 ∩ C_3 = C_3 (C_3 is a subgroup of S_3)."""
+        s3 = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        c3 = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = intersect_symmetry([s3], [c3], (5, 5, 5), (5, 5, 5), (5, 5, 5))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3  # C_3
+
+    def test_none_input_returns_none(self):
+        """If either input is None, result is None."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        assert intersect_symmetry(None, [g], (5, 5, 5), (5, 5, 5), (5, 5, 5)) is None
+        assert intersect_symmetry([g], None, (5, 5, 5), (5, 5, 5), (5, 5, 5)) is None
+
+    def test_disjoint_axes_dropped(self):
+        """Groups on different axes don't intersect → None."""
+        g1 = PermutationGroup.symmetric(2, axes=(0, 1))
+        g2 = PermutationGroup.symmetric(2, axes=(2, 3))
+        result = intersect_symmetry([g1], [g2], (5, 5, 5, 5), (5, 5, 5, 5), (5, 5, 5, 5))
+        assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestIntersectSymmetryGeneralGroups -v`
+Expected: FAIL
+
+- [ ] **Step 3: Rewrite intersect_symmetry**
+
+Replace at `src/whest/_symmetric.py:414-466`:
+
+```python
+def intersect_symmetry(
+    groups_a: list[PermutationGroup] | None,
+    groups_b: list[PermutationGroup] | None,
+    shape_a: tuple[int, ...],
+    shape_b: tuple[int, ...],
+    output_shape: tuple[int, ...],
+) -> list[PermutationGroup] | None:
+    """Intersect symmetry groups for binary ops, accounting for broadcasting.
+
+    Parameters
+    ----------
+    groups_a, groups_b : list of PermutationGroup or None
+    shape_a, shape_b : input shapes
+    output_shape : broadcast output shape
+    """
+    if groups_a is None or groups_b is None:
+        return None
+
+    ndim_out = len(output_shape)
+    ndim_a = len(shape_a)
+    ndim_b = len(shape_b)
+
+    offset_a = ndim_out - ndim_a
+    offset_b = ndim_out - ndim_b
+
+    def _remap_axes(groups: list[PermutationGroup], offset: int, input_shape: tuple[int, ...]):
+        """Remap group axes to output dims and remove broadcast-stretched dims."""
+        result = []
+        for group in groups:
+            if group.axes is None:
+                continue
+            new_axes = []
+            local_kept = []
+            for local_idx, tensor_dim in enumerate(group.axes):
+                out_dim = tensor_dim + offset
+                # Check if broadcast-stretched (size 1 → larger).
+                if 0 <= tensor_dim < len(input_shape):
+                    if input_shape[tensor_dim] == 1 and output_shape[out_dim] > 1:
+                        continue  # stretched — remove from group
+                new_axes.append(out_dim)
+                local_kept.append(local_idx)
+            if len(local_kept) >= 2:
+                restricted = group.restrict(tuple(local_kept))
+                if restricted.order() > 1:
+                    result.append(PermutationGroup(
+                        *restricted.generators, axes=tuple(new_axes)
+                    ))
+        return result
+
+    aligned_a = _remap_axes(groups_a, offset_a, shape_a)
+    aligned_b = _remap_axes(groups_b, offset_b, shape_b)
+
+    # Intersect: for groups acting on the same output axes, compute element intersection.
+    b_by_axes: dict[tuple[int, ...], PermutationGroup] = {}
+    for g in aligned_b:
+        if g.axes is not None:
+            b_by_axes[g.axes] = g
+
+    intersection: list[PermutationGroup] = []
+    for ga in aligned_a:
+        if ga.axes is None:
+            continue
+        gb = b_by_axes.get(ga.axes)
+        if gb is None:
+            continue
+        # Element-set intersection.
+        common_elements = set(ga.elements()) & set(gb.elements())
+        if len(common_elements) <= 1:
+            continue
+        intersection.append(PermutationGroup(*common_elements, axes=ga.axes))
+
+    return intersection if intersection else None
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestIntersectSymmetryGeneralGroups -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_symmetric.py tests/test_symmetric_coverage.py
+git commit -m "feat: rewrite intersect_symmetry for general permutation groups"
+```
+
+---
+
+### Task 7: Update callers — `SymmetricTensor.__getitem__` and `_pointwise.py`
+
+**Files:**
+- Modify: `src/whest/_symmetric.py:562-595` (SymmetricTensor.__getitem__)
+- Modify: `src/whest/_pointwise.py:80-130` (binary op symmetry)
+- Modify: `src/whest/_pointwise.py:200-228` (reduction symmetry)
+- Test: `tests/test_symmetric_coverage.py`
+
+- [ ] **Step 1: Write integration test**
+
+Add to `tests/test_symmetric_coverage.py`:
+
+```python
+class TestSymmetricTensorGeneralGroups:
+    """End-to-end tests: SymmetricTensor with general groups through slice/reduce."""
+
+    def test_c3_tensor_slice_loses_symmetry(self):
+        """SymmetricTensor with C_3, slicing one axis → no symmetry."""
+        import numpy as np
+        from whest._symmetric import SymmetricTensor
+
+        arr = np.zeros((3, 3, 3))
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        t = SymmetricTensor(arr, symmetric_axes=[(0, 1, 2)], perm_groups=[g])
+        result = t[:, :, 0]
+        assert not isinstance(result, SymmetricTensor) or not result.symmetric_axes
+
+    def test_s3_tensor_slice_keeps_s2(self):
+        """SymmetricTensor with S_3, slicing one axis → S_2 survives."""
+        import numpy as np
+        from whest._symmetric import SymmetricTensor
+
+        arr = np.zeros((3, 3, 3))
+        g = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        t = SymmetricTensor(arr, symmetric_axes=[(0, 1, 2)], perm_groups=[g])
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = t[:, :, 0]
+        assert isinstance(result, SymmetricTensor)
+        assert len(result._symmetry_groups) == 1
+        assert result._symmetry_groups[0].order() == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestSymmetricTensorGeneralGroups -v`
+Expected: FAIL (callers still pass tuples)
+
+- [ ] **Step 3: Update SymmetricTensor.__getitem__**
+
+Replace `__getitem__` in `src/whest/_symmetric.py` (lines 562-595):
+
+```python
+def __getitem__(self, key):  # type: ignore[override]
+    result = super().__getitem__(key)
+    if not isinstance(result, np.ndarray) or result.ndim == 0:
+        return result if not isinstance(result, np.ndarray) else np.asarray(result)
+
+    if not self._symmetry_groups:
+        return np.asarray(result)
+
+    new_groups = propagate_symmetry_slice(self._symmetry_groups, self.shape, key)
+    if new_groups is not None:
+        out = np.asarray(result).view(SymmetricTensor)
+        out._symmetry_groups = new_groups
+        out._symmetric_axes = [g.axes for g in new_groups if g.axes is not None]
+        # Warn if symmetry was partially lost.
+        if len(new_groups) < len(self._symmetry_groups):
+            lost_axes = [
+                g.axes for g in self._symmetry_groups
+                if not any(
+                    ng.axes == g.axes or (ng.axes is not None and g.axes is not None)
+                    for ng in new_groups
+                )
+            ]
+            if lost_axes:
+                _warn_symmetry_loss(
+                    [a for a in lost_axes if a is not None],
+                    "slicing changed dim sizes or removed dims",
+                )
+        return out
+    else:
+        if self._symmetry_groups:
+            _warn_symmetry_loss(
+                [g.axes for g in self._symmetry_groups if g.axes is not None],
+                "slicing removed all symmetric dim groups",
+            )
+        return np.asarray(result)
+```
+
+- [ ] **Step 4: Update _pointwise.py reduction caller**
+
+In `src/whest/_pointwise.py`, update the `_counted_reduction` function (around line 200-228). Change:
+
+```python
+            new_groups = propagate_symmetry_reduce(
+                sym_info.symmetric_axes, len(a.shape), axis, keepdims=keepdims
+            )
+            if new_groups is not None:
+                result = _np.asarray(result).view(SymmetricTensor)
+                result._symmetric_axes = new_groups
+                # Warn if groups were partially lost.
+                old_set = set(sym_info.symmetric_axes)
+                new_set = set(new_groups)
+                if new_set != old_set:
+                    lost = [g for g in sym_info.symmetric_axes if g not in new_set]
+                    if lost:
+                        _warn_symmetry_loss(lost, f"{op_name} reduced dims")
+```
+
+To:
+
+```python
+            perm_groups = sym_info.groups if sym_info.groups else []
+            new_groups = propagate_symmetry_reduce(
+                perm_groups, len(a.shape), axis, keepdims=keepdims
+            )
+            if new_groups is not None:
+                result = _np.asarray(result).view(SymmetricTensor)
+                result._symmetry_groups = new_groups
+                result._symmetric_axes = [g.axes for g in new_groups if g.axes is not None]
+                if len(new_groups) < len(perm_groups):
+                    lost_axes = [g.axes for g in perm_groups if g.axes is not None]
+                    if lost_axes:
+                        _warn_symmetry_loss(lost_axes, f"{op_name} reduced dims")
+```
+
+- [ ] **Step 5: Update _pointwise.py binary op caller**
+
+In `src/whest/_pointwise.py`, update the binary op path (around lines 90-105). Change:
+
+```python
+            x_axes = x_sym.symmetric_axes if x_sym else []
+            y_axes = y_sym.symmetric_axes if y_sym else []
+            out_sym_axes = intersect_symmetry(
+                x_axes if x_axes else None,
+                y_axes if y_axes else None,
+                x.shape,
+                y.shape,
+                output_shape,
+            )
+```
+
+To:
+
+```python
+            x_groups = x_sym.groups if x_sym else []
+            y_groups = y_sym.groups if y_sym else []
+            out_groups = intersect_symmetry(
+                x_groups if x_groups else None,
+                y_groups if y_groups else None,
+                x.shape,
+                y.shape,
+                output_shape,
+            )
+            out_sym_axes = (
+                [g.axes for g in out_groups if g.axes is not None]
+                if out_groups else None
+            )
+```
+
+And update the `SymmetricTensor` construction (around line 122) from:
+
+```python
+        if out_sym_axes:
+            result = SymmetricTensor(result, symmetric_axes=out_sym_axes)
+```
+
+To:
+
+```python
+        if out_sym_axes:
+            result = SymmetricTensor(result, symmetric_axes=out_sym_axes, perm_groups=out_groups)
+```
+
+Also update the warning block that follows (lines 123-134) to derive `input_groups` from `PermutationGroup.axes` instead of `sym.symmetric_axes`.
+
+- [ ] **Step 6: Run integration tests**
+
+Run: `uv run pytest tests/test_symmetric_coverage.py::TestSymmetricTensorGeneralGroups -v`
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/whest/_symmetric.py src/whest/_pointwise.py tests/test_symmetric_coverage.py
+git commit -m "feat: update callers to use PermutationGroup-based propagation"
+```
+
+---
+
+### Task 8: Fix existing tests and run full suite
+
+**Files:**
+- Modify: `tests/test_symmetric_coverage.py` (existing tests that pass tuples)
+- Modify: `tests/test_pointwise_coverage.py` (if needed)
+
+- [ ] **Step 1: Update existing propagate_symmetry_slice tests**
+
+The existing tests in `TestPropagateSymmetrySlice` and `TestPropagateSymmetryReduce` classes pass bare tuples like `[(0, 1)]`. Update them to pass `PermutationGroup` objects instead.
+
+For each test calling `propagate_symmetry_slice([(0, 1, 2)], ...)`, change to:
+```python
+propagate_symmetry_slice([PermutationGroup.symmetric(3, axes=(0, 1, 2))], ...)
+```
+
+For each test calling `propagate_symmetry_reduce([(1, 2)], ...)`, change to:
+```python
+propagate_symmetry_reduce([PermutationGroup.symmetric(2, axes=(1, 2))], ...)
+```
+
+Similarly update `intersect_symmetry` test calls.
+
+Update assertions: old tests assert `result == [(0, 1)]` (tuples). New results are `list[PermutationGroup]`. Change to:
+```python
+assert result is not None
+assert len(result) == 1
+assert result[0].axes == (0, 1)
+assert result[0].order() == 2  # S_2
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `uv run pytest tests/ -v --tb=short`
+Expected: all PASS (or pre-existing xfails only)
+
+- [ ] **Step 3: Fix any remaining failures**
+
+Address any test failures found in step 2. Common issues:
+- Tests in `test_pointwise_coverage.py` that check `intersect_symmetry` with tuples
+- Tests that compare results to `list[tuple]` instead of checking group properties
+- The `_counted_reduction` and `_counted_binary` paths that construct `SymmetryInfo`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/
+git commit -m "fix: update existing tests for PermutationGroup-based propagation"
+```
+
+- [ ] **Step 5: Run full test suite one final time**
+
+Run: `uv run pytest tests/ -v --tb=short`
+Expected: all PASS

--- a/.aicrowd/superpowers/specs/2026-04-14-stabilizer-propagation-design.md
+++ b/.aicrowd/superpowers/specs/2026-04-14-stabilizer-propagation-design.md
@@ -1,0 +1,163 @@
+# Stabilizer-Based Symmetry Propagation for Slices and Reductions
+
+## Problem
+
+`propagate_symmetry_slice` and `propagate_symmetry_reduce` operate on
+`list[tuple[int, ...]]` — bare axis tuples that implicitly assume the full
+symmetric group S_k. Now that the codebase supports general permutation groups
+(C_k, D_k, arbitrary generators), these functions produce incorrect results
+for non-S_k groups.
+
+**Example of the bug:** A tensor with C_3 on axes {0,1,2}. Slicing axis 2
+with an integer leaves axes {0,1}. The current code reports S_2 on {0,1}
+(swap allowed), but C_3 never contained a (0↔1) transposition — no symmetry
+should survive.
+
+## Core Insight
+
+When axes are removed from a tensor (by slicing or reduction), the output
+symmetry is the **stabilizer subgroup** of the input group — the subgroup of
+elements that don't mix removed and kept axes. The type of stabilizer depends
+on the operation:
+
+- **Slicing** (integer index pins an axis to a specific value):
+  **pointwise stabilizer** — each removed axis must map to itself individually.
+- **Reduction** (e.g. `sum(axis=k)` eliminates an axis by aggregation):
+  **setwise stabilizer** — removed axes must map among themselves as a set
+  (since summation treats all positions equivalently, swapping two summed
+  axes is valid).
+
+After computing the stabilizer, the surviving permutations are **projected**
+(re-indexed) to the new, smaller axis numbering.
+
+### Worked Examples
+
+**C_4 on {0,1,2,3}, slice axes {1,3} (integer indexing):**
+
+| Element | 0→ | 1→ | 2→ | 3→ | Fixes 1 AND 3? |
+|---------|----|----|----|----|-----------------|
+| id      | 0  | 1  | 2  | 3  | yes             |
+| rot     | 1  | 2  | 3  | 0  | no              |
+| rot²    | 2  | 3  | 0  | 1  | no              |
+| rot³    | 3  | 0  | 1  | 2  | no              |
+
+Pointwise stabilizer = {id}. No symmetry survives.
+
+**C_4 on {0,1,2,3}, reduce axes {1,3} (sum):**
+
+| Element | {1,3}→{1,3}? | {0,2}→{0,2}? |
+|---------|--------------|--------------|
+| id      | yes          | yes          |
+| rot     | no           | no           |
+| rot²    | yes (1→3,3→1)| yes (0→2,2→0)|
+| rot³    | no           | no           |
+
+Setwise stabilizer = {id, rot²}. After projecting to kept axes {0,2} →
+re-index to {0,1}: output has C_2 (the swap 0↔1).
+
+**S_3 on {0,1,2}, slice axis 2:**
+
+Pointwise stabilizer of {2} = elements where 2→2:
+{id, (0↔1)}. Output has S_2 on {0,1}. Matches current behavior.
+
+## Design
+
+### 1. New Methods on `PermutationGroup`
+
+**`pointwise_stabilizer(fixed: set[int]) -> PermutationGroup`**
+- Returns subgroup where every point in `fixed` maps to itself
+- Algorithm: filter `self.elements()`, build new group from surviving elements
+- Used by slice propagation
+
+**`setwise_stabilizer(subset: set[int]) -> PermutationGroup`**
+- Returns subgroup where `subset` maps to `subset` as a set
+- Algorithm: filter `self.elements()` by `{g(x) for x in subset} == subset`
+- Used by reduce propagation
+
+**`restrict(kept: tuple[int, ...]) -> PermutationGroup`**
+- Precondition: group already stabilizes `kept` (setwise)
+- Projects each permutation to only the `kept` positions, re-indexes to 0..len(kept)-1
+- Updates `axes`: selects the corresponding entries from the original `axes` tuple.
+  E.g. original `axes=(2,5,7)`, `kept=(0,2)` (group-local) → new `axes=(2,7)`.
+  The caller (propagation function) then remaps these tensor-level axes through
+  the old→new axis mapping to get final output axis numbers.
+- Returns group of smaller degree
+
+All three use the existing Dimino-based enumeration (groups are small).
+
+### 2. Updated `propagate_symmetry_slice`
+
+```
+propagate_symmetry_slice(groups: list[PermutationGroup], shape, key)
+    -> list[PermutationGroup] | None
+```
+
+Algorithm:
+1. Expand/normalize key (same as today)
+2. Classify each original axis: "removed" (int), "resized" (sub-range), "untouched" (full slice)
+3. Build old→new axis mapping (removed dims get None, account for newaxis)
+4. For each group G:
+   a. Map group's `axes` to the dim_actions classification
+   b. Compute pointwise stabilizer of removed axes (group-local indices)
+   c. Among surviving axes, if sizes differ (some resized, some not),
+      compute setwise stabilizer of equal-size partitions
+   d. `restrict()` to kept axes, remap via old→new
+   e. Keep if degree >= 2
+5. Return surviving groups or None
+
+### 3. Updated `propagate_symmetry_reduce`
+
+```
+propagate_symmetry_reduce(groups: list[PermutationGroup], ndim, axis, keepdims)
+    -> list[PermutationGroup] | None
+```
+
+Algorithm:
+1. Normalize `axis` to absolute indices. If None, return None.
+2. For each group G:
+   a. Let `reduced` = group-local indices of axes being reduced
+   b. Compute setwise stabilizer of `reduced`
+   c. `restrict()` to kept (non-reduced) axes
+   d. If keepdims: reduced axes stay at size 1 — skip `restrict()` (no axes
+      removed), but the setwise stabilizer from step (b) already ensures
+      only valid permutations survive. No re-indexing needed since axis
+      positions are unchanged.
+   e. If not keepdims: remap group axes through old→new axis mapping
+   f. Keep if degree >= 2
+3. Return surviving groups or None
+
+### 4. Updated `intersect_symmetry`
+
+```
+intersect_symmetry(groups_a, groups_b, shape_a, shape_b, output_shape)
+    -> list[PermutationGroup] | None
+```
+
+For binary ops, the output group is the intersection of both operands' groups:
+- Align each operand's groups to output shape (broadcasting)
+- For groups acting on the same axis set: intersect element sets, build new group
+- Drop groups that don't appear in both operands
+
+### 5. Callers
+
+`SymmetricTensor.__getitem__` and ufunc hooks pass `self._symmetry_groups`
+(list of `PermutationGroup`) to the updated propagation functions. Results
+are stored directly as `_symmetry_groups` on the output tensor.
+
+`SymmetryInfo` continues to accept `symmetric_axes` tuples as a convenience
+and auto-builds S_k groups in `__post_init__`.
+
+## Files to Change
+
+| File | Changes |
+|------|---------|
+| `src/whest/_perm_group.py` | Add `pointwise_stabilizer`, `setwise_stabilizer`, `restrict` |
+| `src/whest/_symmetric.py` | Rewrite `propagate_symmetry_slice`, `propagate_symmetry_reduce`, `intersect_symmetry` to take groups; update `SymmetricTensor.__getitem__` and ufunc callers |
+| `tests/test_symmetric_coverage.py` | Add tests for C_k/D_k stabilizer cases (the worked examples above) |
+| `tests/test_perm_group.py` | Unit tests for new PermutationGroup methods |
+
+## Non-Goals
+
+- Schreier-Sims or other scalable algorithms (Dimino is sufficient for our group sizes)
+- Changes to the einsum σ-loop (already handles general groups correctly)
+- Changes to `SymmetryInfo.__post_init__` (already builds groups from tuples)

--- a/docs/how-to/exploit-symmetry.md
+++ b/docs/how-to/exploit-symmetry.md
@@ -219,46 +219,70 @@ Symmetry metadata propagates automatically through operations using conservative
 | `we.add(S, T)` (different groups) | depends | Only groups present in *both* inputs survive |
 | `S * scalar` | `SymmetricTensor` | Scalar ops preserve all groups |
 | `S.copy()` | `SymmetricTensor` | Metadata preserved |
-| `S[0]` (integer index) | `SymmetricTensor` or ndarray | Indexed dim removed from group; remaining dims keep symmetry if 2+ survive |
-| `S[0:k]` (slice) | `SymmetricTensor` or ndarray | Resized dim pulled from group; same-size dims keep symmetry |
-| `we.sum(S, axis=0)` | `SymmetricTensor` or ndarray | Reduced dim removed from group; remaining dims renumbered |
+| `S[0]` (integer index) | `SymmetricTensor` or ndarray | **Pointwise stabilizer:** only group elements that fix the removed axis survive; remaining dims keep the stabilizer subgroup if order > 1 |
+| `S[0:k]` (slice) | `SymmetricTensor` or ndarray | Resized dim: stabilizer of size-class partition; same-size dims keep symmetry |
+| `we.sum(S, axis=0)` | `SymmetricTensor` or ndarray | **Setwise stabilizer:** group elements that map reduced axes among themselves survive; remaining dims keep the stabilizer subgroup |
 | `we.sum(S)` (all axes) | `WhestArray` | Scalar result — no symmetry |
 | `S @ T` | plain ndarray | `AB != (AB)^T` in general |
 
 #### Slicing rules in detail
 
-When you slice a `SymmetricTensor`, symmetry propagates based on what happens to each dimension:
+When you slice a `SymmetricTensor`, symmetry propagates via the
+**pointwise stabilizer** — the subgroup of elements that fix each removed
+axis individually. For S_k (full symmetric) groups, this is simple:
+removing one axis from S_k leaves S_{k-1} on the rest. For non-S_k groups,
+fewer (or no) elements may survive.
 
 ```python
 import whest as we
 import numpy as np
 
-# 4D tensor with full ((0,1,2,3)) symmetry, shape (10,10,10,10)
+# S_4 on axes (0,1,2,3): removing axis 0 → S_3 on (0,1,2) [renumbered]
 A = we.as_symmetric(sym_data, symmetric_axes=(0, 1, 2, 3))
-
-A[0]          # shape (10,10,10) — dim 0 removed → ((0,1,2)) symmetry
-A[0:5]        # shape (5,10,10,10) — dim 0 resized, pulled from group → ((1,2,3))
-A[0:10]       # shape (10,10,10,10) — same size, group intact → ((0,1,2,3))
-A[0:5, 0:5]   # shape (5,5,10,10) — conservative: both pulled → ((2,3))
+A[0]          # shape (10,10,10) — S_3 symmetry on (0,1,2)
+A[0:5]        # shape (5,10,10,10) — dim 0 resized, different size → pulled
+A[0:10]       # shape (10,10,10,10) — same size, group intact
 A[arr]        # advanced indexing → plain ndarray (symmetry stripped)
+
+# C_3 on axes (0,1,2): removing any single axis → no symmetry
+# (C_3 has no element that fixes a point, except identity)
+T = we.as_symmetric(data, symmetry=we.PermutationGroup.cyclic(3, axes=(0, 1, 2)))
+T[:, :, 0]   # plain ndarray — C_3 pointwise stabilizer of {2} is trivial
 ```
 
 #### Reduction rules in detail
 
+Reductions use the **setwise stabilizer** — the subgroup of elements that
+map reduced axes among themselves as a set. This is less restrictive than
+the pointwise stabilizer used for slicing, because summing treats all
+positions along a reduced axis equivalently.
+
 ```python
-A.sum(axis=0)              # ((0,1,2,3)) → ((0,1,2)) on 3D result
-A.sum(axis=(0,1))          # ((0,1,2,3)) → ((0,1)) on 2D result
-A.sum(axis=0, keepdims=True)  # dim 0 now size 1, pulled → ((1,2,3)) on 4D result
+# S_3: reducing axis 0 → S_2 on remaining axes (same as slicing)
+A.sum(axis=0)              # S_4 → S_3 on 3D result
+
+# C_4 on (0,1,2,3): reducing axes {1,3} → C_2 survives
+# (rot² maps {1,3}→{3,1} = {1,3} as a set, and {0,2}→{2,0})
+T.sum(axis=(1, 3))         # C_2 on output axes (0,1) [renumbered from (0,2)]
+
+# C_3 on (0,1,2): reducing axis 2 → trivial (no C_3 element maps {2}→{2})
+T.sum(axis=2)              # plain ndarray
+
+A.sum(axis=0, keepdims=True)  # dim 0 now size 1 — setwise stab, no re-index
 A.sum()                    # scalar → no symmetry
 ```
 
 #### Binary intersection rules
 
+For binary operations, the output symmetry is the **element-set intersection**
+of both operands' groups (on matching axes). With general groups,
+S_3 ∩ C_3 = C_3 (the common elements), not just "same tuple = keep."
+
 ```python
-# Both have ((0,1)) → intersection is ((0,1))
+# Both have S_2 on (0,1) → intersection is S_2
 we.add(S1, S2)
 
-# S1 has ((0,1),(2,3)), S2 has ((0,1)) → intersection is ((0,1))
+# S1 has S_3 on (0,1,2), S2 has C_3 on (0,1,2) → intersection is C_3
 we.add(S1, S2)
 
 # S has ((0,1)), B is plain ndarray → intersection is empty → plain ndarray

--- a/src/whest/_perm_group.py
+++ b/src/whest/_perm_group.py
@@ -371,6 +371,26 @@ class PermutationGroup:
                     queue.append(image)
         return frozenset(visited)
 
+    def pointwise_stabilizer(self, fixed: set[int]) -> PermutationGroup:
+        """Subgroup of elements that fix every point in *fixed*.
+
+        Parameters
+        ----------
+        fixed : set of int
+            Group-local indices that must map to themselves.
+
+        Returns
+        -------
+        PermutationGroup
+            The pointwise stabilizer subgroup (same degree).
+        """
+        if not fixed:
+            return PermutationGroup(*self._generators, axes=self._axes)
+        surviving = [g for g in self.elements() if all(g(p) == p for p in fixed)]
+        if not surviving:
+            surviving = [Permutation.identity(self._degree)]
+        return PermutationGroup(*surviving, axes=self._axes)
+
     def burnside_unique_count(self, size_dict: dict[int, int]) -> int:
         """Count unique tensor elements via Burnside's lemma.
 

--- a/src/whest/_perm_group.py
+++ b/src/whest/_perm_group.py
@@ -409,8 +409,7 @@ class PermutationGroup:
             return PermutationGroup(*self._generators, axes=self._axes)
         frozen = frozenset(subset)
         surviving = [
-            g for g in self.elements()
-            if frozenset(g(x) for x in frozen) == frozen
+            g for g in self.elements() if frozenset(g(x) for x in frozen) == frozen
         ]
         if not surviving:
             surviving = [Permutation.identity(self._degree)]

--- a/src/whest/_perm_group.py
+++ b/src/whest/_perm_group.py
@@ -416,6 +416,43 @@ class PermutationGroup:
             surviving = [Permutation.identity(self._degree)]
         return PermutationGroup(*surviving, axes=self._axes)
 
+    def restrict(self, kept: tuple[int, ...]) -> PermutationGroup:
+        """Project permutations onto *kept* positions, re-indexing to 0..len(kept)-1.
+
+        Precondition: the group must already stabilize *kept* setwise
+        (every element maps the set of kept positions to itself).
+
+        Parameters
+        ----------
+        kept : tuple of int
+            Group-local indices to keep, in the desired output order.
+
+        Returns
+        -------
+        PermutationGroup
+            Group of degree ``len(kept)`` with projected permutations.
+            ``axes`` is updated to select the corresponding entries from
+            the original ``axes`` tuple (or None if original had no axes).
+        """
+        new_degree = len(kept)
+        if new_degree == 0:
+            raise ValueError("kept must be non-empty")
+
+        # Map old group-local index → new index
+        old_to_new = {old: new for new, old in enumerate(kept)}
+
+        projected: set[Permutation] = set()
+        for g in self.elements():
+            new_arr = [old_to_new[g(k)] for k in kept]
+            projected.add(Permutation(new_arr))
+
+        new_axes: tuple[int, ...] | None = None
+        if self._axes is not None:
+            new_axes = tuple(self._axes[k] for k in kept)
+
+        gens = list(projected) if projected else [Permutation.identity(new_degree)]
+        return PermutationGroup(*gens, axes=new_axes)
+
     def burnside_unique_count(self, size_dict: dict[int, int]) -> int:
         """Count unique tensor elements via Burnside's lemma.
 

--- a/src/whest/_perm_group.py
+++ b/src/whest/_perm_group.py
@@ -391,6 +391,31 @@ class PermutationGroup:
             surviving = [Permutation.identity(self._degree)]
         return PermutationGroup(*surviving, axes=self._axes)
 
+    def setwise_stabilizer(self, subset: set[int]) -> PermutationGroup:
+        """Subgroup of elements that map *subset* to itself as a set.
+
+        Parameters
+        ----------
+        subset : set of int
+            Group-local indices. The subgroup consists of elements g where
+            {g(x) for x in subset} == subset.
+
+        Returns
+        -------
+        PermutationGroup
+            The setwise stabilizer subgroup (same degree).
+        """
+        if not subset or subset == set(range(self._degree)):
+            return PermutationGroup(*self._generators, axes=self._axes)
+        frozen = frozenset(subset)
+        surviving = [
+            g for g in self.elements()
+            if frozenset(g(x) for x in frozen) == frozen
+        ]
+        if not surviving:
+            surviving = [Permutation.identity(self._degree)]
+        return PermutationGroup(*surviving, axes=self._axes)
+
     def burnside_unique_count(self, size_dict: dict[int, int]) -> int:
         """Count unique tensor elements via Burnside's lemma.
 

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -107,7 +107,8 @@ def _counted_binary(np_func, op_name: str):
             )
             out_sym_axes = (
                 [g.axes for g in out_groups if g.axes is not None]
-                if out_groups else None
+                if out_groups
+                else None
             )
 
         out_sym_info = (
@@ -125,7 +126,9 @@ def _counted_binary(np_func, op_name: str):
         result = np_func(x_orig, y_orig)
         check_nan_inf(result, op_name)
         if out_sym_axes:
-            result = SymmetricTensor(result, symmetric_axes=out_sym_axes, perm_groups=out_groups)
+            result = SymmetricTensor(
+                result, symmetric_axes=out_sym_axes, perm_groups=out_groups
+            )
             # Warn if either input had more symmetry.
             input_axes = set()
             if x_sym:
@@ -213,13 +216,18 @@ def _counted_reduction(
             if new_groups is not None:
                 result = _np.asarray(result).view(SymmetricTensor)
                 result._symmetry_groups = new_groups
-                result._symmetric_axes = [g.axes for g in new_groups if g.axes is not None]
+                result._symmetric_axes = [
+                    g.axes for g in new_groups if g.axes is not None
+                ]
                 # Warn if any group changed (order decreased or axes changed).
                 old_axes_set = {g.axes for g in perm_groups if g.axes is not None}
                 new_axes_set = {g.axes for g in new_groups if g.axes is not None}
                 if old_axes_set != new_axes_set:
-                    lost = [g.axes for g in perm_groups
-                            if g.axes is not None and g.axes not in new_axes_set]
+                    lost = [
+                        g.axes
+                        for g in perm_groups
+                        if g.axes is not None and g.axes not in new_axes_set
+                    ]
                     if lost:
                         _warn_symmetry_loss(lost, f"{op_name} reduced dims")
             else:

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -214,10 +214,14 @@ def _counted_reduction(
                 result = _np.asarray(result).view(SymmetricTensor)
                 result._symmetry_groups = new_groups
                 result._symmetric_axes = [g.axes for g in new_groups if g.axes is not None]
-                if len(new_groups) < len(perm_groups):
-                    lost_axes = [g.axes for g in perm_groups if g.axes is not None]
-                    if lost_axes:
-                        _warn_symmetry_loss(lost_axes, f"{op_name} reduced dims")
+                # Warn if any group changed (order decreased or axes changed).
+                old_axes_set = {g.axes for g in perm_groups if g.axes is not None}
+                new_axes_set = {g.axes for g in new_groups if g.axes is not None}
+                if old_axes_set != new_axes_set:
+                    lost = [g.axes for g in perm_groups
+                            if g.axes is not None and g.axes not in new_axes_set]
+                    if lost:
+                        _warn_symmetry_loss(lost, f"{op_name} reduced dims")
             else:
                 if isinstance(result, SymmetricTensor):
                     result = _np.asarray(result)

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -87,21 +87,27 @@ def _counted_binary(np_func, op_name: str):
         y_is_scalar = y.ndim == 0
 
         # Determine output symmetry.
+        out_groups: list | None = None
         out_sym_axes: list | None = None
         if x_sym and y_is_scalar:
+            out_groups = x_sym.groups if x_sym.groups else None
             out_sym_axes = x_sym.symmetric_axes
         elif y_sym and x_is_scalar:
+            out_groups = y_sym.groups if y_sym.groups else None
             out_sym_axes = y_sym.symmetric_axes
         elif x_sym or y_sym:
-            # Use intersection (handles both exact-match and partial-overlap).
-            x_axes = x_sym.symmetric_axes if x_sym else []
-            y_axes = y_sym.symmetric_axes if y_sym else []
-            out_sym_axes = intersect_symmetry(
-                x_axes if x_axes else None,
-                y_axes if y_axes else None,
+            x_groups = x_sym.groups if x_sym else []
+            y_groups = y_sym.groups if y_sym else []
+            out_groups = intersect_symmetry(
+                x_groups if x_groups else None,
+                y_groups if y_groups else None,
                 x.shape,
                 y.shape,
                 output_shape,
+            )
+            out_sym_axes = (
+                [g.axes for g in out_groups if g.axes is not None]
+                if out_groups else None
             )
 
         out_sym_info = (
@@ -119,15 +125,15 @@ def _counted_binary(np_func, op_name: str):
         result = np_func(x_orig, y_orig)
         check_nan_inf(result, op_name)
         if out_sym_axes:
-            result = SymmetricTensor(result, symmetric_axes=out_sym_axes)
+            result = SymmetricTensor(result, symmetric_axes=out_sym_axes, perm_groups=out_groups)
             # Warn if either input had more symmetry.
-            input_groups = set()
+            input_axes = set()
             if x_sym:
-                input_groups.update(x_sym.symmetric_axes)
+                input_axes.update(x_sym.symmetric_axes)
             if y_sym:
-                input_groups.update(y_sym.symmetric_axes)
+                input_axes.update(y_sym.symmetric_axes)
             out_set = set(out_sym_axes)
-            lost = [g for g in input_groups if g not in out_set]
+            lost = [g for g in input_axes if g not in out_set]
             if lost:
                 _warn_symmetry_loss(
                     lost, f"{op_name} — groups not shared by both operands"
@@ -200,25 +206,24 @@ def _counted_reduction(
         # Propagate symmetry through reduction.
         if sym_info is not None:
             keepdims = kwargs.get("keepdims", False)
+            perm_groups = sym_info.groups if sym_info.groups else []
             new_groups = propagate_symmetry_reduce(
-                sym_info.symmetric_axes, len(a.shape), axis, keepdims=keepdims
+                perm_groups, len(a.shape), axis, keepdims=keepdims
             )
             if new_groups is not None:
                 result = _np.asarray(result).view(SymmetricTensor)
-                result._symmetric_axes = new_groups
-                # Warn if groups were partially lost.
-                old_set = set(sym_info.symmetric_axes)
-                new_set = set(new_groups)
-                if new_set != old_set:
-                    lost = [g for g in sym_info.symmetric_axes if g not in new_set]
-                    if lost:
-                        _warn_symmetry_loss(lost, f"{op_name} reduced dims")
+                result._symmetry_groups = new_groups
+                result._symmetric_axes = [g.axes for g in new_groups if g.axes is not None]
+                if len(new_groups) < len(perm_groups):
+                    lost_axes = [g.axes for g in perm_groups if g.axes is not None]
+                    if lost_axes:
+                        _warn_symmetry_loss(lost_axes, f"{op_name} reduced dims")
             else:
                 if isinstance(result, SymmetricTensor):
                     result = _np.asarray(result)
-                if sym_info.symmetric_axes:
+                if perm_groups:
                     _warn_symmetry_loss(
-                        sym_info.symmetric_axes,
+                        [g.axes for g in perm_groups if g.axes is not None],
                         f"{op_name} removed all symmetric dim groups",
                     )
         elif isinstance(result, SymmetricTensor):

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -236,8 +236,12 @@ def propagate_symmetry_slice(
     shape : tuple of int
         Original tensor shape.
     key : indexing key
+        The slicing/indexing key.
 
-    Returns *None* if no symmetry survives (caller should return plain ndarray).
+    Returns
+    -------
+    list of PermutationGroup or None
+        Surviving groups, or ``None`` if no symmetry survives.
     """
     ndim = len(shape)
 
@@ -400,7 +404,10 @@ def propagate_symmetry_reduce(
     keepdims : bool
         Whether reduced dims are kept at size 1.
 
-    Returns *None* if no symmetry survives.
+    Returns
+    -------
+    list of PermutationGroup or None
+        Surviving groups, or ``None`` if no symmetry survives.
     """
     if axis is None:
         return None

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -476,11 +476,23 @@ def intersect_symmetry(
 ) -> list[PermutationGroup] | None:
     """Intersect symmetry groups for binary ops, accounting for broadcasting.
 
+    For groups acting on the same output axes, computes the element-set
+    intersection.  Broadcast-stretched dimensions (size 1 → larger) are
+    removed from groups before intersecting.
+
     Parameters
     ----------
     groups_a, groups_b : list of PermutationGroup or None
-    shape_a, shape_b : input shapes
-    output_shape : broadcast output shape
+        Symmetry groups for each operand.
+    shape_a, shape_b : tuple of int
+        Input shapes (before broadcasting).
+    output_shape : tuple of int
+        Broadcast output shape.
+
+    Returns
+    -------
+    list of PermutationGroup or None
+        Groups present in both operands, or *None* if no shared symmetry.
     """
     if groups_a is None or groups_b is None:
         return None
@@ -635,6 +647,14 @@ class SymmetricTensor(np.ndarray):
     # -- slicing with symmetry propagation --
 
     def __getitem__(self, key):  # type: ignore[override]
+        """Index with symmetry propagation.
+
+        Computes the pointwise-stabilizer subgroup for axes removed by
+        integer indexing, then restricts surviving groups to the output
+        axes.  Returns a plain ``ndarray`` when no symmetry survives.
+        Emits :class:`~whest.errors.SymmetryLossWarning` on partial or
+        total symmetry loss.
+        """
         result = super().__getitem__(key)
         if not isinstance(result, np.ndarray) or result.ndim == 0:
             return result if not isinstance(result, np.ndarray) else np.asarray(result)

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -337,9 +337,10 @@ def propagate_symmetry_slice(
         if not local_kept:
             continue
 
-        # Setwise stabilizer: elements that map the set of removed axes to itself.
-        # This allows permutations among removed axes that share the same slice value.
-        stab = group.setwise_stabilizer(local_removed)
+        # Pointwise stabilizer: each removed axis must map to itself.
+        # (Setwise would only be valid when all removed axes share the
+        # same slice value, which we can't determine in general.)
+        stab = group.pointwise_stabilizer(local_removed)
 
         # Among surviving axes, check for size mismatches.
         size_map: dict[int, int] = {}

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -504,7 +504,9 @@ def intersect_symmetry(
     offset_a = ndim_out - ndim_a
     offset_b = ndim_out - ndim_b
 
-    def _remap_axes(groups: list[PermutationGroup], offset: int, input_shape: tuple[int, ...]):
+    def _remap_axes(
+        groups: list[PermutationGroup], offset: int, input_shape: tuple[int, ...]
+    ):
         """Remap group axes to output dims and remove broadcast-stretched dims."""
         result = []
         for group in groups:
@@ -523,9 +525,9 @@ def intersect_symmetry(
             if len(local_kept) >= 2:
                 restricted = group.restrict(tuple(local_kept))
                 if restricted.order() > 1:
-                    result.append(PermutationGroup(
-                        *restricted.generators, axes=tuple(new_axes)
-                    ))
+                    result.append(
+                        PermutationGroup(*restricted.generators, axes=tuple(new_axes))
+                    )
         return result
 
     aligned_a = _remap_axes(groups_a, offset_a, shape_a)
@@ -670,8 +672,7 @@ class SymmetricTensor(np.ndarray):
             # Warn if symmetry was partially lost.
             if len(new_groups) < len(self._symmetry_groups):
                 lost_axes = [
-                    g.axes for g in self._symmetry_groups
-                    if g.axes is not None
+                    g.axes for g in self._symmetry_groups if g.axes is not None
                 ]
                 if lost_axes:
                     _warn_symmetry_loss(

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -382,12 +382,23 @@ def propagate_symmetry_slice(
 
 
 def propagate_symmetry_reduce(
-    symmetric_axes: list[tuple[int, ...]],
+    groups: list[PermutationGroup],
     ndim: int,
     axis: int | tuple[int, ...] | None,
     keepdims: bool = False,
-) -> list[tuple[int, ...]] | None:
+) -> list[PermutationGroup] | None:
     """Compute new symmetry groups after a reduction.
+
+    Parameters
+    ----------
+    groups : list of PermutationGroup
+        Each group has ``axes`` indicating which tensor dimensions it acts on.
+    ndim : int
+        Original tensor rank.
+    axis : int, tuple of int, or None
+        Axes being reduced.
+    keepdims : bool
+        Whether reduced dims are kept at size 1.
 
     Returns *None* if no symmetry survives.
     """
@@ -396,37 +407,64 @@ def propagate_symmetry_reduce(
 
     # Normalize axis.
     if isinstance(axis, int):
-        axes = (axis % ndim,)
+        axes_set = {axis % ndim}
     else:
-        axes = tuple(a % ndim for a in axis)
-    axes_set = set(axes)
+        axes_set = {a % ndim for a in axis}
 
-    if keepdims:
-        # Reduced dims stay but have size 1 → pull from groups.
-        new_groups: list[tuple[int, ...]] = []
-        for group in symmetric_axes:
-            surviving = tuple(d for d in group if d not in axes_set)
-            if len(surviving) >= 2:
-                new_groups.append(surviving)
-        return new_groups if new_groups else None
-    else:
-        # Removed dims — renumber.
-        old_to_new: dict[int, int] = {}
+    # Build old→new mapping (only needed when not keepdims).
+    old_to_new: dict[int, int] = {}
+    if not keepdims:
         new_idx = 0
         for d in range(ndim):
             if d not in axes_set:
                 old_to_new[d] = new_idx
                 new_idx += 1
+    else:
+        old_to_new = {d: d for d in range(ndim)}
 
-        new_groups = []
-        for group in symmetric_axes:
-            surviving = []
-            for d in group:
-                if d in old_to_new:
-                    surviving.append(old_to_new[d])
-            if len(surviving) >= 2:
-                new_groups.append(tuple(sorted(surviving)))
-        return new_groups if new_groups else None
+    new_groups: list[PermutationGroup] = []
+    for group in groups:
+        grp_axes = group.axes
+        if grp_axes is None:
+            continue
+
+        # Map tensor axes to group-local indices.
+        local_reduced: set[int] = set()
+        local_kept: list[int] = []
+        for local_idx, tensor_dim in enumerate(grp_axes):
+            if tensor_dim in axes_set:
+                local_reduced.add(local_idx)
+            else:
+                local_kept.append(local_idx)
+
+        if not local_reduced:
+            # Group is entirely outside the reduced axes — just remap.
+            new_axes = tuple(old_to_new[grp_axes[i]] for i in range(group.degree))
+            new_groups.append(PermutationGroup(*group.generators, axes=new_axes))
+            continue
+
+        if not local_kept:
+            # All axes in this group are reduced — group vanishes from output.
+            continue
+
+        # Setwise stabilizer: elements mapping reduced axes among themselves.
+        stab = group.setwise_stabilizer(local_reduced)
+
+        # Restrict to kept local indices.
+        kept_tuple = tuple(local_kept)
+        if len(kept_tuple) < 2:
+            continue
+
+        restricted = stab.restrict(kept_tuple)
+        if restricted.order() <= 1:
+            continue
+
+        # Remap to new tensor axis numbering.
+        new_axes = tuple(old_to_new[grp_axes[k]] for k in kept_tuple)
+        final = PermutationGroup(*restricted.generators, axes=new_axes)
+        new_groups.append(final)
+
+    return new_groups if new_groups else None
 
 
 def intersect_symmetry(

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -639,33 +639,30 @@ class SymmetricTensor(np.ndarray):
         if not isinstance(result, np.ndarray) or result.ndim == 0:
             return result if not isinstance(result, np.ndarray) else np.asarray(result)
 
-        if not self._symmetric_axes:
+        if not self._symmetry_groups:
             return np.asarray(result)
 
-        new_groups = propagate_symmetry_slice(self._symmetric_axes, self.shape, key)
+        new_groups = propagate_symmetry_slice(self._symmetry_groups, self.shape, key)
         if new_groups is not None:
             out = np.asarray(result).view(SymmetricTensor)
-            out._symmetric_axes = new_groups
-            out._symmetry_groups = [
-                PermutationGroup.symmetric(len(g), axes=g)
-                for g in new_groups
-                if len(g) >= 2
-            ]
+            out._symmetry_groups = new_groups
+            out._symmetric_axes = [g.axes for g in new_groups if g.axes is not None]
             # Warn if symmetry was partially lost.
-            old_set = set(self._symmetric_axes)
-            new_set = set(new_groups)
-            if new_set != old_set:
-                lost = [g for g in self._symmetric_axes if g not in new_set]
-                if lost:
+            if len(new_groups) < len(self._symmetry_groups):
+                lost_axes = [
+                    g.axes for g in self._symmetry_groups
+                    if g.axes is not None
+                ]
+                if lost_axes:
                     _warn_symmetry_loss(
-                        lost, "slicing changed dim sizes or removed dims"
+                        lost_axes, "slicing changed dim sizes or removed dims"
                     )
             return out
         else:
-            # All symmetry lost.
-            if self._symmetric_axes:
+            if self._symmetry_groups:
                 _warn_symmetry_loss(
-                    self._symmetric_axes, "slicing removed all symmetric dim groups"
+                    [g.axes for g in self._symmetry_groups if g.axes is not None],
+                    "slicing removed all symmetric dim groups",
                 )
             return np.asarray(result)
 

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -223,21 +223,27 @@ def _warn_symmetry_loss(
 
 
 def propagate_symmetry_slice(
-    symmetric_axes: list[tuple[int, ...]],
+    groups: list[PermutationGroup],
     shape: tuple[int, ...],
     key,
-) -> list[tuple[int, ...]] | None:
+) -> list[PermutationGroup] | None:
     """Compute new symmetry groups after ``__getitem__(key)``.
+
+    Parameters
+    ----------
+    groups : list of PermutationGroup
+        Each group has ``axes`` indicating which tensor dimensions it acts on.
+    shape : tuple of int
+        Original tensor shape.
+    key : indexing key
 
     Returns *None* if no symmetry survives (caller should return plain ndarray).
     """
     ndim = len(shape)
 
-    # Normalize key to a tuple.
     if not isinstance(key, tuple):
         key = (key,)
 
-    # Advanced indexing (ndarray / list) → bail out.
     for k in key:
         if isinstance(k, (np.ndarray, list)):
             return None
@@ -251,27 +257,23 @@ def propagate_symmetry_slice(
                 raise IndexError("only one Ellipsis allowed")
             ellipsis_seen = True
             n_newaxis_in_key = sum(1 for kk in key if kk is None)
-            n_explicit = len(key) - 1 - n_newaxis_in_key  # -1 for Ellipsis
+            n_explicit = len(key) - 1 - n_newaxis_in_key
             n_fill = ndim - n_explicit
             expanded.extend([slice(None)] * n_fill)
         else:
             expanded.append(k)
     if not ellipsis_seen:
-        # Pad with slice(None) for unspecified trailing dims.
         n_newaxis = sum(1 for k in expanded if k is None)
         while len(expanded) - n_newaxis < ndim:
             expanded.append(slice(None))
     key_expanded = expanded
 
-    # Walk through the key, tracking each original dim.
-    # old_dim_idx tracks which original dim we're consuming.
+    # Classify each original dim.
     old_dim_idx = 0
-    # For each original dim: "removed", ("kept", new_size), or "untouched"
     dim_actions: dict[int, str | tuple] = {}
 
     for k in key_expanded:
         if k is None:
-            # np.newaxis — adds a dim, doesn't consume an original dim.
             continue
         if old_dim_idx >= ndim:
             break
@@ -279,7 +281,6 @@ def propagate_symmetry_slice(
             dim_actions[old_dim_idx] = "removed"
             old_dim_idx += 1
         elif isinstance(k, slice):
-            # Compute resulting size for this dim.
             start, stop, step = k.indices(shape[old_dim_idx])
             new_size = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
             if new_size == shape[old_dim_idx]:
@@ -288,23 +289,18 @@ def propagate_symmetry_slice(
                 dim_actions[old_dim_idx] = ("resized", new_size)
             old_dim_idx += 1
         else:
-            # Unknown indexer — bail.
             return None
 
-    # Fill remaining dims as untouched.
     while old_dim_idx < ndim:
         dim_actions[old_dim_idx] = "untouched"
         old_dim_idx += 1
 
-    # Build old→new dim mapping (removed dims get None).
+    # Build old→new dim mapping.
     removed_dims = {d for d, a in dim_actions.items() if a == "removed"}
     old_to_new: dict[int, int | None] = {}
-    new_idx = 0
-    # Account for newaxis insertions: they shift new indices.
-    # Simple approach: count newaxis positions before each original dim.
     newaxis_positions: list[int] = []
     orig_idx = 0
-    for i, k in enumerate(key_expanded):
+    for k in key_expanded:
         if k is None:
             newaxis_positions.append(orig_idx)
         else:
@@ -312,7 +308,6 @@ def propagate_symmetry_slice(
 
     new_idx = 0
     for d in range(ndim):
-        # Insert newaxis dims that come before this original dim.
         while newaxis_positions and newaxis_positions[0] <= d:
             newaxis_positions.pop(0)
             new_idx += 1
@@ -322,43 +317,65 @@ def propagate_symmetry_slice(
             old_to_new[d] = new_idx
             new_idx += 1
 
-    # Remap symmetry groups.
-    new_groups: list[tuple[int, ...]] = []
-    for group in symmetric_axes:
-        # Collect surviving dims with their effective sizes.
-        surviving_with_size: list[tuple[int, int]] = []  # (new_dim, size)
-        for d in group:
-            action = dim_actions.get(d, "untouched")
-            if action == "removed":
-                continue
-            new_d = old_to_new.get(d)
-            if new_d is None:
-                continue
-            if isinstance(action, tuple) and action[0] == "resized":
-                surviving_with_size.append((new_d, action[1]))
-            else:
-                surviving_with_size.append((new_d, shape[d]))
-
-        if not surviving_with_size:
+    # Process each group.
+    new_groups: list[PermutationGroup] = []
+    for group in groups:
+        axes = group.axes
+        if axes is None:
             continue
 
-        # Group by size — only dims with the same size can stay in a group.
-        # Use the most common size (the untouched original size).
-        from collections import Counter
+        # Map tensor axes to group-local indices.
+        local_removed: set[int] = set()
+        local_kept: list[int] = []
+        for local_idx, tensor_dim in enumerate(axes):
+            action = dim_actions.get(tensor_dim, "untouched")
+            if action == "removed":
+                local_removed.add(local_idx)
+            else:
+                local_kept.append(local_idx)
 
-        size_counts = Counter(s for _, s in surviving_with_size)
-        # Pick the original (untouched) size as the canonical one.
-        # That's the size that appears for untouched dims.
-        original_size = shape[group[0]]
-        if original_size in size_counts:
-            canonical_size = original_size
-        else:
-            # All dims were resized; pick the most common size.
-            canonical_size = size_counts.most_common(1)[0][0]
+        if not local_kept:
+            continue
 
-        same_size_dims = [d for d, s in surviving_with_size if s == canonical_size]
-        if len(same_size_dims) >= 2:
-            new_groups.append(tuple(sorted(same_size_dims)))
+        # Setwise stabilizer: elements that map the set of removed axes to itself.
+        # This allows permutations among removed axes that share the same slice value.
+        stab = group.setwise_stabilizer(local_removed)
+
+        # Among surviving axes, check for size mismatches.
+        size_map: dict[int, int] = {}
+        for local_idx in local_kept:
+            tensor_dim = axes[local_idx]
+            action = dim_actions.get(tensor_dim, "untouched")
+            if isinstance(action, tuple) and action[0] == "resized":
+                size_map[local_idx] = action[1]
+            else:
+                size_map[local_idx] = shape[tensor_dim]
+
+        sizes = set(size_map.values())
+        if len(sizes) > 1:
+            for sz in sizes:
+                same_size = {li for li, s in size_map.items() if s == sz}
+                complement = set(local_kept) - same_size
+                if complement:
+                    stab = stab.setwise_stabilizer(same_size)
+
+        # Restrict to kept local indices.
+        kept_tuple = tuple(local_kept)
+        if len(kept_tuple) < 2:
+            continue
+
+        restricted = stab.restrict(kept_tuple)
+
+        if restricted.order() <= 1:
+            continue
+
+        # Remap axes to new tensor dim numbering.
+        new_axes = tuple(old_to_new[axes[k]] for k in kept_tuple)
+        if any(a is None for a in new_axes):
+            continue
+
+        final = PermutationGroup(*restricted.generators, axes=new_axes)
+        new_groups.append(final)
 
     return new_groups if new_groups else None
 

--- a/src/whest/_symmetric.py
+++ b/src/whest/_symmetric.py
@@ -468,56 +468,75 @@ def propagate_symmetry_reduce(
 
 
 def intersect_symmetry(
-    dims_a: list[tuple[int, ...]] | None,
-    dims_b: list[tuple[int, ...]] | None,
+    groups_a: list[PermutationGroup] | None,
+    groups_b: list[PermutationGroup] | None,
     shape_a: tuple[int, ...],
     shape_b: tuple[int, ...],
     output_shape: tuple[int, ...],
-) -> list[tuple[int, ...]] | None:
-    """Intersect symmetry groups for binary ops, accounting for broadcasting."""
-    if dims_a is None or dims_b is None:
+) -> list[PermutationGroup] | None:
+    """Intersect symmetry groups for binary ops, accounting for broadcasting.
+
+    Parameters
+    ----------
+    groups_a, groups_b : list of PermutationGroup or None
+    shape_a, shape_b : input shapes
+    output_shape : broadcast output shape
+    """
+    if groups_a is None or groups_b is None:
         return None
 
     ndim_out = len(output_shape)
     ndim_a = len(shape_a)
     ndim_b = len(shape_b)
 
-    # Align dims to the right (broadcasting alignment).
     offset_a = ndim_out - ndim_a
     offset_b = ndim_out - ndim_b
 
-    # Remap to output dim indices.
-    def _remap(dims: list[tuple[int, ...]], offset: int) -> list[tuple[int, ...]]:
-        return [tuple(d + offset for d in g) for g in dims]
-
-    aligned_a = _remap(dims_a, offset_a)
-    aligned_b = _remap(dims_b, offset_b)
-
-    # Identify broadcast-stretched dims for each input.
-    def _remove_stretched(
-        groups: list[tuple[int, ...]],
-        input_shape: tuple[int, ...],
-        offset: int,
-    ) -> list[tuple[int, ...]]:
+    def _remap_axes(groups: list[PermutationGroup], offset: int, input_shape: tuple[int, ...]):
+        """Remap group axes to output dims and remove broadcast-stretched dims."""
         result = []
         for group in groups:
-            surviving = []
-            for d in group:
-                orig_d = d - offset
-                if 0 <= orig_d < len(input_shape):
-                    if input_shape[orig_d] == 1 and output_shape[d] > 1:
-                        continue  # stretched
-                surviving.append(d)
-            if len(surviving) >= 2:
-                result.append(tuple(sorted(surviving)))
+            if group.axes is None:
+                continue
+            new_axes = []
+            local_kept = []
+            for local_idx, tensor_dim in enumerate(group.axes):
+                out_dim = tensor_dim + offset
+                # Check if broadcast-stretched (size 1 → larger).
+                if 0 <= tensor_dim < len(input_shape):
+                    if input_shape[tensor_dim] == 1 and output_shape[out_dim] > 1:
+                        continue  # stretched — remove from group
+                new_axes.append(out_dim)
+                local_kept.append(local_idx)
+            if len(local_kept) >= 2:
+                restricted = group.restrict(tuple(local_kept))
+                if restricted.order() > 1:
+                    result.append(PermutationGroup(
+                        *restricted.generators, axes=tuple(new_axes)
+                    ))
         return result
 
-    cleaned_a = _remove_stretched(aligned_a, shape_a, offset_a)
-    cleaned_b = _remove_stretched(aligned_b, shape_b, offset_b)
+    aligned_a = _remap_axes(groups_a, offset_a, shape_a)
+    aligned_b = _remap_axes(groups_b, offset_b, shape_b)
 
-    # Intersect: keep groups present in both.
-    set_b = set(tuple(g) for g in cleaned_b)
-    intersection = [g for g in cleaned_a if tuple(g) in set_b]
+    # Intersect: for groups acting on the same output axes, compute element intersection.
+    b_by_axes: dict[tuple[int, ...], PermutationGroup] = {}
+    for g in aligned_b:
+        if g.axes is not None:
+            b_by_axes[g.axes] = g
+
+    intersection: list[PermutationGroup] = []
+    for ga in aligned_a:
+        if ga.axes is None:
+            continue
+        gb = b_by_axes.get(ga.axes)
+        if gb is None:
+            continue
+        # Element-set intersection.
+        common_elements = set(ga.elements()) & set(gb.elements())
+        if len(common_elements) <= 1:
+            continue
+        intersection.append(PermutationGroup(*common_elements, axes=ga.axes))
 
     return intersection if intersection else None
 

--- a/tests/test_perm_group.py
+++ b/tests/test_perm_group.py
@@ -498,3 +498,51 @@ class TestPointwiseStabilizer:
         g = PermutationGroup.symmetric(3)
         stab = g.pointwise_stabilizer({0, 1, 2})
         assert stab.order() == 1
+
+
+class TestSetwiseStabilizer:
+    def test_c4_setwise_13(self):
+        """C_4 setwise stabilizer of {1,3} → {id, rot²} = C_2."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.setwise_stabilizer({1, 3})
+        assert stab.order() == 2
+        for elem in stab.elements():
+            assert {elem(1), elem(3)} == {1, 3}
+
+    def test_c3_setwise_any_pair(self):
+        """C_3 setwise stabilizer of any 2-element subset → trivial."""
+        g = PermutationGroup.cyclic(3)
+        stab = g.setwise_stabilizer({0, 1})
+        assert stab.order() == 1
+
+    def test_s3_setwise_pair(self):
+        """S_3 setwise stabilizer of {0,1} → {id, (0 1)} = S_2."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.setwise_stabilizer({0, 1})
+        assert stab.order() == 2
+        for elem in stab.elements():
+            assert {elem(0), elem(1)} == {0, 1}
+
+    def test_s4_setwise_pair(self):
+        """S_4 setwise stabilizer of {0,1}: 2! × 2! = 4 elements."""
+        g = PermutationGroup.symmetric(4)
+        stab = g.setwise_stabilizer({0, 1})
+        assert stab.order() == 4
+
+    def test_empty_set(self):
+        """Setwise stabilizer of empty set is the full group."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.setwise_stabilizer(set())
+        assert stab.order() == g.order()
+
+    def test_full_set(self):
+        """Setwise stabilizer of the full set is the full group."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.setwise_stabilizer({0, 1, 2})
+        assert stab.order() == g.order()
+
+    def test_d4_setwise(self):
+        """D_4 setwise stabilizer of {0,2} (opposite corners)."""
+        g = PermutationGroup.dihedral(4)
+        stab = g.setwise_stabilizer({0, 2})
+        assert stab.order() == 4

--- a/tests/test_perm_group.py
+++ b/tests/test_perm_group.py
@@ -217,10 +217,17 @@ class TestBurnsideCount:
             g.burnside_unique_count({0: 3, 1: 5})
 
 
+try:
+    import sympy as _sympy_check  # noqa: F401
+
+    _sympy_available = True
+except ImportError:
+    _sympy_available = False
+
+
+@pytest.mark.skipif(not _sympy_available, reason="sympy not installed")
 class TestSympyBridge:
     """Tests that require sympy. Skipped if sympy is not installed."""
-
-    sympy = pytest.importorskip("sympy")
 
     def test_permutation_round_trip(self):
         from sympy.combinatorics import Permutation as SPerm
@@ -446,3 +453,48 @@ class TestPermutationGroupNewMethods:
     def test_orbit_cyclic(self):
         g = PermutationGroup.cyclic(4)
         assert g.orbit(0) == frozenset({0, 1, 2, 3})
+
+
+class TestPointwiseStabilizer:
+    def test_s3_fix_one_point(self):
+        """S_3 fixing point 2 → {id, (0 1)} = S_2."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({2})
+        assert stab.order() == 2
+        assert stab.degree == 3
+        for elem in stab.elements():
+            assert elem(2) == 2
+
+    def test_c3_fix_one_point(self):
+        """C_3 fixing any single point → trivial group."""
+        g = PermutationGroup.cyclic(3)
+        for pt in range(3):
+            stab = g.pointwise_stabilizer({pt})
+            assert stab.order() == 1
+
+    def test_c4_fix_two_points(self):
+        """C_4 fixing {1,3} pointwise → only identity."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.pointwise_stabilizer({1, 3})
+        assert stab.order() == 1
+
+    def test_s4_fix_two_points(self):
+        """S_4 fixing {0,1} pointwise → S_2 on {2,3}."""
+        g = PermutationGroup.symmetric(4)
+        stab = g.pointwise_stabilizer({0, 1})
+        assert stab.order() == 2
+        for elem in stab.elements():
+            assert elem(0) == 0
+            assert elem(1) == 1
+
+    def test_fix_empty_set(self):
+        """Fixing empty set returns the full group."""
+        g = PermutationGroup.cyclic(4)
+        stab = g.pointwise_stabilizer(set())
+        assert stab.order() == g.order()
+
+    def test_fix_all_points(self):
+        """Fixing all points returns trivial group."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({0, 1, 2})
+        assert stab.order() == 1

--- a/tests/test_perm_group.py
+++ b/tests/test_perm_group.py
@@ -546,3 +546,53 @@ class TestSetwiseStabilizer:
         g = PermutationGroup.dihedral(4)
         stab = g.setwise_stabilizer({0, 2})
         assert stab.order() == 4
+
+
+class TestRestrict:
+    def test_s3_restrict_to_pair(self):
+        """S_3 pointwise-stabilizer of {2}, restricted to {0,1} → S_2."""
+        g = PermutationGroup.symmetric(3, axes=(10, 20, 30))
+        stab = g.pointwise_stabilizer({2})
+        r = stab.restrict((0, 1))
+        assert r.degree == 2
+        assert r.order() == 2
+        assert r.axes == (10, 20)
+
+    def test_c4_setwise_restrict(self):
+        """C_4 setwise-stabilizer of {1,3}, restricted to {0,2} → C_2."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        stab = g.setwise_stabilizer({1, 3})
+        r = stab.restrict((0, 2))
+        assert r.degree == 2
+        assert r.order() == 2
+        assert r.axes == (0, 2)
+        # The non-identity element swaps 0↔1 (re-indexed from 0↔2)
+        elems = r.elements()
+        non_id = [e for e in elems if not e.is_identity]
+        assert len(non_id) == 1
+        assert non_id[0](0) == 1 and non_id[0](1) == 0
+
+    def test_restrict_preserves_identity(self):
+        """Restricting a trivial group gives a trivial group."""
+        g = PermutationGroup.cyclic(3)
+        stab = g.pointwise_stabilizer({0, 1, 2})  # trivial
+        r = stab.restrict((0, 1))
+        assert r.degree == 2
+        assert r.order() == 1
+
+    def test_restrict_single_point(self):
+        """Restricting to a single point gives degree-1 trivial group."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({1, 2})
+        r = stab.restrict((0,))
+        assert r.degree == 1
+        assert r.order() == 1
+
+    def test_restrict_no_axes(self):
+        """Restrict works when group has no axes metadata."""
+        g = PermutationGroup.symmetric(3)
+        stab = g.pointwise_stabilizer({2})
+        r = stab.restrict((0, 1))
+        assert r.degree == 2
+        assert r.order() == 2
+        assert r.axes is None

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -800,3 +800,61 @@ class TestSymmetryInfoEdgeCases:
         """Groups with < 2 dims don't produce auto PermutationGroup."""
         info = SymmetryInfo(symmetric_axes=[(0,)], shape=(3,))
         assert len(info.groups) == 0
+
+
+class TestPropagateSliceGeneralGroups:
+    """Test propagate_symmetry_slice with non-S_k groups."""
+
+    def test_c3_slice_one_axis_no_symmetry(self):
+        """C_3 on {0,1,2}, slice axis 2 → no symmetry survives."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), 0))
+        assert result is None
+
+    def test_c4_slice_two_axes_c2_survives(self):
+        """C_4 on {0,1,2,3}, slice axes {1,3} → C_2 on output {0,1}."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        result = propagate_symmetry_slice([g], (5, 5, 5, 5), (slice(None), 0, slice(None), 0))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].degree == 2
+        assert result[0].order() == 2
+        assert result[0].axes == (0, 1)
+
+    def test_s3_slice_one_axis_s2_survives(self):
+        """S_3 on {0,1,2}, slice axis 2 → S_2 on {0,1}. Same as old behavior."""
+        g = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), 0))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 2
+
+    def test_d4_slice_one_axis(self):
+        """D_4 on {0,1,2,3}, slice axis 0 → pointwise stab of {0}, restricted."""
+        g = PermutationGroup.dihedral(4, axes=(0, 1, 2, 3))
+        result = propagate_symmetry_slice([g], (5, 5, 5, 5), (0, slice(None), slice(None), slice(None)))
+        assert result is not None
+        assert len(result) == 1
+        stab = result[0]
+        assert stab.degree == 3
+        for elem in stab.elements():
+            assert elem.size == 3
+
+    def test_multiple_groups_independent(self):
+        """Two independent groups, slice removes axis from one."""
+        g1 = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        g2 = PermutationGroup.symmetric(2, axes=(3, 4))
+        result = propagate_symmetry_slice(
+            [g1, g2], (5, 5, 5, 5, 5), (0, slice(None), slice(None), slice(None), slice(None))
+        )
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 2
+
+    def test_no_axes_removed_group_unchanged(self):
+        """Full slice preserves group unchanged."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), slice(None)))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -855,3 +855,53 @@ class TestPropagateSliceGeneralGroups:
         assert result is not None
         assert len(result) == 1
         assert result[0].order() == 3
+
+
+class TestPropagateReduceGeneralGroups:
+    """Test propagate_symmetry_reduce with non-S_k groups."""
+
+    def test_c4_reduce_13_c2_survives(self):
+        """C_4 on {0,1,2,3}, reduce axes {1,3} → C_2 on output {0,1}."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        result = propagate_symmetry_reduce([g], 4, (1, 3), keepdims=False)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 2
+        assert result[0].axes == (0, 1)
+
+    def test_c3_reduce_one_axis_trivial(self):
+        """C_3 on {0,1,2}, reduce axis 2 → only identity survives → no group."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_reduce([g], 3, 2, keepdims=False)
+        assert result is None
+
+    def test_s3_reduce_one_axis_s2(self):
+        """S_3 on {0,1,2}, reduce axis 2 → S_2 on {0,1}. Matches old behavior."""
+        g = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        result = propagate_symmetry_reduce([g], 3, 2, keepdims=False)
+        assert result is not None
+        assert result[0].order() == 2
+
+    def test_reduce_none_returns_none(self):
+        """axis=None reduces everything → no symmetry."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = propagate_symmetry_reduce([g], 3, None)
+        assert result is None
+
+    def test_c4_reduce_keepdims(self):
+        """C_4 on {0,1,2,3}, reduce axes {1,3} keepdims=True → C_2."""
+        g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        result = propagate_symmetry_reduce([g], 4, (1, 3), keepdims=True)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 2
+        assert result[0].axes == (0, 2)
+
+    def test_reduce_disjoint_axis(self):
+        """Reduce an axis not in the group → group unchanged, axes renumbered."""
+        g = PermutationGroup.cyclic(3, axes=(1, 2, 3))
+        result = propagate_symmetry_reduce([g], 4, 0, keepdims=False)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3
+        assert result[0].axes == (0, 1, 2)

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -938,3 +938,27 @@ class TestIntersectSymmetryGeneralGroups:
         g2 = PermutationGroup.symmetric(2, axes=(2, 3))
         result = intersect_symmetry([g1], [g2], (5, 5, 5, 5), (5, 5, 5, 5), (5, 5, 5, 5))
         assert result is None
+
+
+class TestSymmetricTensorGeneralGroups:
+    """End-to-end tests: SymmetricTensor with general groups through slice/reduce."""
+
+    def test_c3_tensor_slice_loses_symmetry(self):
+        """SymmetricTensor with C_3, slicing one axis -> no symmetry."""
+        arr = np.zeros((3, 3, 3))
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        t = SymmetricTensor(arr, symmetric_axes=[(0, 1, 2)], perm_groups=[g])
+        result = t[:, :, 0]
+        assert not isinstance(result, SymmetricTensor) or not result.symmetric_axes
+
+    def test_s3_tensor_slice_keeps_s2(self):
+        """SymmetricTensor with S_3, slicing one axis -> S_2 survives."""
+        arr = np.zeros((3, 3, 3))
+        g = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        t = SymmetricTensor(arr, symmetric_axes=[(0, 1, 2)], perm_groups=[g])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = t[:, :, 0]
+        assert isinstance(result, SymmetricTensor)
+        assert len(result._symmetry_groups) == 1
+        assert result._symmetry_groups[0].order() == 2

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -31,6 +31,23 @@ from whest.errors import SymmetryError, SymmetryLossWarning
 # ============================================================================
 
 
+def _sg(*axes: int) -> PermutationGroup:
+    """Shorthand: full symmetric group on the given axes."""
+    return PermutationGroup.symmetric(len(axes), axes=axes)
+
+
+def _assert_groups_equal(result, expected_axes_list):
+    """Assert result is a list of PermutationGroups matching expected axes tuples."""
+    assert result is not None
+    assert len(result) == len(expected_axes_list)
+    for grp, axes in zip(result, expected_axes_list):
+        assert isinstance(grp, PermutationGroup)
+        assert grp.axes == tuple(axes), f"expected axes {tuple(axes)}, got {grp.axes}"
+        import math
+
+        assert grp.order() == math.factorial(len(axes))
+
+
 def _sym_matrix(n: int = 5, seed: int = 42) -> np.ndarray:
     rng = np.random.default_rng(seed)
     a = rng.standard_normal((n, n))
@@ -255,114 +272,114 @@ class TestIsSymmetric:
 class TestPropagateSymmetrySlice:
     def test_full_slice_preserves(self):
         """Slicing with [:, :] preserves symmetry."""
-        result = propagate_symmetry_slice([(0, 1)], (5, 5), (slice(None), slice(None)))
-        assert result == [(0, 1)]
+        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (slice(None), slice(None)))
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_integer_index_removes_dim(self):
         """Integer index removes a dim from the group."""
-        result = propagate_symmetry_slice([(0, 1)], (5, 5), (0,))
+        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (0,))
         # Dim 0 removed, only dim 1 survives -> group too small
         assert result is None
 
     def test_partial_slice_resizes(self):
         """Partial slice that changes size but keeps both dims."""
-        result = propagate_symmetry_slice([(0, 1)], (5, 5), (slice(0, 3), slice(0, 3)))
-        assert result == [(0, 1)]
+        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (slice(0, 3), slice(0, 3)))
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_partial_slice_different_sizes_breaks(self):
         """Slicing dims to different sizes breaks symmetry."""
-        result = propagate_symmetry_slice([(0, 1)], (5, 5), (slice(0, 3), slice(0, 2)))
+        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (slice(0, 3), slice(0, 2)))
         # Dims have different sizes, group is lost
         assert result is None
 
     def test_ellipsis_expansion(self):
         """Ellipsis expands to fill missing dims."""
-        result = propagate_symmetry_slice([(0, 1)], (5, 5), (Ellipsis,))
-        assert result == [(0, 1)]
+        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (Ellipsis,))
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_ellipsis_with_trailing_index(self):
         """Ellipsis + integer index at the end."""
         # shape (3, 5, 5), group (1, 2), key (..., 0)
-        result = propagate_symmetry_slice([(1, 2)], (3, 5, 5), (Ellipsis, 0))
+        result = propagate_symmetry_slice([_sg(1, 2)], (3, 5, 5), (Ellipsis, 0))
         # Dim 2 removed via integer, dim 1 survives -> group has 1 element
         assert result is None
 
     def test_double_ellipsis_raises(self):
         with pytest.raises(IndexError, match="only one Ellipsis"):
-            propagate_symmetry_slice([(0, 1)], (5, 5), (Ellipsis, Ellipsis))
+            propagate_symmetry_slice([_sg(0, 1)], (5, 5), (Ellipsis, Ellipsis))
 
     def test_newaxis_handling(self):
         """np.newaxis adds a dim but doesn't consume an original dim."""
         # shape (5, 5), group (0, 1), key (None, :, :)
         result = propagate_symmetry_slice(
-            [(0, 1)], (5, 5), (None, slice(None), slice(None))
+            [_sg(0, 1)], (5, 5), (None, slice(None), slice(None))
         )
         # newaxis shifts dims: original 0->1, original 1->2
-        assert result == [(1, 2)]
+        _assert_groups_equal(result, [(1, 2)])
 
     def test_newaxis_between_symmetric_dims(self):
         """newaxis inserted between symmetric dims."""
         result = propagate_symmetry_slice(
-            [(0, 1)], (5, 5), (slice(None), None, slice(None))
+            [_sg(0, 1)], (5, 5), (slice(None), None, slice(None))
         )
         # Original 0->0, newaxis at 1, original 1->2
-        assert result == [(0, 2)]
+        _assert_groups_equal(result, [(0, 2)])
 
     def test_advanced_indexing_bails(self):
         """Array or list indexing returns None."""
-        assert propagate_symmetry_slice([(0, 1)], (5, 5), (np.array([0, 1]),)) is None
-        assert propagate_symmetry_slice([(0, 1)], (5, 5), ([0, 1],)) is None
+        assert propagate_symmetry_slice([_sg(0, 1)], (5, 5), (np.array([0, 1]),)) is None
+        assert propagate_symmetry_slice([_sg(0, 1)], (5, 5), ([0, 1],)) is None
 
     def test_non_tuple_key_normalized(self):
         """Non-tuple key is wrapped in a tuple."""
-        result = propagate_symmetry_slice([(0, 1)], (5, 5), slice(None))
+        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), slice(None))
         # Single slice(None) -> only touches dim 0, rest padded
-        assert result == [(0, 1)]
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_three_way_one_dim_removed(self):
         """Removing one dim from a 3-way group leaves a 2-way group."""
         # shape (4, 4, 4), group (0, 1, 2), key (0, :, :)
-        result = propagate_symmetry_slice([(0, 1, 2)], (4, 4, 4), (0,))
+        result = propagate_symmetry_slice([_sg(0, 1, 2)], (4, 4, 4), (0,))
         # Dim 0 removed, dims 1,2 become 0,1
-        assert result == [(0, 1)]
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_multiple_groups_partial_survival(self):
         """One group survives, the other doesn't."""
         # shape (3, 3, 4, 4), groups (0,1) and (2,3)
         # Index dim 0 with int, keep dims 1,2,3
-        result = propagate_symmetry_slice([(0, 1), (2, 3)], (3, 3, 4, 4), (0,))
+        result = propagate_symmetry_slice([_sg(0, 1), _sg(2, 3)], (3, 3, 4, 4), (0,))
         # Group (0,1): dim 0 removed -> only dim 1 survives -> lost
         # Group (2,3): both survive, remapped to (1, 2)
-        assert result == [(1, 2)]
+        _assert_groups_equal(result, [(1, 2)])
 
     def test_all_resized_picks_most_common(self):
         """When all dims are resized, picks the most common size."""
         # shape (10, 10, 10), group (0, 1, 2)
         # Slice all to size 3
         result = propagate_symmetry_slice(
-            [(0, 1, 2)], (10, 10, 10), (slice(0, 3), slice(0, 3), slice(0, 3))
+            [_sg(0, 1, 2)], (10, 10, 10), (slice(0, 3), slice(0, 3), slice(0, 3))
         )
-        assert result == [(0, 1, 2)]
+        _assert_groups_equal(result, [(0, 1, 2)])
 
     def test_ellipsis_with_newaxis(self):
         """Ellipsis combined with newaxis."""
         # shape (5, 5), group (0,1), key (Ellipsis, None)
-        result = propagate_symmetry_slice([(0, 1)], (5, 5), (Ellipsis, None))
-        assert result == [(0, 1)]
+        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (Ellipsis, None))
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_step_slice(self):
         """Slice with step > 1 changes size."""
         # shape (6, 6), group (0,1), key (::2, ::2) -> size 3 each
         result = propagate_symmetry_slice(
-            [(0, 1)], (6, 6), (slice(None, None, 2), slice(None, None, 2))
+            [_sg(0, 1)], (6, 6), (slice(None, None, 2), slice(None, None, 2))
         )
-        assert result == [(0, 1)]
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_step_slice_different(self):
         """Different step slices produce different sizes."""
         # shape (6, 6), key (::2, ::3) -> sizes 3, 2
         result = propagate_symmetry_slice(
-            [(0, 1)], (6, 6), (slice(None, None, 2), slice(None, None, 3))
+            [_sg(0, 1)], (6, 6), (slice(None, None, 2), slice(None, None, 3))
         )
         assert result is None
 
@@ -375,56 +392,56 @@ class TestPropagateSymmetrySlice:
 class TestPropagateSymmetryReduce:
     def test_reduce_none_axis(self):
         """axis=None reduces all dims -> no symmetry."""
-        assert propagate_symmetry_reduce([(0, 1)], 2, None) is None
+        assert propagate_symmetry_reduce([_sg(0, 1)], 2, None) is None
 
     def test_reduce_non_symmetric_axis_keepdims_false(self):
         """Reducing a non-symmetric axis with keepdims=False renumbers dims."""
         # shape (3, 5, 5), groups [(1,2)], reduce axis=0
-        result = propagate_symmetry_reduce([(1, 2)], 3, 0, keepdims=False)
+        result = propagate_symmetry_reduce([_sg(1, 2)], 3, 0, keepdims=False)
         # Dim 0 removed, dims 1,2 become 0,1
-        assert result == [(0, 1)]
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_reduce_symmetric_axis_keepdims_false(self):
         """Reducing one symmetric axis breaks that group to 1 dim."""
         # shape (5, 5), groups [(0,1)], reduce axis=0
-        result = propagate_symmetry_reduce([(0, 1)], 2, 0, keepdims=False)
+        result = propagate_symmetry_reduce([_sg(0, 1)], 2, 0, keepdims=False)
         # Only dim 1 survives -> too small
         assert result is None
 
     def test_reduce_non_symmetric_axis_keepdims_true(self):
         """Reducing non-symmetric axis with keepdims=True keeps numbering."""
         # shape (3, 5, 5), groups [(1,2)], reduce axis=0, keepdims=True
-        result = propagate_symmetry_reduce([(1, 2)], 3, 0, keepdims=True)
-        assert result == [(1, 2)]
+        result = propagate_symmetry_reduce([_sg(1, 2)], 3, 0, keepdims=True)
+        _assert_groups_equal(result, [(1, 2)])
 
     def test_reduce_symmetric_axis_keepdims_true(self):
         """Reducing one symmetric axis with keepdims removes it from group."""
         # shape (5, 5, 5), groups [(0,1,2)], reduce axis=0, keepdims=True
-        result = propagate_symmetry_reduce([(0, 1, 2)], 3, 0, keepdims=True)
-        assert result == [(1, 2)]
+        result = propagate_symmetry_reduce([_sg(0, 1, 2)], 3, 0, keepdims=True)
+        _assert_groups_equal(result, [(1, 2)])
 
     def test_reduce_all_symmetric_axes_keepdims_true(self):
         """Reducing all symmetric axes with keepdims=True -> no group."""
-        result = propagate_symmetry_reduce([(0, 1)], 2, (0, 1), keepdims=True)
+        result = propagate_symmetry_reduce([_sg(0, 1)], 2, (0, 1), keepdims=True)
         assert result is None
 
     def test_reduce_tuple_axis(self):
         """Reducing multiple axes at once."""
         # shape (3, 4, 4, 3), groups [(1,2), (0,3)]
-        result = propagate_symmetry_reduce([(1, 2), (0, 3)], 4, (0, 3), keepdims=False)
+        result = propagate_symmetry_reduce([_sg(1, 2), _sg(0, 3)], 4, (0, 3), keepdims=False)
         # Dims 0,3 removed. Dims 1,2 become 0,1.
-        assert result == [(0, 1)]
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_reduce_negative_axis(self):
         """Negative axis is normalized."""
         # ndim=3, axis=-1 -> axis=2
-        result = propagate_symmetry_reduce([(0, 1)], 3, -1, keepdims=False)
+        result = propagate_symmetry_reduce([_sg(0, 1)], 3, -1, keepdims=False)
         # Dim 2 removed, dims 0,1 unchanged
-        assert result == [(0, 1)]
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_reduce_all_axes_keepdims_false(self):
         """Reduce both axes of a 2-group without keepdims."""
-        result = propagate_symmetry_reduce([(0, 1)], 2, (0, 1), keepdims=False)
+        result = propagate_symmetry_reduce([_sg(0, 1)], 2, (0, 1), keepdims=False)
         assert result is None
 
 
@@ -438,18 +455,18 @@ class TestIntersectSymmetry:
         assert intersect_symmetry(None, None, (3,), (3,), (3,)) is None
 
     def test_one_none(self):
-        assert intersect_symmetry([(0, 1)], None, (3, 3), (3, 3), (3, 3)) is None
-        assert intersect_symmetry(None, [(0, 1)], (3, 3), (3, 3), (3, 3)) is None
+        assert intersect_symmetry([_sg(0, 1)], None, (3, 3), (3, 3), (3, 3)) is None
+        assert intersect_symmetry(None, [_sg(0, 1)], (3, 3), (3, 3), (3, 3)) is None
 
     def test_same_groups(self):
         """Identical groups produce the intersection."""
-        result = intersect_symmetry([(0, 1)], [(0, 1)], (3, 3), (3, 3), (3, 3))
-        assert result == [(0, 1)]
+        result = intersect_symmetry([_sg(0, 1)], [_sg(0, 1)], (3, 3), (3, 3), (3, 3))
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_different_groups(self):
         """Non-overlapping groups produce empty intersection."""
         result = intersect_symmetry(
-            [(0, 1)], [(2, 3)], (3, 3, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3)
+            [_sg(0, 1)], [_sg(2, 3)], (3, 3, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3)
         )
         assert result is None
 
@@ -460,15 +477,15 @@ class TestIntersectSymmetry:
         # output: (1, 3, 3)
         # a's dims 0,1 -> output dims 1,2
         # b's dims 1,2 -> output dims 1,2
-        result = intersect_symmetry([(0, 1)], [(1, 2)], (3, 3), (1, 3, 3), (1, 3, 3))
-        assert result == [(1, 2)]
+        result = intersect_symmetry([_sg(0, 1)], [_sg(1, 2)], (3, 3), (1, 3, 3), (1, 3, 3))
+        _assert_groups_equal(result, [(1, 2)])
 
     def test_broadcast_stretched_dim(self):
         """A dim that is broadcast-stretched (1 -> n) is removed from groups."""
         # a: shape (1, 3), group [(0,1)] - dim 0 is size 1
         # output: (3, 3) - dim 0 stretched from 1->3
         # b: shape (3, 3), group [(0,1)]
-        result = intersect_symmetry([(0, 1)], [(0, 1)], (1, 3), (3, 3), (3, 3))
+        result = intersect_symmetry([_sg(0, 1)], [_sg(0, 1)], (1, 3), (3, 3), (3, 3))
         # a's dim 0 is stretched, so (0,1) group loses dim 0 -> too small
         # b's (0,1) survives but a's doesn't match -> no intersection
         assert result is None
@@ -476,13 +493,13 @@ class TestIntersectSymmetry:
     def test_multiple_groups_partial_intersection(self):
         """Only matching groups survive intersection."""
         result = intersect_symmetry(
-            [(0, 1), (2, 3)],
-            [(0, 1)],
+            [_sg(0, 1), _sg(2, 3)],
+            [_sg(0, 1)],
             (3, 3, 4, 4),
             (3, 3, 4, 4),
             (3, 3, 4, 4),
         )
-        assert result == [(0, 1)]
+        _assert_groups_equal(result, [(0, 1)])
 
 
 # ============================================================================
@@ -705,20 +722,20 @@ class TestReductionsKeepdims:
     """Test propagate_symmetry_reduce keepdims branching via direct calls."""
 
     def test_keepdims_true_removes_from_group(self):
-        result = propagate_symmetry_reduce([(0, 1, 2)], 3, 0, keepdims=True)
-        assert result == [(1, 2)]
+        result = propagate_symmetry_reduce([_sg(0, 1, 2)], 3, 0, keepdims=True)
+        _assert_groups_equal(result, [(1, 2)])
 
     def test_keepdims_false_renumbers(self):
-        result = propagate_symmetry_reduce([(1, 2)], 3, 0, keepdims=False)
-        assert result == [(0, 1)]
+        result = propagate_symmetry_reduce([_sg(1, 2)], 3, 0, keepdims=False)
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_keepdims_true_non_symmetric_axis(self):
-        result = propagate_symmetry_reduce([(0, 1)], 3, 2, keepdims=True)
-        assert result == [(0, 1)]
+        result = propagate_symmetry_reduce([_sg(0, 1)], 3, 2, keepdims=True)
+        _assert_groups_equal(result, [(0, 1)])
 
     def test_keepdims_false_non_symmetric_axis(self):
-        result = propagate_symmetry_reduce([(0, 1)], 3, 2, keepdims=False)
-        assert result == [(0, 1)]
+        result = propagate_symmetry_reduce([_sg(0, 1)], 3, 2, keepdims=False)
+        _assert_groups_equal(result, [(0, 1)])
 
 
 # ============================================================================

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -272,7 +272,9 @@ class TestIsSymmetric:
 class TestPropagateSymmetrySlice:
     def test_full_slice_preserves(self):
         """Slicing with [:, :] preserves symmetry."""
-        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (slice(None), slice(None)))
+        result = propagate_symmetry_slice(
+            [_sg(0, 1)], (5, 5), (slice(None), slice(None))
+        )
         _assert_groups_equal(result, [(0, 1)])
 
     def test_integer_index_removes_dim(self):
@@ -283,12 +285,16 @@ class TestPropagateSymmetrySlice:
 
     def test_partial_slice_resizes(self):
         """Partial slice that changes size but keeps both dims."""
-        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (slice(0, 3), slice(0, 3)))
+        result = propagate_symmetry_slice(
+            [_sg(0, 1)], (5, 5), (slice(0, 3), slice(0, 3))
+        )
         _assert_groups_equal(result, [(0, 1)])
 
     def test_partial_slice_different_sizes_breaks(self):
         """Slicing dims to different sizes breaks symmetry."""
-        result = propagate_symmetry_slice([_sg(0, 1)], (5, 5), (slice(0, 3), slice(0, 2)))
+        result = propagate_symmetry_slice(
+            [_sg(0, 1)], (5, 5), (slice(0, 3), slice(0, 2))
+        )
         # Dims have different sizes, group is lost
         assert result is None
 
@@ -327,7 +333,9 @@ class TestPropagateSymmetrySlice:
 
     def test_advanced_indexing_bails(self):
         """Array or list indexing returns None."""
-        assert propagate_symmetry_slice([_sg(0, 1)], (5, 5), (np.array([0, 1]),)) is None
+        assert (
+            propagate_symmetry_slice([_sg(0, 1)], (5, 5), (np.array([0, 1]),)) is None
+        )
         assert propagate_symmetry_slice([_sg(0, 1)], (5, 5), ([0, 1],)) is None
 
     def test_non_tuple_key_normalized(self):
@@ -428,7 +436,9 @@ class TestPropagateSymmetryReduce:
     def test_reduce_tuple_axis(self):
         """Reducing multiple axes at once."""
         # shape (3, 4, 4, 3), groups [(1,2), (0,3)]
-        result = propagate_symmetry_reduce([_sg(1, 2), _sg(0, 3)], 4, (0, 3), keepdims=False)
+        result = propagate_symmetry_reduce(
+            [_sg(1, 2), _sg(0, 3)], 4, (0, 3), keepdims=False
+        )
         # Dims 0,3 removed. Dims 1,2 become 0,1.
         _assert_groups_equal(result, [(0, 1)])
 
@@ -477,7 +487,9 @@ class TestIntersectSymmetry:
         # output: (1, 3, 3)
         # a's dims 0,1 -> output dims 1,2
         # b's dims 1,2 -> output dims 1,2
-        result = intersect_symmetry([_sg(0, 1)], [_sg(1, 2)], (3, 3), (1, 3, 3), (1, 3, 3))
+        result = intersect_symmetry(
+            [_sg(0, 1)], [_sg(1, 2)], (3, 3), (1, 3, 3), (1, 3, 3)
+        )
         _assert_groups_equal(result, [(1, 2)])
 
     def test_broadcast_stretched_dim(self):
@@ -832,7 +844,9 @@ class TestPropagateSliceGeneralGroups:
         """C_4 on {0,1,2,3}, slice axes {1,3} → pointwise stab of {1,3} = trivial."""
         g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
         # Pointwise stabilizer: each of 1,3 must map to itself. Only identity does.
-        result = propagate_symmetry_slice([g], (5, 5, 5, 5), (slice(None), 0, slice(None), 0))
+        result = propagate_symmetry_slice(
+            [g], (5, 5, 5, 5), (slice(None), 0, slice(None), 0)
+        )
         assert result is None
 
     def test_s3_slice_one_axis_s2_survives(self):
@@ -846,7 +860,9 @@ class TestPropagateSliceGeneralGroups:
     def test_d4_slice_one_axis(self):
         """D_4 on {0,1,2,3}, slice axis 0 → pointwise stab of {0}, restricted."""
         g = PermutationGroup.dihedral(4, axes=(0, 1, 2, 3))
-        result = propagate_symmetry_slice([g], (5, 5, 5, 5), (0, slice(None), slice(None), slice(None)))
+        result = propagate_symmetry_slice(
+            [g], (5, 5, 5, 5), (0, slice(None), slice(None), slice(None))
+        )
         assert result is not None
         assert len(result) == 1
         stab = result[0]
@@ -859,7 +875,9 @@ class TestPropagateSliceGeneralGroups:
         g1 = PermutationGroup.cyclic(3, axes=(0, 1, 2))
         g2 = PermutationGroup.symmetric(2, axes=(3, 4))
         result = propagate_symmetry_slice(
-            [g1, g2], (5, 5, 5, 5, 5), (0, slice(None), slice(None), slice(None), slice(None))
+            [g1, g2],
+            (5, 5, 5, 5, 5),
+            (0, slice(None), slice(None), slice(None), slice(None)),
         )
         assert result is not None
         assert len(result) == 1
@@ -868,7 +886,9 @@ class TestPropagateSliceGeneralGroups:
     def test_no_axes_removed_group_unchanged(self):
         """Full slice preserves group unchanged."""
         g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
-        result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), slice(None)))
+        result = propagate_symmetry_slice(
+            [g], (5, 5, 5), (slice(None), slice(None), slice(None))
+        )
         assert result is not None
         assert len(result) == 1
         assert result[0].order() == 3
@@ -953,7 +973,9 @@ class TestIntersectSymmetryGeneralGroups:
         """Groups on different axes don't intersect → None."""
         g1 = PermutationGroup.symmetric(2, axes=(0, 1))
         g2 = PermutationGroup.symmetric(2, axes=(2, 3))
-        result = intersect_symmetry([g1], [g2], (5, 5, 5, 5), (5, 5, 5, 5), (5, 5, 5, 5))
+        result = intersect_symmetry(
+            [g1], [g2], (5, 5, 5, 5), (5, 5, 5, 5), (5, 5, 5, 5)
+        )
         assert result is None
 
 

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -904,4 +904,37 @@ class TestPropagateReduceGeneralGroups:
         assert result is not None
         assert len(result) == 1
         assert result[0].order() == 3
-        assert result[0].axes == (0, 1, 2)
+
+
+class TestIntersectSymmetryGeneralGroups:
+    """Test intersect_symmetry with PermutationGroup objects."""
+
+    def test_same_group_returns_group(self):
+        """Intersecting a group with itself returns same group."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = intersect_symmetry([g], [g], (5, 5, 5), (5, 5, 5), (5, 5, 5))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3
+
+    def test_s3_intersect_c3(self):
+        """S_3 ∩ C_3 = C_3 (C_3 is a subgroup of S_3)."""
+        s3 = PermutationGroup.symmetric(3, axes=(0, 1, 2))
+        c3 = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        result = intersect_symmetry([s3], [c3], (5, 5, 5), (5, 5, 5), (5, 5, 5))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].order() == 3
+
+    def test_none_input_returns_none(self):
+        """If either input is None, result is None."""
+        g = PermutationGroup.cyclic(3, axes=(0, 1, 2))
+        assert intersect_symmetry(None, [g], (5, 5, 5), (5, 5, 5), (5, 5, 5)) is None
+        assert intersect_symmetry([g], None, (5, 5, 5), (5, 5, 5), (5, 5, 5)) is None
+
+    def test_disjoint_axes_dropped(self):
+        """Groups on different axes don't intersect → None."""
+        g1 = PermutationGroup.symmetric(2, axes=(0, 1))
+        g2 = PermutationGroup.symmetric(2, axes=(2, 3))
+        result = intersect_symmetry([g1], [g2], (5, 5, 5, 5), (5, 5, 5, 5), (5, 5, 5, 5))
+        assert result is None

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -811,15 +811,12 @@ class TestPropagateSliceGeneralGroups:
         result = propagate_symmetry_slice([g], (5, 5, 5), (slice(None), slice(None), 0))
         assert result is None
 
-    def test_c4_slice_two_axes_c2_survives(self):
-        """C_4 on {0,1,2,3}, slice axes {1,3} → C_2 on output {0,1}."""
+    def test_c4_slice_two_axes_no_symmetry(self):
+        """C_4 on {0,1,2,3}, slice axes {1,3} → pointwise stab of {1,3} = trivial."""
         g = PermutationGroup.cyclic(4, axes=(0, 1, 2, 3))
+        # Pointwise stabilizer: each of 1,3 must map to itself. Only identity does.
         result = propagate_symmetry_slice([g], (5, 5, 5, 5), (slice(None), 0, slice(None), 0))
-        assert result is not None
-        assert len(result) == 1
-        assert result[0].degree == 2
-        assert result[0].order() == 2
-        assert result[0].axes == (0, 1)
+        assert result is None
 
     def test_s3_slice_one_axis_s2_survives(self):
         """S_3 on {0,1,2}, slice axis 2 → S_2 on {0,1}. Same as old behavior."""

--- a/whest-client/src/whest/_perm_group.py
+++ b/whest-client/src/whest/_perm_group.py
@@ -375,6 +375,87 @@ class PermutationGroup:
                     queue.append(image)
         return frozenset(visited)
 
+    def pointwise_stabilizer(self, fixed: set[int]) -> PermutationGroup:
+        """Subgroup of elements that fix every point in *fixed*.
+
+        Parameters
+        ----------
+        fixed : set of int
+            Group-local indices that must map to themselves.
+
+        Returns
+        -------
+        PermutationGroup
+            The pointwise stabilizer subgroup (same degree).
+        """
+        if not fixed:
+            return PermutationGroup(*self._generators, axes=self._axes)
+        surviving = [g for g in self.elements() if all(g(p) == p for p in fixed)]
+        if not surviving:
+            surviving = [Permutation.identity(self._degree)]
+        return PermutationGroup(*surviving, axes=self._axes)
+
+    def setwise_stabilizer(self, subset: set[int]) -> PermutationGroup:
+        """Subgroup of elements that map *subset* to itself as a set.
+
+        Parameters
+        ----------
+        subset : set of int
+            Group-local indices. The subgroup consists of elements g where
+            {g(x) for x in subset} == subset.
+
+        Returns
+        -------
+        PermutationGroup
+            The setwise stabilizer subgroup (same degree).
+        """
+        if not subset or subset == set(range(self._degree)):
+            return PermutationGroup(*self._generators, axes=self._axes)
+        frozen = frozenset(subset)
+        surviving = [
+            g for g in self.elements() if frozenset(g(x) for x in frozen) == frozen
+        ]
+        if not surviving:
+            surviving = [Permutation.identity(self._degree)]
+        return PermutationGroup(*surviving, axes=self._axes)
+
+    def restrict(self, kept: tuple[int, ...]) -> PermutationGroup:
+        """Project permutations onto *kept* positions, re-indexing to 0..len(kept)-1.
+
+        Precondition: the group must already stabilize *kept* setwise
+        (every element maps the set of kept positions to itself).
+
+        Parameters
+        ----------
+        kept : tuple of int
+            Group-local indices to keep, in the desired output order.
+
+        Returns
+        -------
+        PermutationGroup
+            Group of degree ``len(kept)`` with projected permutations.
+            ``axes`` is updated to select the corresponding entries from
+            the original ``axes`` tuple (or None if original had no axes).
+        """
+        new_degree = len(kept)
+        if new_degree == 0:
+            raise ValueError("kept must be non-empty")
+
+        # Map old group-local index → new index
+        old_to_new = {old: new for new, old in enumerate(kept)}
+
+        projected: set[Permutation] = set()
+        for g in self.elements():
+            new_arr = [old_to_new[g(k)] for k in kept]
+            projected.add(Permutation(new_arr))
+
+        new_axes: tuple[int, ...] | None = None
+        if self._axes is not None:
+            new_axes = tuple(self._axes[k] for k in kept)
+
+        gens = list(projected) if projected else [Permutation.identity(new_degree)]
+        return PermutationGroup(*gens, axes=new_axes)
+
     def burnside_unique_count(self, size_dict: dict[int, int]) -> int:
         """Count unique tensor elements via Burnside's lemma.
 


### PR DESCRIPTION
## Summary

- Fixes symmetry propagation through slicing and reductions for non-S_k groups (C_k, D_k, arbitrary generators)
- **Slicing** now uses the **pointwise stabilizer** — only group elements that fix each removed axis individually survive
- **Reductions** now use the **setwise stabilizer** — group elements that map reduced axes among themselves as a set survive
- **Binary ops** now compute element-set intersection of groups on matching axes
- Adds `pointwise_stabilizer`, `setwise_stabilizer`, and `restrict` methods to `PermutationGroup`

**Bug example:** A tensor with C₃ symmetry on axes {0,1,2}, sliced on axis 2, previously reported S₂ on {0,1} — but C₃ never contained that transposition. Now correctly reports no symmetry.

## Test plan

- [x] New unit tests for `pointwise_stabilizer`, `setwise_stabilizer`, `restrict` on C_k, D_k, S_k groups
- [x] New integration tests for `propagate_symmetry_slice` and `propagate_symmetry_reduce` with general groups
- [x] All existing tests migrated from tuple-based to PermutationGroup-based API
- [x] Full test suite passes (3084 passed, 0 regressions)
- [x] Docs updated: exploit-symmetry guide, docstrings, griffe-compatible Returns sections