### PR TITLE
feat: wall-clock time limits, duration tracking, and timing UX

### DIFF
--- a/.aicrowd/superpowers/plans/2026-04-14-timing-budget-tightening.md
+++ b/.aicrowd/superpowers/plans/2026-04-14-timing-budget-tightening.md
@@ -1,0 +1,1013 @@
+# Timing Budget Tightening & Duration Tracking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten wall-clock enforcement, complete duration tracking across all 72 missing call sites, remove all timing-related xfails, and add timing data to participant-facing output.
+
+**Architecture:** Cooperative deadline checking via `_OpTimer.__exit__` post-op check. Duration tracking via `with budget.deduct(...)` context manager pattern across all op modules. Display layer reads existing `budget_summary_dict()` timing fields plus new per-op duration aggregation.
+
+**Tech Stack:** Python, numpy, Rich (optional display dependency)
+
+---
+
+### Task 1: Post-op deadline check in `_OpTimer.__exit__`
+
+**Files:**
+- Modify: `src/whest/_budget.py:26-55` (`_OpTimer` class)
+- Test: `tests/test_budget.py`
+
+- [ ] **Step 1: Write failing test for post-op deadline enforcement**
+
+Add to `tests/test_budget.py`:
+
+```python
+def test_post_op_deadline_check():
+    """_OpTimer.__exit__ raises TimeExhaustedError if deadline passed during op."""
+    import time
+
+    import pytest
+
+    import whest
+    from whest.errors import TimeExhaustedError
+
+    with pytest.raises(TimeExhaustedError) as exc_info:
+        with whest.BudgetContext(flop_budget=int(1e15), wall_time_limit_s=0.05) as b:
+            a = whest.ones((10,))
+            # Burn through the time limit with a sleep inside a timed op
+            # The deduct() pre-check passes, but __exit__ should catch the overshoot
+            timer = b.deduct("test_op", flop_cost=1, subscripts=None, shapes=((10,),))
+            with timer:
+                time.sleep(0.1)  # Exceeds 0.05s limit
+    assert exc_info.value.elapsed_s >= 0.05
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::test_post_op_deadline_check -xvs`
+Expected: FAIL — currently `_OpTimer.__exit__` doesn't check the deadline.
+
+- [ ] **Step 3: Add cooperative enforcement comment and post-op check**
+
+In `src/whest/_budget.py`, add a comment block above `_OpTimer` and modify `__exit__`:
+
+```python
+# ---------------------------------------------------------------------------
+# Why cooperative (not signal-based) deadline enforcement?
+#
+# We deliberately avoid SIGALRM / signal-based preemption because:
+# 1. Python signal handlers only run between bytecodes — they cannot
+#    interrupt C extensions (numpy/LAPACK/BLAS), which are exactly the
+#    operations where time limits matter most.
+# 2. signal.alarm() is POSIX-only (no Windows) and integer-second only.
+# 3. Signals are main-thread-only and can interfere with numpy internals.
+#
+# The hard enforcement boundary is the container/OS level: whest
+# submissions run inside Docker containers with kernel-level time limits
+# (cgroups / rlimit) that deliver SIGKILL when exceeded.
+#
+# The in-library wall_time_limit_s is a UX feature: it gives participants
+# a clean, informative TimeExhaustedError (with op name, elapsed time,
+# and configured limit) rather than a brutal container kill.
+#
+# The deadline is checked:
+# 1. Pre-op: in BudgetContext.deduct() before the numpy call starts.
+# 2. Post-op: in _OpTimer.__exit__() after the numpy call completes.
+#
+# This bounds overshoot to the duration of a single numpy call.
+# ---------------------------------------------------------------------------
+
+
+class _OpTimer:
+    """Lightweight timer returned by BudgetContext.deduct().
+
+    Use as a context manager to measure wall-clock duration of the
+    numpy operation that follows the FLOP deduction::
+
+        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(...)):
+            result = np_func(x)
+
+    If used without ``with``, duration stays ``None`` on the OpRecord.
+    """
+
+    __slots__ = ("_budget", "_start")
+
+    def __init__(self, budget: "BudgetContext"):
+        self._budget = budget
+        self._start: float | None = None
+
+    def __enter__(self) -> "_OpTimer":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if self._start is not None:
+            duration = time.perf_counter() - self._start
+            log = self._budget._op_log
+            log[-1] = log[-1]._replace(duration=duration)
+            self._budget._total_tracked_time += duration
+
+            # Post-op deadline check: only if no exception is already propagating
+            if (
+                exc_type is None
+                and self._budget._deadline is not None
+                and time.perf_counter() > self._budget._deadline
+            ):
+                from whest.errors import TimeExhaustedError
+
+                raise TimeExhaustedError(
+                    log[-1].op_name,
+                    elapsed_s=time.perf_counter() - self._budget._start_time,
+                    limit_s=self._budget._wall_time_limit_s,
+                )
+        return False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::test_post_op_deadline_check -xvs`
+Expected: PASS
+
+- [ ] **Step 5: Run full budget test suite**
+
+Run: `uv run pytest tests/test_budget.py -x --timeout=30`
+Expected: All existing tests pass (the two xfail'd duration tests still xfail — that's fine, fixed in Task 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/whest/_budget.py tests/test_budget.py
+git commit -m "feat: add post-op deadline check in _OpTimer.__exit__
+
+Cooperative wall-clock enforcement now checks the deadline both
+before (in deduct()) and after (in __exit__()) each numpy call.
+Includes comment documenting why we use cooperative checking
+rather than signal-based preemption."
+```
+
+---
+
+### Task 2: Duration tracking — pointwise ops (`_pointwise.py`)
+
+**Files:**
+- Modify: `src/whest/_pointwise.py:28-244` (5 factory functions)
+- Test: `tests/test_budget.py` (existing xfail'd tests cover this)
+
+This is the biggest single change — 32 call sites, but all go through 5 factory functions. The reduction factory (`_counted_reduction`) has a wrinkle: `budget.deduct()` is called *after* `np_func()` because it needs `result` to compute `extra_output` cost.
+
+- [ ] **Step 1: Write a targeted test for pointwise duration tracking**
+
+Add to `tests/test_budget.py`:
+
+```python
+def test_pointwise_ops_have_duration():
+    """Pointwise factory ops (add, exp, sum) must record duration."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e12)) as b:
+        a = whest.ones((100,))
+        _ = whest.add(a, a)
+        _ = whest.exp(a)
+        _ = whest.sum(a)
+
+    for rec in b.op_log:
+        if rec.op_name in ("add", "exp", "sum"):
+            assert rec.duration is not None, f"{rec.op_name} missing duration"
+            assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::test_pointwise_ops_have_duration -xvs`
+Expected: FAIL — `add`, `exp`, `sum` all have `duration=None`.
+
+- [ ] **Step 3: Wrap `_counted_unary` factory**
+
+In `src/whest/_pointwise.py`, change `_counted_unary` (lines 28-47). The `budget.deduct()` call and the `np_func(x)` call must be wrapped together:
+
+```python
+def _counted_unary(np_func, op_name: str):
+    def wrapper(x):
+        budget = require_budget()
+        if not isinstance(x, _np.ndarray):
+            x = _np.asarray(x)
+        sym_info = x.symmetry_info if isinstance(x, SymmetricTensor) else None
+        cost = pointwise_cost(x.shape, symmetry_info=sym_info)
+        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+            result = np_func(x)
+        check_nan_inf(result, op_name)
+        if sym_info is not None:
+            result = SymmetricTensor(result, symmetric_axes=sym_info.symmetric_axes)
+        if sym_info is None:
+            result = _aswhest(result)
+        return result
+
+    wrapper.__name__ = op_name
+    wrapper.__qualname__ = op_name
+    attach_docstring(wrapper, np_func, "counted_unary", "numel(output) FLOPs")
+    return wrapper
+```
+
+- [ ] **Step 4: Wrap `_counted_unary_multi` factory**
+
+In `src/whest/_pointwise.py`, change `_counted_unary_multi` (lines 50-69):
+
+```python
+def _counted_unary_multi(np_func, op_name: str):
+    """Factory for unary functions that return multiple arrays (e.g., modf, frexp)."""
+
+    def wrapper(x):
+        budget = require_budget()
+        if not isinstance(x, _np.ndarray):
+            x = _np.asarray(x)
+        cost = pointwise_cost(x.shape)
+        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+            result = np_func(x)
+        if isinstance(result, tuple):
+            result = tuple(_aswhest(r) for r in result)
+        else:
+            result = _aswhest(result)
+        return result
+
+    wrapper.__name__ = op_name
+    wrapper.__qualname__ = op_name
+    attach_docstring(wrapper, np_func, "counted_unary", "numel(input) FLOPs")
+    return wrapper
+```
+
+- [ ] **Step 5: Wrap `_counted_binary` factory**
+
+In `src/whest/_pointwise.py`, change `_counted_binary` (lines 72-155). The key change is wrapping the `budget.deduct()` and `np_func()` call:
+
+Replace the bare deduct + call (lines 113-119):
+```python
+        budget.deduct(
+            op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
+        )
+        # Call the underlying ufunc with the ORIGINAL inputs so that
+        # Python-scalar dtype promotion (NEP 50) and FloatingPointError
+        # propagation (np.errstate) work exactly as in plain numpy.
+        result = np_func(x_orig, y_orig)
+```
+
+With:
+```python
+        with budget.deduct(
+            op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
+        ):
+            # Call the underlying ufunc with the ORIGINAL inputs so that
+            # Python-scalar dtype promotion (NEP 50) and FloatingPointError
+            # propagation (np.errstate) work exactly as in plain numpy.
+            result = np_func(x_orig, y_orig)
+```
+
+- [ ] **Step 6: Wrap `_counted_binary_multi` factory**
+
+In `src/whest/_pointwise.py`, change `_counted_binary_multi` (lines 158-182). Replace lines 169-172:
+
+```python
+        budget.deduct(
+            op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
+        )
+        result = np_func(x, y)
+```
+
+With:
+```python
+        with budget.deduct(
+            op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
+        ):
+            result = np_func(x, y)
+```
+
+- [ ] **Step 7: Wrap `_counted_reduction` factory**
+
+In `src/whest/_pointwise.py`, change `_counted_reduction` (lines 185-244). This one is trickier — `budget.deduct()` is currently called *after* `np_func()` because `extra_output` needs the result shape. Restructure to call numpy first, then wrap deduct around a no-op (just to get timing), or better: compute cost before, run numpy inside the timer:
+
+Replace lines 193-198:
+```python
+        cost = reduction_cost(a.shape, axis, symmetry_info=sym_info) * cost_multiplier
+        result = np_func(a, axis=axis, **kwargs)
+        if extra_output:
+            out_shape = _np.asarray(result).shape
+            cost += pointwise_cost(out_shape)
+        budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(a.shape,))
+```
+
+With:
+```python
+        cost = reduction_cost(a.shape, axis, symmetry_info=sym_info) * cost_multiplier
+        if extra_output:
+            # Pre-compute output shape for the extra cost without running numpy yet.
+            # Use numpy's shape inference: reduce a.shape along axis.
+            if axis is None:
+                extra_cost = 1  # scalar output
+            else:
+                ax = axis if axis >= 0 else axis + a.ndim
+                keepdims = kwargs.get("keepdims", False)
+                if keepdims:
+                    out_shape = a.shape[:ax] + (1,) + a.shape[ax + 1:]
+                else:
+                    out_shape = a.shape[:ax] + a.shape[ax + 1:]
+                extra_cost = pointwise_cost(out_shape)
+            cost += extra_cost
+        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+            result = np_func(a, axis=axis, **kwargs)
+```
+
+- [ ] **Step 8: Wrap standalone functions `around`, `round`, `sort_complex`**
+
+These are non-factory functions in `_pointwise.py` that also have bare `deduct()` calls. For each one, wrap the deduct + numpy call:
+
+For `around` (lines 290-292), replace:
+```python
+    budget.deduct("around", flop_cost=cost, subscripts=None, shapes=(a.shape,))
+    result = _np.around(a, decimals=decimals, out=out)
+```
+With:
+```python
+    with budget.deduct("around", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.around(a, decimals=decimals, out=out)
+```
+
+Apply the same pattern to `round` (lines 367-369) and `sort_complex` (lines 398-399).
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::test_pointwise_ops_have_duration -xvs`
+Expected: PASS
+
+- [ ] **Step 10: Run full test suite for pointwise**
+
+Run: `uv run pytest tests/ -x -k "pointwise or budget" --timeout=30`
+Expected: All pass (except the two remaining xfails which need linalg too).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/whest/_pointwise.py tests/test_budget.py
+git commit -m "feat: add duration tracking to all pointwise ops
+
+Wrap numpy calls in 'with budget.deduct(...)' context manager in
+all 5 pointwise factory functions and 3 standalone functions.
+Covers add, exp, multiply, sum, and all other unary/binary/reduction ops."
+```
+
+---
+
+### Task 3: Duration tracking — linalg ops
+
+**Files:**
+- Modify: `src/whest/linalg/_decompositions.py` (7 sites)
+- Modify: `src/whest/linalg/_properties.py` (8 sites)
+- Modify: `src/whest/linalg/_solvers.py` (6 sites)
+- Modify: `src/whest/linalg/_compound.py` (2 sites)
+- Modify: `src/whest/linalg/_svd.py` (1 site)
+- Modify: `src/whest/linalg/_aliases.py` (1 site — `cross`)
+- Test: `tests/test_budget.py`
+
+All linalg sites follow the same pattern: bare `budget.deduct()` followed by a numpy call. Wrap each in `with`.
+
+- [ ] **Step 1: Write test for linalg duration tracking**
+
+Add to `tests/test_budget.py`:
+
+```python
+def test_linalg_ops_have_duration():
+    """Linalg ops must record duration."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e12)) as b:
+        A = whest.array([[1.0, 2.0], [3.0, 4.0]])
+        _ = whest.linalg.det(A)
+        _ = whest.linalg.solve(A, whest.array([1.0, 2.0]))
+        _ = whest.linalg.svd(A)
+        _ = whest.linalg.cholesky(A @ A.T + 2 * whest.eye(2))  # ensure positive definite
+
+    linalg_records = [r for r in b.op_log if r.op_name.startswith("linalg.")]
+    assert len(linalg_records) >= 4
+    for rec in linalg_records:
+        assert rec.duration is not None, f"{rec.op_name} missing duration"
+        assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::test_linalg_ops_have_duration -xvs`
+Expected: FAIL — linalg ops have `duration=None`.
+
+- [ ] **Step 3: Wrap `_decompositions.py`**
+
+For each function in `src/whest/linalg/_decompositions.py`, wrap the `budget.deduct()` + numpy call. Example for `cholesky` (lines 46-47):
+
+Replace:
+```python
+    budget.deduct("linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,))
+    return _np.linalg.cholesky(a, upper=upper)
+```
+With:
+```python
+    with budget.deduct("linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.cholesky(a, upper=upper)
+    return result
+```
+
+Apply this pattern to all 7 functions: `cholesky`, `qr`, `eig`, `eigh`, `eigvals`, `eigvalsh`, `svdvals`.
+
+- [ ] **Step 4: Wrap `_properties.py`**
+
+Apply the same wrapping pattern to all 8 functions in `src/whest/linalg/_properties.py`: `trace`, `det`, `slogdet`, `norm`, `vector_norm`, `matrix_norm`, `cond`, `matrix_rank`.
+
+For functions that have early-return paths (like `norm` which returns early on invalid axis), keep the early return outside the `with` block.
+
+- [ ] **Step 5: Wrap `_solvers.py`**
+
+Apply the pattern to all 6 functions in `src/whest/linalg/_solvers.py`: `solve`, `lstsq`, `inv`, `pinv`, `tensorsolve`, `tensorinv`.
+
+- [ ] **Step 6: Wrap `_compound.py`**
+
+Apply the pattern to both functions in `src/whest/linalg/_compound.py`: `multi_dot`, `matrix_power`.
+
+- [ ] **Step 7: Wrap `_svd.py`**
+
+Apply the pattern to `svd` in `src/whest/linalg/_svd.py` (line 75). This function has branching logic after deduct (compute_uv True/False), so wrap the entire branch:
+
+Replace:
+```python
+    budget.deduct("linalg.svd", flop_cost=cost, subscripts=None, shapes=(a.shape,))
+
+    if compute_uv:
+        ...
+    else:
+        ...
+```
+With:
+```python
+    with budget.deduct("linalg.svd", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        if compute_uv:
+            ...
+        else:
+            ...
+```
+
+- [ ] **Step 8: Wrap `_aliases.py` — `cross` function**
+
+In `src/whest/linalg/_aliases.py`, wrap the `cross` function (lines 33-45). Note: `cross` calls numpy *before* deduct (to get the result size). Restructure similarly to the reduction pattern — compute cost from input shapes, then wrap:
+
+Replace:
+```python
+    result = _np.linalg.cross(x1, x2, axis=axis)
+    r = _np.asarray(result)
+    budget.deduct(
+        "linalg.cross",
+        flop_cost=_builtins.max(r.size * 3, 1),
+        subscripts=None,
+        shapes=(_np.asarray(x1).shape, _np.asarray(x2).shape),
+    )
+```
+With:
+```python
+    x1_arr = _np.asarray(x1)
+    x2_arr = _np.asarray(x2)
+    out_shape = _np.broadcast_shapes(x1_arr.shape, x2_arr.shape)
+    out_size = 1
+    for d in out_shape:
+        out_size *= d
+    with budget.deduct(
+        "linalg.cross",
+        flop_cost=_builtins.max(out_size * 3, 1),
+        subscripts=None,
+        shapes=(x1_arr.shape, x2_arr.shape),
+    ):
+        result = _np.linalg.cross(x1, x2, axis=axis)
+```
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::test_linalg_ops_have_duration -xvs`
+Expected: PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/whest/linalg/
+git commit -m "feat: add duration tracking to all linalg ops
+
+Wrap numpy calls in 'with budget.deduct(...)' context manager
+across _decompositions.py (7), _properties.py (8), _solvers.py (6),
+_compound.py (2), _svd.py (1), _aliases.py (1). Total: 25 sites."
+```
+
+---
+
+### Task 4: Duration tracking — counting ops (`_counting_ops.py`)
+
+**Files:**
+- Modify: `src/whest/_counting_ops.py` (15 sites)
+- Test: `tests/test_budget.py`
+
+- [ ] **Step 1: Write test for counting ops duration**
+
+Add to `tests/test_budget.py`:
+
+```python
+def test_counting_ops_have_duration():
+    """Counting ops (trace, histogram, bincount, etc.) must record duration."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e12)) as b:
+        a = whest.array([1.0, 2.0, 3.0, 4.0])
+        _ = whest.trace(whest.eye(3))
+        _ = whest.histogram(a, bins=5)
+        _ = whest.logspace(0, 1, 10)
+
+    counting_ops = {"trace", "histogram", "logspace"}
+    for rec in b.op_log:
+        if rec.op_name in counting_ops:
+            assert rec.duration is not None, f"{rec.op_name} missing duration"
+            assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::test_counting_ops_have_duration -xvs`
+Expected: FAIL
+
+- [ ] **Step 3: Wrap all 15 call sites in `_counting_ops.py`**
+
+Apply the standard wrapping pattern to each function. For every bare `budget.deduct()` + numpy call, wrap:
+
+Functions to wrap: `trace`, `allclose`, `array_equal`, `array_equiv`, `histogram`, `histogram2d`, `histogramdd`, `histogram_bin_edges`, `bincount`, `logspace`, `geomspace`, `vander`, `count_nonzero`, `correlate`, `convolve`.
+
+Example for `trace` (lines 27-28):
+```python
+    budget.deduct("trace", flop_cost=cost, subscripts=None, shapes=(a.shape,))
+    return _np.trace(a, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out)
+```
+Becomes:
+```python
+    with budget.deduct("trace", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.trace(a, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out)
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::test_counting_ops_have_duration -xvs`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_counting_ops.py tests/test_budget.py
+git commit -m "feat: add duration tracking to all counting ops
+
+Wrap numpy calls in 'with budget.deduct(...)' across all 15
+counting op functions: trace, histogram, bincount, logspace, etc."
+```
+
+---
+
+### Task 5: Remove duration tracking xfails
+
+**Files:**
+- Modify: `tests/test_budget.py:230,244` (remove 2 xfail markers)
+
+- [ ] **Step 1: Remove xfail from `test_oprecord_durations_populated`**
+
+In `tests/test_budget.py`, remove line 230:
+```python
+@pytest.mark.xfail(reason="Duration tracking not yet implemented for all op types")
+```
+
+- [ ] **Step 2: Remove xfail from `test_durations_populated_across_op_types`**
+
+In `tests/test_budget.py`, remove line 244:
+```python
+@pytest.mark.xfail(reason="Duration tracking not yet implemented for all op types")
+```
+
+- [ ] **Step 3: Run both tests to verify they pass**
+
+Run: `uv run pytest tests/test_budget.py::test_oprecord_durations_populated tests/test_budget.py::test_durations_populated_across_op_types -xvs`
+Expected: PASS — both tests should now pass with all ops returning durations.
+
+- [ ] **Step 4: Run full budget test suite**
+
+Run: `uv run pytest tests/test_budget.py -x --timeout=30`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_budget.py
+git commit -m "fix: remove duration tracking xfails — all ops now have duration"
+```
+
+---
+
+### Task 6: Add `TimeExhaustedError` to client package
+
+**Files:**
+- Modify: `scripts/sync_client.py:72-77,80-118` (`_generate_errors()`)
+- Generated: `whest-client/src/whest/errors.py` (auto-generated, do not edit directly)
+- Modify: `tests/test_client_server_parity.py:151,161` (remove 2 xfails)
+
+- [ ] **Step 1: Add `TimeExhaustedError` to `_generate_errors()` in `scripts/sync_client.py`**
+
+In `scripts/sync_client.py`, add to `_CUSTOM_INIT_CLASSES` (line 72-77):
+
+```python
+    _CUSTOM_INIT_CLASSES = {
+        "BudgetExhaustedError",
+        "NoBudgetContextError",
+        "SymmetryError",
+        "TimeExhaustedError",
+        "UnsupportedFunctionError",
+    }
+```
+
+And add to `_CLASSES` list (after `BudgetExhaustedError`, before `NoBudgetContextError`):
+
+```python
+        (
+            "TimeExhaustedError",
+            "WhestError",
+            "Raised when an operation exceeds the wall-clock time limit.",
+        ),
+```
+
+- [ ] **Step 2: Regenerate client errors**
+
+Run: `uv run scripts/sync_client.py`
+Expected: Prints "wrote whest-client/src/whest/errors.py" (among others).
+
+- [ ] **Step 3: Verify the generated file contains `TimeExhaustedError`**
+
+Run: `grep TimeExhaustedError whest-client/src/whest/errors.py`
+Expected: Shows class definition and entries in `_WHEST_ERRORS` and `_ERROR_MAP`.
+
+- [ ] **Step 4: Remove xfails from `test_client_server_parity.py`**
+
+Remove the xfail markers at lines 151 and 161:
+```python
+    @pytest.mark.xfail(reason="TimeExhaustedError not yet added to client package")
+```
+
+- [ ] **Step 5: Run client-server parity tests**
+
+Run: `uv run pytest tests/test_client_server_parity.py::TestErrorParity -xvs`
+Expected: PASS — both tests should now find `TimeExhaustedError` in the client.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/sync_client.py whest-client/src/whest/errors.py tests/test_client_server_parity.py
+git commit -m "feat: add TimeExhaustedError to client package
+
+Update sync_client.py generator and regenerate client errors.py.
+Remove client-server parity xfails."
+```
+
+---
+
+### Task 7: Banner — show time limit
+
+**Files:**
+- Modify: `src/whest/_budget.py:252-262` (`__enter__` banner)
+- Test: `tests/test_budget.py`
+
+- [ ] **Step 1: Write test for banner with time limit**
+
+Add to `tests/test_budget.py`:
+
+```python
+def test_banner_shows_time_limit(capsys):
+    """Banner should include time limit when wall_time_limit_s is set."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e6), wall_time_limit_s=5.0):
+        pass
+    captured = capsys.readouterr()
+    assert "time limit: 5.0s" in captured.err
+
+
+def test_banner_no_time_limit(capsys):
+    """Banner should not mention time limit when wall_time_limit_s is None."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e6)):
+        pass
+    captured = capsys.readouterr()
+    assert "time limit" not in captured.err
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::test_banner_shows_time_limit -xvs`
+Expected: FAIL — banner doesn't include time limit.
+
+- [ ] **Step 3: Update banner in `__enter__`**
+
+In `src/whest/_budget.py`, modify the `__enter__` method (lines 252-262):
+
+```python
+        if not self._quiet:
+            import sys
+
+            import whest
+
+            banner = (
+                f"whest {whest.__version__} "
+                f"(numpy {whest.__numpy_version__} backend) | "
+                f"budget: {self._flop_budget:.2e} FLOPs"
+            )
+            if self._wall_time_limit_s is not None:
+                banner += f" | time limit: {self._wall_time_limit_s:.1f}s"
+            print(banner, file=sys.stderr)
+```
+
+- [ ] **Step 4: Run both banner tests**
+
+Run: `uv run pytest tests/test_budget.py::test_banner_shows_time_limit tests/test_budget.py::test_banner_no_time_limit -xvs`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_budget.py tests/test_budget.py
+git commit -m "feat: show time limit in budget banner
+
+When wall_time_limit_s is set, the entry banner now includes
+'| time limit: 5.0s' so participants know they're on a clock."
+```
+
+---
+
+### Task 8: Display — add per-op duration to `BudgetAccumulator.get_data()`
+
+**Files:**
+- Modify: `src/whest/_budget.py:376-438` (`get_data()`)
+- Test: `tests/test_budget.py`
+
+The display layer needs per-op duration data. Currently `get_data()` aggregates `flop_cost` and `calls` per op but not `duration`. Add a `"duration"` key to each op entry.
+
+- [ ] **Step 1: Write test for per-op duration in get_data()**
+
+Add to `tests/test_budget.py`:
+
+```python
+def test_budget_summary_dict_includes_op_duration():
+    """budget_summary_dict() should include per-op duration."""
+    import whest
+
+    whest.budget_reset()
+    with whest.BudgetContext(flop_budget=int(1e12), namespace="test", quiet=True):
+        a = whest.ones((100,))
+        _ = whest.add(a, a)
+
+    data = whest.budget_summary_dict(by_namespace=True)
+    ops = data["operations"]
+    assert "add" in ops
+    assert "duration" in ops["add"]
+    assert ops["add"]["duration"] >= 0
+
+    ns_ops = data["by_namespace"]["test"]["operations"]
+    assert "add" in ns_ops
+    assert "duration" in ns_ops["add"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::test_budget_summary_dict_includes_op_duration -xvs`
+Expected: FAIL — no `"duration"` key in op dicts.
+
+- [ ] **Step 3: Add duration aggregation to `get_data()`**
+
+In `src/whest/_budget.py`, modify `get_data()`. In both the top-level and per-namespace loops, add duration tracking:
+
+In the top-level loop (around line 388-391):
+```python
+            for op in rec.op_log:
+                if op.op_name not in ops:
+                    ops[op.op_name] = {"flop_cost": 0, "calls": 0, "duration": 0.0}
+                ops[op.op_name]["flop_cost"] += op.flop_cost
+                ops[op.op_name]["calls"] += 1
+                if op.duration is not None:
+                    ops[op.op_name]["duration"] += op.duration
+```
+
+In the per-namespace loop (around line 429-435):
+```python
+                for op in rec.op_log:
+                    if op.op_name not in by_ns[ns]["operations"]:
+                        by_ns[ns]["operations"][op.op_name] = {
+                            "flop_cost": 0,
+                            "calls": 0,
+                            "duration": 0.0,
+                        }
+                    by_ns[ns]["operations"][op.op_name]["flop_cost"] += op.flop_cost
+                    by_ns[ns]["operations"][op.op_name]["calls"] += 1
+                    if op.duration is not None:
+                        by_ns[ns]["operations"][op.op_name]["duration"] += op.duration
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::test_budget_summary_dict_includes_op_duration -xvs`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_budget.py tests/test_budget.py
+git commit -m "feat: add per-op duration to budget_summary_dict()
+
+BudgetAccumulator.get_data() now aggregates OpRecord.duration into
+each operation's dict, enabling display layer to show timing breakdowns."
+```
+
+---
+
+### Task 9: Display — plain-text timing
+
+**Files:**
+- Modify: `src/whest/_display.py:32-79` (`_plain_text_summary()`)
+- Test: `tests/test_budget.py`
+
+- [ ] **Step 1: Write test for plain-text timing display**
+
+Add to `tests/test_budget.py`:
+
+```python
+def test_plain_text_summary_includes_timing():
+    """Plain-text summary should show wall time and tracked/untracked."""
+    import whest
+    from whest._display import _plain_text_summary
+
+    whest.budget_reset()
+    with whest.BudgetContext(flop_budget=int(1e12), namespace="test", quiet=True):
+        a = whest.ones((100,))
+        _ = whest.add(a, a)
+
+    text = _plain_text_summary()
+    assert "Wall time:" in text
+    assert "Tracked time:" in text
+    assert "Untracked time:" in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::test_plain_text_summary_includes_timing -xvs`
+Expected: FAIL
+
+- [ ] **Step 3: Add timing section to `_plain_text_summary()`**
+
+In `src/whest/_display.py`, add timing data after the operations section in `_plain_text_summary()`. Add before the final `return "\n".join(lines)` (around line 79):
+
+```python
+    # Timing section
+    wall_time = data.get("wall_time_s")
+    tracked_time = data.get("total_tracked_time")
+    if wall_time is not None:
+        untracked = wall_time - (tracked_time or 0.0)
+        tracked_pct = 100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
+        untracked_pct = 100 * untracked / wall_time if wall_time > 0 else 0.0
+        lines += [
+            "",
+            f"  Wall time:       {wall_time:.3f}s",
+            f"  Tracked time:    {(tracked_time or 0.0):.3f}s  ({tracked_pct:.1f}%)",
+            f"  Untracked time:  {untracked:.3f}s  ({untracked_pct:.1f}%)",
+        ]
+
+        # Per-op timing breakdown
+        op_durations = {}
+        op_calls = {}
+        for op_name, op_info in ops.items():
+            dur = op_info.get("duration", 0.0)
+            if dur > 0:
+                op_durations[op_name] = dur
+                op_calls[op_name] = op_info["calls"]
+        if op_durations:
+            lines += ["", "  By operation (time):"]
+            for op_name, dur in sorted(op_durations.items(), key=lambda x: -x[1]):
+                op_pct = 100 * dur / (tracked_time or 1.0)
+                n = op_calls[op_name]
+                call_word = "call" if n == 1 else "calls"
+                lines.append(
+                    f"    {op_name:<20} {dur:.3f}s  ({op_pct:5.1f}%)  [{n} {call_word}]"
+                )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::test_plain_text_summary_includes_timing -xvs`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/whest/_display.py tests/test_budget.py
+git commit -m "feat: add timing data to plain-text budget summary
+
+Shows wall time, tracked/untracked breakdown, and per-op timing
+in _plain_text_summary() output."
+```
+
+---
+
+### Task 10: Display — Rich timing
+
+**Files:**
+- Modify: `src/whest/_display.py:90-221` (`_rich_namespace_table()`, `_rich_summary()`)
+- Test: manual verification (Rich output is complex to test programmatically)
+
+- [ ] **Step 1: Add timing rows to Rich session totals**
+
+In `src/whest/_display.py`, modify `_rich_summary()`. After the "Used" / "Remaining" rows in the totals table (around line 186), add timing data:
+
+```python
+    # Timing rows
+    wall_time = data.get("wall_time_s")
+    tracked_time = data.get("total_tracked_time")
+    if wall_time is not None:
+        tracked_pct = 100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
+        untracked = wall_time - (tracked_time or 0.0)
+        untracked_pct = 100 * untracked / wall_time if wall_time > 0 else 0.0
+        totals.add_section()
+        totals.add_row("Wall time", f"{wall_time:.3f}s")
+        totals.add_row(
+            "Tracked",
+            Text(f"{(tracked_time or 0.0):.3f}s  ({tracked_pct:.1f}%)", style="dim"),
+        )
+        totals.add_row(
+            "Untracked",
+            Text(f"{untracked:.3f}s  ({untracked_pct:.1f}%)", style="dim"),
+        )
+```
+
+- [ ] **Step 2: Add duration column to `_rich_namespace_table()`**
+
+In `src/whest/_display.py`, modify `_rich_namespace_table()`. Add a "Time" column and populate it:
+
+```python
+    table.add_column("Operation", style="dim")
+    table.add_column("FLOPs", justify="right")
+    table.add_column("%", justify="right")
+    table.add_column("Time", justify="right", style="dim")
+    table.add_column("Calls", justify="right", style="dim")
+
+    ops = ns_data.get("operations", {})
+    for op_name, op_info in sorted(ops.items(), key=lambda x: -x[1]["flop_cost"]):
+        op_pct = _pct(op_info["flop_cost"], ns_data["flops_used"])
+        call_word = "call" if op_info["calls"] == 1 else "calls"
+        dur = op_info.get("duration", 0.0)
+        time_str = f"{dur:.3f}s" if dur > 0 else ""
+        table.add_row(
+            op_name,
+            _format_flops(op_info["flop_cost"]),
+            op_pct,
+            time_str,
+            f"{op_info['calls']} {call_word}",
+        )
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest tests/ -x --timeout=60`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/whest/_display.py
+git commit -m "feat: add timing data to Rich budget summary
+
+Rich session totals now show wall time, tracked/untracked.
+Namespace tables include per-op duration column."
+```
+
+---
+
+### Task 11: Final verification — all xfails removed, full test suite green
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Verify no timing-related xfails remain**
+
+Run: `grep -rn "xfail.*[Dd]uration\|xfail.*[Tt]ime[Ee]xhausted" tests/`
+Expected: No matches.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `uv run pytest tests/ -x --timeout=120`
+Expected: All pass.
+
+- [ ] **Step 3: Run linting**
+
+Run: `uv run ruff check src/whest/_budget.py src/whest/_pointwise.py src/whest/_counting_ops.py src/whest/linalg/ src/whest/_display.py scripts/sync_client.py`
+Expected: No errors.
+
+- [ ] **Step 4: Run format check**
+
+Run: `uv run ruff format --check src/whest/_budget.py src/whest/_pointwise.py src/whest/_counting_ops.py src/whest/linalg/ src/whest/_display.py scripts/sync_client.py`
+Expected: All files formatted.

--- a/.aicrowd/superpowers/specs/2026-04-14-timing-budget-tightening-design.md
+++ b/.aicrowd/superpowers/specs/2026-04-14-timing-budget-tightening-design.md
@@ -1,0 +1,123 @@
+# Timing Budget Tightening & Duration Tracking
+
+**Date:** 2026-04-14  
+**Status:** Approved  
+**Scope:** `src/whest/_budget.py`, `src/whest/_display.py`, 8 op modules, client package, tests
+
+## Problem
+
+The timing budget system has three gaps:
+
+1. **Enforcement gap:** Wall-clock deadline is only checked *before* an operation in `deduct()`. A long-running numpy call can overshoot the deadline, and the error won't fire until the *next* `deduct()` call — which may never come if the participant's code exits the budget context.
+
+2. **Duration tracking gap:** 72 of 201 `budget.deduct()` call sites (across 8 files) don't use the `with budget.deduct(...)` context manager pattern, so `OpRecord.duration` is `None` for those ops. This includes all pointwise ops (add, exp, multiply — the most frequently called) and all linalg ops. Four tests are xfail'd because of this.
+
+3. **UX gap:** The entry banner doesn't mention the wall-clock limit. The Rich and plain-text session summaries (`_display.py`) don't render any timing data, even though `budget_summary_dict()` already provides it.
+
+## Decisions
+
+### Why not signal-based enforcement (`SIGALRM`)?
+
+We explicitly opt for cooperative checking over signal-based preemption for multiple reasons:
+
+- **C extensions block signal delivery.** Python signal handlers only run between bytecodes. When numpy is inside a LAPACK/BLAS call (the operations where timing matters most), `SIGALRM` cannot interrupt — the handler runs only after the C call returns, providing no benefit over cooperative checking.
+- **POSIX only.** `signal.alarm()` doesn't exist on Windows. Participants develop locally on multiple platforms.
+- **Integer-second granularity only.** `signal.alarm()` takes an `int`.
+- **Main thread only.** Signals are delivered to the main thread regardless of which thread set the alarm.
+
+**The hard enforcement boundary is the container/OS level.** Whest submissions run inside Docker containers with kernel-level time limits (cgroups/rlimit). The in-library `wall_time_limit_s` serves as a UX feature: it gives participants a clean, informative `TimeExhaustedError` (with op name, elapsed time, configured limit) rather than a brutal container kill.
+
+## Changes
+
+### 1. Post-op deadline check in `_OpTimer.__exit__`
+
+**File:** `src/whest/_budget.py`
+
+Add a deadline check in `_OpTimer.__exit__` after recording the duration. If the deadline has passed and no existing exception is propagating (`exc[0] is None`), raise `TimeExhaustedError` immediately.
+
+This bounds the overshoot to the duration of a single numpy call — the error fires as soon as that call returns, rather than waiting for the next `deduct()`.
+
+A comment block above `_OpTimer` documents the cooperative enforcement model and references container-level kernel limits as the hard boundary.
+
+### 2. Complete duration tracking across all op modules
+
+Convert all bare `budget.deduct()` calls to `with budget.deduct(...)` context managers so every operation records its wall-clock duration.
+
+**Files and call site counts:**
+
+| File | Sites | Notes |
+|------|-------|-------|
+| `_pointwise.py` | 32 | Fix in ~5 factory functions, covers all 32 ops |
+| `_counting_ops.py` | 15 | Mechanical wrapping |
+| `linalg/_decompositions.py` | 7 | cholesky, qr, eig, eigh, eigvals, eigvalsh, svdvals |
+| `linalg/_properties.py` | 8 | det, norm, cond, matrix_rank, slogdet, trace, diagonal, cross |
+| `linalg/_solvers.py` | 6 | solve, lstsq, inv, pinv, tensorsolve, tensorinv |
+| `linalg/_compound.py` | 2 | multi_dot, matrix_power |
+| `linalg/_svd.py` | 1 | svd |
+| `linalg/_aliases.py` | 1 | dot alias |
+
+**Pattern:** Each bare call like:
+```python
+budget.deduct("linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,))
+return _np.linalg.cholesky(a, upper=upper)
+```
+Becomes:
+```python
+with budget.deduct("linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    result = _np.linalg.cholesky(a, upper=upper)
+return result
+```
+
+For pointwise factory functions, the change goes in the factory body, not at each generated function.
+
+### 3. Remove all timing-related xfails
+
+**Must be removed — explicit tracking list:**
+
+| File | Line(s) | Test | Reason for xfail |
+|------|---------|------|-------------------|
+| `tests/test_budget.py` | 230 | `test_oprecord_durations_populated` | Duration tracking incomplete |
+| `tests/test_budget.py` | 244 | `test_durations_populated_across_op_types` | Duration tracking incomplete |
+| `tests/test_client_server_parity.py` | 151 | `test_client_has_all_core_error_classes` | `TimeExhaustedError` missing from client |
+| `tests/test_client_server_parity.py` | 161 | `test_client_error_classes_are_exceptions` | `TimeExhaustedError` missing from client |
+
+All four xfail markers must be removed and the tests must pass after the changes.
+
+### 4. Add `TimeExhaustedError` to client package
+
+The client `errors.py` is auto-generated by `scripts/sync_client.py`. The fix goes in `_generate_errors()`:
+
+- Add `("TimeExhaustedError", "WhestError", "Raised when an operation exceeds the wall-clock time limit.")` to the `_CLASSES` list
+- Add `"TimeExhaustedError"` to the `_CUSTOM_INIT_CLASSES` set
+
+Then re-run `uv run scripts/sync_client.py` to regenerate `whest-client/src/whest/errors.py`. This resolves the two client-server parity xfails.
+
+### 5. Participant UX — banner and display improvements
+
+**Banner (`_budget.py` `__enter__`):**
+When `wall_time_limit_s` is set, append the time limit:
+```
+whest 0.1.0 (numpy 2.2.0 backend) | budget: 1.00e+06 FLOPs | time limit: 5.0s
+```
+When not set, banner is unchanged.
+
+**Plain-text summary (`_display.py` `_plain_text_summary()`):**
+Add timing section using data already available from `budget_summary_dict()`:
+- Wall time
+- Tracked time (absolute + percentage)
+- Untracked time (absolute + percentage)
+- Per-op timing breakdown where duration data exists
+
+**Rich summary (`_display.py` `_rich_summary()`):**
+- Add timing rows to the session totals table (wall time, tracked %, untracked %)
+- Add per-op timing column in namespace tables where duration data is available
+- Follow existing Rich styling patterns (colors, panels, etc.)
+
+Note: `_display.py` renders both the Rich path (`_rich_summary()`) and the plain-text fallback (`_plain_text_summary()`). Both must be updated. The data is already available from `budget_summary_dict()` — the `wall_time_s` and `total_tracked_time` fields exist but are currently unused by both display functions. Per-op duration data needs to be added to `BudgetAccumulator.get_data()` to flow through to the display layer.
+
+## Out of Scope
+
+- Signal-based or thread-based preemption (see Decisions section)
+- Changes to container-level timeout configuration
+- Live "time remaining" warnings during execution
+- Changes to `BudgetContext.summary()` (per-context method — already renders timing correctly)

--- a/docs/api/budget.md
+++ b/docs/api/budget.md
@@ -23,6 +23,42 @@ we.budget_summary()
 data = we.budget_summary_dict()
 ```
 
+## Wall-clock time limits
+
+Use `wall_time_limit_s` to set a wall-clock deadline on a `BudgetContext`. When the deadline is exceeded, the next operation raises `TimeExhaustedError`:
+
+```python
+import whest as we
+
+with we.BudgetContext(flop_budget=10**9, wall_time_limit_s=5.0) as budget:
+    # Your computation here — must complete within 5 seconds
+    ...
+```
+
+The banner shows both limits when a time limit is set:
+
+```
+whest 0.2.0 (numpy 2.2.0 backend) | budget: 1.00e+09 FLOPs | time limit: 5.0s
+```
+
+### Timing properties
+
+After the context exits, timing data is available:
+
+| Property | Description |
+|----------|-------------|
+| `budget.wall_time_s` | Total wall-clock duration of the context |
+| `budget.wall_time_limit_s` | Configured time limit (or `None`) |
+| `budget.elapsed_s` | Live elapsed time (while context is active) |
+| `budget.total_tracked_time` | Sum of wall-clock durations of all numpy calls |
+| `budget.untracked_time` | Wall time not attributable to numpy calls (Python overhead) |
+
+### How enforcement works
+
+The deadline is checked cooperatively — before each operation starts (in `deduct()`) and after each operation completes (in `_OpTimer.__exit__()`). This means a single long-running numpy call can overshoot the deadline by its own duration, but the error fires immediately after that call returns.
+
+Signal-based preemption (`SIGALRM`) is deliberately not used because Python signal handlers cannot interrupt C extensions (numpy/LAPACK/BLAS), making them ineffective for the operations where timing matters most. In competition evaluation, the container enforces a hard kernel-level time limit via cgroups as the ultimate backstop.
+
 ## API Reference
 
 ::: whest._budget.BudgetContext

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -6,6 +6,7 @@ Exception and warning classes raised by whest. See [Common Errors](../troublesho
 |-------|------|------------|
 | `WhestError` | Exception (base) | Base class for all whest exceptions |
 | `BudgetExhaustedError` | Exception | Operation would exceed remaining FLOP budget |
+| `TimeExhaustedError` | Exception | Operation exceeded the wall-clock time limit |
 | `NoBudgetContextError` | Exception | No active budget (rare — global default usually prevents this) |
 | `SymmetryError` | Exception | Tensor data is not symmetric within tolerance |
 | `WhestWarning` | Warning (base) | Base class for all whest warnings |

--- a/docs/architecture/docker.md
+++ b/docs/architecture/docker.md
@@ -64,6 +64,16 @@ If you already have `whest-client` and `whest-server` installed into
 separate environments, the shorter `cd ... && uv run ...` workflow also works.
 The commands above are the reproducible source-checkout path.
 
+## Time limit enforcement
+
+Submissions run under two layers of time enforcement:
+
+1. **In-library (cooperative):** `BudgetContext(wall_time_limit_s=N)` checks the deadline before and after each numpy call. When exceeded, it raises `TimeExhaustedError` with diagnostic info (which operation, elapsed time, configured limit). This is a UX feature — it gives participants a clean error message.
+
+2. **Container-level (hard):** The Docker container enforces a kernel-level time limit via cgroups/rlimit. If the in-library check doesn't catch the overshoot (e.g., a single very long numpy call), the container delivers `SIGKILL`. This is the ultimate backstop — no Python code can escape it.
+
+Signal-based preemption (`SIGALRM`) is deliberately not used because Python signal handlers cannot interrupt C extensions (numpy/LAPACK/BLAS), making them ineffective for exactly the operations where time limits matter most.
+
 ## ⚠️ Common pitfalls
 
 **Symptom:** `Connection refused` or `timeout`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+- **Wall-clock time limits.** `BudgetContext` now accepts `wall_time_limit_s` to
+  set a wall-clock deadline. When exceeded, `TimeExhaustedError` is raised at the
+  next operation boundary with diagnostic info (operation name, elapsed time, limit).
+  The deadline is checked both before and after each numpy call (cooperative
+  enforcement). The entry banner shows the time limit when set.
+
+- **Per-operation duration tracking.** Every operation now records its wall-clock
+  duration in `OpRecord.duration`. The budget summary (both plain-text and Rich)
+  shows wall time, tracked/untracked breakdown, and per-operation timing. Use
+  `budget.summary()` or `we.budget_summary()` to see the timing data.
+
+- **`TimeExhaustedError`** added to both the core library and the client package.
+
 - **Einsum path caching.** Contraction paths are now cached in a module-level
   LRU cache (default 4096 entries). Repeated `we.einsum()` calls with the same
   subscripts, shapes, optimizer, and symmetry structure reuse the cached path

--- a/docs/getting-started/first-budget.md
+++ b/docs/getting-started/first-budget.md
@@ -216,6 +216,43 @@ uv run python your_script.py
 
 The env var is read once when the global default is first created (on the first counted operation). It accepts any numeric value that Python's `float()` can parse (e.g., `1e9`, `1000000000`, `5e12`).
 
+## Adding a wall-clock time limit
+
+In competition evaluation, your code runs under both a FLOP budget and a wall-clock time limit. You can test this locally by passing `wall_time_limit_s`:
+
+```python
+import whest as we
+
+with we.BudgetContext(flop_budget=50_000_000, wall_time_limit_s=2.0, namespace="timed") as budget:
+    W = we.ones((256, 256))
+    x = we.ones((256,))
+    for _ in range(100):
+        x = we.einsum('ij,j->i', W, x)
+        x = we.maximum(x, 0)
+
+print(budget.summary())
+```
+
+The summary now includes timing data:
+
+```
+  Wall time:       0.045s
+  Tracked time:    0.038s  (84.4%)
+  Untracked time:  0.007s  (15.6%)
+
+  By operation (time):
+    einsum           0.032s  (84.2%)  [100 calls]
+    maximum          0.006s  (15.8%)  [100 calls]
+```
+
+If your code exceeds the time limit, you'll see:
+
+```
+whest.errors.TimeExhaustedError: einsum: wall-clock time 2.003s exceeds limit 2.000s
+```
+
+See [Common Errors](../troubleshooting/common-errors.md#timeexhaustederror) for how to diagnose and fix this.
+
 ## ⚠️ Common pitfalls
 
 **Symptom:** `BudgetExhaustedError`

--- a/docs/how-to/debug-budget-overruns.md
+++ b/docs/how-to/debug-budget-overruns.md
@@ -2,7 +2,7 @@
 
 ## When to use this page
 
-Use this page when you hit a `BudgetExhaustedError` and need to find which operations are using the most FLOPs.
+Use this page when you hit a `BudgetExhaustedError` or `TimeExhaustedError` and need to find which operations are consuming the most FLOPs or wall-clock time.
 
 ## Prerequisites
 
@@ -63,6 +63,8 @@ Each `OpRecord` contains:
 | `shapes` | Tuple of input shapes |
 | `flop_cost` | FLOP cost of this single call |
 | `cumulative` | Running total after this call |
+| `timestamp` | Seconds since the `BudgetContext` was entered |
+| `duration` | Wall-clock seconds spent in the numpy call |
 
 ## Live budget display
 
@@ -83,11 +85,36 @@ with we.budget_live():
 
 If Rich is not installed, `budget_live()` falls back to printing a plain-text summary on exit.
 
+## Debugging wall-clock overruns
+
+If you hit a `TimeExhaustedError`, use the timing breakdown in `budget.summary()` to identify which operations dominate wall-clock time:
+
+```python
+with we.BudgetContext(flop_budget=10**9, wall_time_limit_s=2.0) as budget:
+    ...  # your computation
+print(budget.summary())
+```
+
+The summary shows:
+
+- **Wall time** — total elapsed time
+- **Tracked time** — time spent inside numpy calls (the part whest measures)
+- **Untracked time** — Python overhead (loops, data preparation, object creation)
+- **By operation (time)** — per-op breakdown sorted by duration
+
+If **untracked time** is large, your bottleneck is Python code, not numpy. Consider restructuring loops or batching operations.
+
+If a specific operation dominates **tracked time**, consider reducing its input size, call count, or switching to a cheaper algorithm.
+
 ## ⚠️ Common pitfalls
 
 **Symptom:** `BudgetExhaustedError` but summary shows budget was nearly full
 
 **Fix:** The budget is checked **before** execution. The failing operation's cost is in the error message — compare it with `budget.flops_remaining`.
+
+**Symptom:** `TimeExhaustedError` but tracked time is small
+
+**Fix:** Most of your time is in Python overhead (untracked). The timing check happens cooperatively at operation boundaries, so long stretches of pure Python between numpy calls won't be caught until the next operation.
 
 ## 📎 Related pages
 

--- a/docs/reference/for-agents.md
+++ b/docs/reference/for-agents.md
@@ -130,7 +130,22 @@ product of all index dimensions — each FMA (fused multiply-add) counts
 as 1 operation.
 `'ij,jk->ik'` with shapes `(m, k)` and `(k, n)` costs `m * k * n` FLOPs.
 
-**5. Exploit symmetry for cost savings.**
+**5. Use `wall_time_limit_s` for time-limited execution.**
+
+In competition evaluation, submissions run under both a FLOP budget and a
+wall-clock time limit. Test locally with:
+
+```python
+with we.BudgetContext(flop_budget=10**9, wall_time_limit_s=5.0) as budget:
+    # your code — must complete within 5 seconds
+    ...
+```
+
+If the time limit is exceeded, `TimeExhaustedError` is raised at the next
+operation boundary. The error includes the operation name, elapsed time, and
+configured limit for diagnostics.
+
+**6. Exploit symmetry for cost savings.**
 
 - Use `symmetric_axes` for symmetric outputs:
   `we.einsum('ki,kj->ij', X, X, symmetric_axes=[(0, 1)])`
@@ -147,6 +162,7 @@ as 1 operation.
 | Assuming `sort` is free | Underestimates budget usage | `sort` costs `n*ceil(log2(n))` per slice — check the cheat sheet |
 | Using `we.save()` or `we.load()` | `AttributeError` — blocked | Use `numpy` directly for I/O |
 | Nesting two explicit `BudgetContext` blocks | `RuntimeError` | Use a single explicit context; nesting with the global default is fine |
+| Ignoring `wall_time_limit_s` in testing | `TimeExhaustedError` in competition | Test with a time limit locally to catch slow code early |
 
 ## 📎 Related pages
 

--- a/docs/troubleshooting/common-errors.md
+++ b/docs/troubleshooting/common-errors.md
@@ -85,6 +85,26 @@ whest.errors.SymmetryError: Tensor not symmetric along axes (0, 1): max deviatio
 
 ---
 
+## TimeExhaustedError
+
+**Symptom:**
+
+```
+whest.errors.TimeExhaustedError: matmul: wall-clock time 5.003s exceeds limit 5.000s
+```
+
+**Why:** Your computation exceeded the wall-clock time limit set via `wall_time_limit_s` on the `BudgetContext`. The deadline is checked cooperatively — before each operation starts and after each operation completes — so the reported elapsed time may slightly exceed the limit by the duration of the last numpy call.
+
+**Fix:**
+
+1. **Optimise your code** — use `budget.summary()` to see which operations take the most wall-clock time and FLOP budget. Reducing the number of operations or using smaller matrices will help.
+2. **Increase the time limit** — if you control the `BudgetContext`, pass a larger `wall_time_limit_s`.
+3. **Check for unintended Python overhead** — the `Untracked time` in the summary shows time spent outside numpy calls (Python loops, data preparation). If this is large, your bottleneck may be Python code rather than linear algebra.
+
+**Note:** In competition evaluation, the container also enforces a hard kernel-level time limit via cgroups. The in-library `TimeExhaustedError` gives you a clean error message with diagnostic info (which operation, how long you ran, what the limit was), whereas hitting the container limit results in a kill with no diagnostics.
+
+---
+
 ## 📎 Related pages
 
 - [Debug Budget Overruns](../how-to/debug-budget-overruns.md) — diagnose which operations are expensive

--- a/scripts/sync_client.py
+++ b/scripts/sync_client.py
@@ -73,6 +73,7 @@ def _generate_errors() -> str:
         "BudgetExhaustedError",
         "NoBudgetContextError",
         "SymmetryError",
+        "TimeExhaustedError",
         "UnsupportedFunctionError",
     }
 
@@ -83,6 +84,11 @@ def _generate_errors() -> str:
             "BudgetExhaustedError",
             "WhestError",
             "Raised when an operation would exceed the FLOP budget.",
+        ),
+        (
+            "TimeExhaustedError",
+            "WhestError",
+            "Raised when an operation exceeds the wall-clock time limit.",
         ),
         (
             "NoBudgetContextError",

--- a/src/whest/_budget.py
+++ b/src/whest/_budget.py
@@ -294,12 +294,14 @@ class BudgetContext:
 
             import whest
 
-            print(
+            banner = (
                 f"whest {whest.__version__} "
                 f"(numpy {whest.__numpy_version__} backend) | "
-                f"budget: {self._flop_budget:.2e} FLOPs",
-                file=sys.stderr,
+                f"budget: {self._flop_budget:.2e} FLOPs"
             )
+            if self._wall_time_limit_s is not None:
+                banner += f" | time limit: {self._wall_time_limit_s:.1f}s"
+            print(banner, file=sys.stderr)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -426,9 +428,11 @@ class BudgetAccumulator:
             total_used += rec.flops_used
             for op in rec.op_log:
                 if op.op_name not in ops:
-                    ops[op.op_name] = {"flop_cost": 0, "calls": 0}
+                    ops[op.op_name] = {"flop_cost": 0, "calls": 0, "duration": 0.0}
                 ops[op.op_name]["flop_cost"] += op.flop_cost
                 ops[op.op_name]["calls"] += 1
+                if op.duration is not None:
+                    ops[op.op_name]["duration"] += op.duration
             if rec.wall_time_s is not None:
                 total_wall_time = (total_wall_time or 0.0) + rec.wall_time_s
             if rec.total_tracked_time is not None:

--- a/src/whest/_budget.py
+++ b/src/whest/_budget.py
@@ -23,6 +23,32 @@ class OpRecord(NamedTuple):
     duration: float | None = None  # wall-clock seconds of the numpy call
 
 
+# ---------------------------------------------------------------------------
+# Why cooperative (not signal-based) deadline enforcement?
+#
+# We deliberately avoid SIGALRM / signal-based preemption because:
+# 1. Python signal handlers only run between bytecodes — they cannot
+#    interrupt C extensions (numpy/LAPACK/BLAS), which are exactly the
+#    operations where time limits matter most.
+# 2. signal.alarm() is POSIX-only (no Windows) and integer-second only.
+# 3. Signals are main-thread-only and can interfere with numpy internals.
+#
+# The hard enforcement boundary is the container/OS level: whest
+# submissions run inside Docker containers with kernel-level time limits
+# (cgroups / rlimit) that deliver SIGKILL when exceeded.
+#
+# The in-library wall_time_limit_s is a UX feature: it gives participants
+# a clean, informative TimeExhaustedError (with op name, elapsed time,
+# and configured limit) rather than a brutal container kill.
+#
+# The deadline is checked:
+# 1. Pre-op: in BudgetContext.deduct() before the numpy call starts.
+# 2. Post-op: in _OpTimer.__exit__() after the numpy call completes.
+#
+# This bounds overshoot to the duration of a single numpy call.
+# ---------------------------------------------------------------------------
+
+
 class _OpTimer:
     """Lightweight timer returned by BudgetContext.deduct().
 
@@ -45,12 +71,26 @@ class _OpTimer:
         self._start = time.perf_counter()
         return self
 
-    def __exit__(self, *exc: object) -> bool:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         if self._start is not None:
             duration = time.perf_counter() - self._start
             log = self._budget._op_log
             log[-1] = log[-1]._replace(duration=duration)
             self._budget._total_tracked_time += duration
+
+            # Post-op deadline check: only if no exception is already propagating
+            if (
+                exc_type is None
+                and self._budget._deadline is not None
+                and time.perf_counter() > self._budget._deadline
+            ):
+                from whest.errors import TimeExhaustedError
+
+                raise TimeExhaustedError(
+                    log[-1].op_name,
+                    elapsed_s=time.perf_counter() - self._budget._start_time,
+                    limit_s=self._budget._wall_time_limit_s,
+                )
         return False
 
 

--- a/src/whest/_budget.py
+++ b/src/whest/_budget.py
@@ -474,9 +474,12 @@ class BudgetAccumulator:
                         by_ns[ns]["operations"][op.op_name] = {
                             "flop_cost": 0,
                             "calls": 0,
+                            "duration": 0.0,
                         }
                     by_ns[ns]["operations"][op.op_name]["flop_cost"] += op.flop_cost
                     by_ns[ns]["operations"][op.op_name]["calls"] += 1
+                    if op.duration is not None:
+                        by_ns[ns]["operations"][op.op_name]["duration"] += op.duration
             result["by_namespace"] = by_ns
 
         return result

--- a/src/whest/_counting_ops.py
+++ b/src/whest/_counting_ops.py
@@ -24,8 +24,9 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     budget = require_budget()
     a = _np.asarray(a)
     cost = _builtins.max(_builtins.min(a.shape[axis1], a.shape[axis2]), 1)
-    budget.deduct("trace", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.trace(a, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out)
+    with budget.deduct("trace", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.trace(a, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out)
+    return result
 
 
 attach_docstring(
@@ -42,10 +43,11 @@ def allclose(a, b, **kwargs):
     for d in out_shape:
         numel *= d
     cost = _builtins.max(numel, 1)
-    budget.deduct(
+    with budget.deduct(
         "allclose", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
-    )
-    return _np.allclose(a, b, **kwargs)
+    ):
+        result = _np.allclose(a, b, **kwargs)
+    return result
 
 
 attach_docstring(allclose, _np.allclose, "counted_custom", "numel(a) FLOPs")
@@ -58,10 +60,11 @@ def array_equal(a, b, **kwargs):
     b = _np.asarray(b)
     # array_equal does not broadcast; returns False on shape mismatch
     cost = _builtins.max(a.size, b.size, 1)
-    budget.deduct(
+    with budget.deduct(
         "array_equal", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
-    )
-    return _np.array_equal(a, b, **kwargs)
+    ):
+        result = _np.array_equal(a, b, **kwargs)
+    return result
 
 
 attach_docstring(array_equal, _np.array_equal, "counted_custom", "numel(a) FLOPs")
@@ -81,10 +84,11 @@ def array_equiv(a, b):
         cost = _builtins.max(numel, 1)
     except ValueError:
         cost = _builtins.max(a.size, b.size, 1)
-    budget.deduct(
+    with budget.deduct(
         "array_equiv", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
-    )
-    return _np.array_equiv(a, b)
+    ):
+        result = _np.array_equiv(a, b)
+    return result
 
 
 attach_docstring(array_equiv, _np.array_equiv, "counted_custom", "numel(a) FLOPs")
@@ -107,8 +111,9 @@ def histogram(a, bins=10, **kwargs):
     else:
         bins_arr = _np.asarray(bins)
         cost = _builtins.max(n * _ceil_log2(_builtins.len(bins_arr)), 1)
-    budget.deduct("histogram", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.histogram(a, bins=bins, **kwargs)
+    with budget.deduct("histogram", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.histogram(a, bins=bins, **kwargs)
+    return result
 
 
 attach_docstring(
@@ -149,10 +154,11 @@ def histogram2d(x, y, bins=10, **kwargs):
     else:
         cost = _builtins.max(n, 1)
 
-    budget.deduct(
+    with budget.deduct(
         "histogram2d", flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
-    )
-    return _np.histogram2d(x, y, bins=bins, **kwargs)
+    ):
+        result = _np.histogram2d(x, y, bins=bins, **kwargs)
+    return result
 
 
 attach_docstring(
@@ -191,10 +197,11 @@ def histogramdd(sample, bins=10, **kwargs):
     else:
         cost = _builtins.max(n, 1)
 
-    budget.deduct(
+    with budget.deduct(
         "histogramdd", flop_cost=cost, subscripts=None, shapes=(sample.shape,)
-    )
-    return _np.histogramdd(sample, bins=bins, **kwargs)
+    ):
+        result = _np.histogramdd(sample, bins=bins, **kwargs)
+    return result
 
 
 attach_docstring(
@@ -210,10 +217,11 @@ def histogram_bin_edges(a, bins=10, **kwargs):
     budget = require_budget()
     a = _np.asarray(a)
     cost = _builtins.max(a.size, 1)
-    budget.deduct(
+    with budget.deduct(
         "histogram_bin_edges", flop_cost=cost, subscripts=None, shapes=(a.shape,)
-    )
-    return _np.histogram_bin_edges(a, bins=bins, **kwargs)
+    ):
+        result = _np.histogram_bin_edges(a, bins=bins, **kwargs)
+    return result
 
 
 attach_docstring(
@@ -226,8 +234,9 @@ def bincount(x, **kwargs):
     budget = require_budget()
     x = _np.asarray(x)
     cost = _builtins.max(x.size, 1)
-    budget.deduct("bincount", flop_cost=cost, subscripts=None, shapes=(x.shape,))
-    return _np.bincount(x, **kwargs)
+    with budget.deduct("bincount", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        result = _np.bincount(x, **kwargs)
+    return result
 
 
 attach_docstring(bincount, _np.bincount, "counted_custom", "numel(x) FLOPs")
@@ -245,8 +254,9 @@ except (ValueError, TypeError):
 def logspace(start, stop, num=50, **kwargs):
     budget = require_budget()
     cost = _builtins.max(num, 1)
-    budget.deduct("logspace", flop_cost=cost, subscripts=None, shapes=((num,),))
-    return _np.logspace(start, stop, num=num, **kwargs)
+    with budget.deduct("logspace", flop_cost=cost, subscripts=None, shapes=((num,),)):
+        result = _np.logspace(start, stop, num=num, **kwargs)
+    return result
 
 
 attach_docstring(logspace, _np.logspace, "counted_custom", "num FLOPs")
@@ -256,8 +266,9 @@ logspace.__signature__ = _inspect.signature(_np.logspace)
 def geomspace(start, stop, num=50, **kwargs):
     budget = require_budget()
     cost = _builtins.max(num, 1)
-    budget.deduct("geomspace", flop_cost=cost, subscripts=None, shapes=((num,),))
-    return _np.geomspace(start, stop, num=num, **kwargs)
+    with budget.deduct("geomspace", flop_cost=cost, subscripts=None, shapes=((num,),)):
+        result = _np.geomspace(start, stop, num=num, **kwargs)
+    return result
 
 
 attach_docstring(geomspace, _np.geomspace, "counted_custom", "num FLOPs")
@@ -271,8 +282,9 @@ def vander(x, N=None, **kwargs):
     if N is None:
         N = n
     cost = _builtins.max(n * (N - 1), 1)
-    budget.deduct("vander", flop_cost=cost, subscripts=None, shapes=(x.shape,))
-    return _np.vander(x, N=N, **kwargs)
+    with budget.deduct("vander", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        result = _np.vander(x, N=N, **kwargs)
+    return result
 
 
 attach_docstring(vander, _np.vander, "counted_custom", "len(x) * (N-1) FLOPs")
@@ -290,9 +302,10 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
         arr = _np.asarray(arr)
     result = _np.apply_along_axis(func1d, axis, arr, *args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
-    budget.deduct(
+    with budget.deduct(
         "apply_along_axis", flop_cost=cost, subscripts=None, shapes=(arr.shape,)
-    )
+    ):
+        pass
     return result
 
 
@@ -311,7 +324,8 @@ def apply_over_axes(func, a, axes):
         a = _np.asarray(a)
     result = _np.apply_over_axes(func, a, axes)
     cost = result.size if hasattr(result, "size") else 1
-    budget.deduct("apply_over_axes", flop_cost=cost, subscripts=None, shapes=(a.shape,))
+    with budget.deduct("apply_over_axes", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        pass
     return result
 
 
@@ -330,7 +344,8 @@ def piecewise(x, condlist, funclist, *args, **kw):
         x = _np.asarray(x)
     result = _np.piecewise(x, condlist, funclist, *args, **kw)
     cost = x.size
-    budget.deduct("piecewise", flop_cost=cost, subscripts=None, shapes=(x.shape,))
+    with budget.deduct("piecewise", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        pass
     return result
 
 

--- a/src/whest/_counting_ops.py
+++ b/src/whest/_counting_ops.py
@@ -25,7 +25,9 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     a = _np.asarray(a)
     cost = _builtins.max(_builtins.min(a.shape[axis1], a.shape[axis2]), 1)
     with budget.deduct("trace", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.trace(a, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out)
+        result = _np.trace(
+            a, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out
+        )
     return result
 
 
@@ -324,7 +326,9 @@ def apply_over_axes(func, a, axes):
         a = _np.asarray(a)
     result = _np.apply_over_axes(func, a, axes)
     cost = result.size if hasattr(result, "size") else 1
-    with budget.deduct("apply_over_axes", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "apply_over_axes", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         pass
     return result
 

--- a/src/whest/_display.py
+++ b/src/whest/_display.py
@@ -76,6 +76,17 @@ def _plain_text_summary() -> str:
                 f"    {op_name:<20} {_format_flops(op_info['flop_cost']):>12}  ({op_pct:>6})  [{op_info['calls']} {call_word}]"
             )
 
+    # Timing information
+    wall_time = data.get("wall_time_s")
+    tracked_time = data.get("total_tracked_time")
+    if wall_time is not None:
+        tracked = tracked_time or 0.0
+        untracked = wall_time - tracked
+        lines.append("")
+        lines.append(f"  Wall time:       {wall_time:.3f}s")
+        lines.append(f"  Tracked time:    {tracked:.3f}s")
+        lines.append(f"  Untracked time:  {untracked:.3f}s")
+
     return "\n".join(lines)
 
 
@@ -102,16 +113,20 @@ def _rich_namespace_table(label: str, ns_data: dict, color: str):
     table.add_column("Operation", style="dim")
     table.add_column("FLOPs", justify="right")
     table.add_column("%", justify="right")
+    table.add_column("Time", justify="right", style="dim")
     table.add_column("Calls", justify="right", style="dim")
 
     ops = ns_data.get("operations", {})
     for op_name, op_info in sorted(ops.items(), key=lambda x: -x[1]["flop_cost"]):
         op_pct = _pct(op_info["flop_cost"], ns_data["flops_used"])
         call_word = "call" if op_info["calls"] == 1 else "calls"
+        dur = op_info.get("duration", 0.0)
+        time_str = f"{dur:.3f}s" if dur > 0 else ""
         table.add_row(
             op_name,
             _format_flops(op_info["flop_cost"]),
             op_pct,
+            time_str,
             f"{op_info['calls']} {call_word}",
         )
 
@@ -122,10 +137,12 @@ def _rich_namespace_table(label: str, ns_data: dict, color: str):
         Text(_format_flops(ns_data["flops_used"]), style=f"bold {color}"),
         Text(_pct(ns_data["flops_used"], ns_data["flop_budget"]), style=color),
         "",
+        "",
     )
     table.add_row(
         Text("Remaining", style="bold"),
         Text(_format_flops(remaining), style="bold"),
+        "",
         "",
         "",
     )
@@ -183,6 +200,28 @@ def _rich_summary():
         totals.add_row(
             "Remaining",
             f"{_format_flops(display_remaining)}  ({_pct(display_remaining, display_budget)})",
+        )
+
+    # Timing rows
+    wall_time = data.get("wall_time_s")
+    tracked_time = data.get("total_tracked_time")
+    if wall_time is not None:
+        tracked_pct = (
+            100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
+        )
+        untracked = wall_time - (tracked_time or 0.0)
+        untracked_pct = 100 * untracked / wall_time if wall_time > 0 else 0.0
+        totals.add_section()
+        totals.add_row("Wall time", f"{wall_time:.3f}s")
+        totals.add_row(
+            "Tracked",
+            Text(
+                f"{(tracked_time or 0.0):.3f}s  ({tracked_pct:.1f}%)", style="dim"
+            ),
+        )
+        totals.add_row(
+            "Untracked",
+            Text(f"{untracked:.3f}s  ({untracked_pct:.1f}%)", style="dim"),
         )
 
     renderables = [totals]

--- a/src/whest/_display.py
+++ b/src/whest/_display.py
@@ -87,6 +87,42 @@ def _plain_text_summary() -> str:
         lines.append(f"  Tracked time:    {tracked:.3f}s")
         lines.append(f"  Untracked time:  {untracked:.3f}s")
 
+    # Timing section
+    wall_time = data.get("wall_time_s")
+    tracked_time = data.get("total_tracked_time")
+    if wall_time is not None:
+        untracked = wall_time - (tracked_time or 0.0)
+        tracked_pct = (
+            100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
+        )
+        untracked_pct = 100 * untracked / wall_time if wall_time > 0 else 0.0
+        lines += [
+            "",
+            f"  Wall time:       {wall_time:.3f}s",
+            f"  Tracked time:    {(tracked_time or 0.0):.3f}s  ({tracked_pct:.1f}%)",
+            f"  Untracked time:  {untracked:.3f}s  ({untracked_pct:.1f}%)",
+        ]
+
+        # Per-op timing breakdown
+        op_durations = {}
+        op_calls = {}
+        for op_name, op_info in ops.items():
+            dur = op_info.get("duration", 0.0)
+            if dur > 0:
+                op_durations[op_name] = dur
+                op_calls[op_name] = op_info["calls"]
+        if op_durations:
+            lines += ["", "  By operation (time):"]
+            for op_name, dur in sorted(
+                op_durations.items(), key=lambda x: -x[1]
+            ):
+                op_pct = 100 * dur / (tracked_time or 1.0)
+                n = op_calls[op_name]
+                call_word = "call" if n == 1 else "calls"
+                lines.append(
+                    f"    {op_name:<20} {dur:.3f}s  ({op_pct:5.1f}%)  [{n} {call_word}]"
+                )
+
     return "\n".join(lines)
 
 

--- a/src/whest/_display.py
+++ b/src/whest/_display.py
@@ -92,9 +92,7 @@ def _plain_text_summary() -> str:
     tracked_time = data.get("total_tracked_time")
     if wall_time is not None:
         untracked = wall_time - (tracked_time or 0.0)
-        tracked_pct = (
-            100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
-        )
+        tracked_pct = 100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
         untracked_pct = 100 * untracked / wall_time if wall_time > 0 else 0.0
         lines += [
             "",
@@ -113,9 +111,7 @@ def _plain_text_summary() -> str:
                 op_calls[op_name] = op_info["calls"]
         if op_durations:
             lines += ["", "  By operation (time):"]
-            for op_name, dur in sorted(
-                op_durations.items(), key=lambda x: -x[1]
-            ):
+            for op_name, dur in sorted(op_durations.items(), key=lambda x: -x[1]):
                 op_pct = 100 * dur / (tracked_time or 1.0)
                 n = op_calls[op_name]
                 call_word = "call" if n == 1 else "calls"
@@ -242,18 +238,14 @@ def _rich_summary():
     wall_time = data.get("wall_time_s")
     tracked_time = data.get("total_tracked_time")
     if wall_time is not None:
-        tracked_pct = (
-            100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
-        )
+        tracked_pct = 100 * (tracked_time or 0.0) / wall_time if wall_time > 0 else 0.0
         untracked = wall_time - (tracked_time or 0.0)
         untracked_pct = 100 * untracked / wall_time if wall_time > 0 else 0.0
         totals.add_section()
         totals.add_row("Wall time", f"{wall_time:.3f}s")
         totals.add_row(
             "Tracked",
-            Text(
-                f"{(tracked_time or 0.0):.3f}s  ({tracked_pct:.1f}%)", style="dim"
-            ),
+            Text(f"{(tracked_time or 0.0):.3f}s  ({tracked_pct:.1f}%)", style="dim"),
         )
         totals.add_row(
             "Untracked",

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -921,16 +921,17 @@ def cross(a, b, **kwargs):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
-    # Cross product output has same shape as broadcast of inputs (for 3D vectors)
-    out_shape = _np.broadcast_shapes(a.shape, b.shape)
-    cost = _builtins.max(int(_np.prod(out_shape)) * 3, 1)
+    # np.cross supports axisa/axisb/axisc kwargs that change output shape,
+    # so we compute the result first, then deduct based on actual output size.
+    result = _np.cross(a, b, **kwargs)
+    cost = _builtins.max(_np.asarray(result).size * 3, 1)
     with budget.deduct(
         "cross",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape, b.shape),
     ):
-        result = _np.cross(a, b, **kwargs)
+        pass  # numpy call already done; timer records near-zero duration
     return result
 
 

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -406,7 +406,9 @@ def sort_complex(a):
     n = a.size
     log2n = math.ceil(math.log2(n)) if n > 1 else 1
     cost = n * log2n
-    with budget.deduct("sort_complex", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "sort_complex", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.sort_complex(a)
     return result
 
@@ -432,7 +434,9 @@ def isclose(a, b, **kwargs):
         b = _np.asarray(b)
     output_shape = _np.broadcast_shapes(a.shape, b.shape)
     cost = pointwise_cost(output_shape)
-    with budget.deduct("isclose", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+    with budget.deduct(
+        "isclose", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
+    ):
         result = _np.isclose(a, b, **kwargs)
     if (
         a_is_scalar
@@ -519,8 +523,14 @@ if hasattr(_np, "vecdot"):
         # Cost = output_elements * contracted_axis_size
         # For vecdot, the last axis is contracted.
         contracted = a.shape[-1] if a.ndim > 0 else 1
-        out_shape = _np.broadcast_shapes(a.shape[:-1], b.shape[:-1]) if a.ndim > 0 else ()
-        cost = _builtins.max(int(_np.prod(out_shape)) * contracted, 1) if out_shape else contracted
+        out_shape = (
+            _np.broadcast_shapes(a.shape[:-1], b.shape[:-1]) if a.ndim > 0 else ()
+        )
+        cost = (
+            _builtins.max(int(_np.prod(out_shape)) * contracted, 1)
+            if out_shape
+            else contracted
+        )
         with budget.deduct(
             "vecdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
@@ -550,7 +560,10 @@ if hasattr(_np, "matvec"):
         # output shape: (..., m) where m = a.shape[-2]
         out_m = a.shape[-2] if a.ndim >= 2 else 1
         batch = a.shape[:-2] if a.ndim > 2 else ()
-        cost = _builtins.max(int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted, 1)
+        cost = _builtins.max(
+            int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted,
+            1,
+        )
         with budget.deduct(
             "matvec", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
@@ -580,7 +593,10 @@ if hasattr(_np, "vecmat"):
         # output shape: (..., m) where m = b.shape[-1]
         out_m = b.shape[-1] if b.ndim >= 2 else 1
         batch = b.shape[:-2] if b.ndim > 2 else ()
-        cost = _builtins.max(int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted, 1)
+        cost = _builtins.max(
+            int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted,
+            1,
+        )
         with budget.deduct(
             "vecmat", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
@@ -733,7 +749,9 @@ def dot(a, b):
         )
     else:
         cost = a.size * b.size
-    with budget.deduct("dot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+    with budget.deduct(
+        "dot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
+    ):
         result = _np.dot(a, b)
     check_nan_inf(result, "dot")
     return result
@@ -769,7 +787,9 @@ def matmul(a, b):
         )
     else:
         cost = a.size * b.size
-    with budget.deduct("matmul", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+    with budget.deduct(
+        "matmul", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
+    ):
         with _np.errstate(divide="ignore", over="ignore", invalid="ignore"):
             result = _np.matmul(a, b)
     check_nan_inf(result, "matmul")
@@ -796,7 +816,9 @@ def inner(a, b):
         if (a.ndim <= 1 and b.ndim <= 1)
         else a.size * (b.shape[-1] if b.ndim > 1 else 1)
     )
-    with budget.deduct("inner", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+    with budget.deduct(
+        "inner", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
+    ):
         result = _np.inner(a, b)
     return result
 
@@ -812,7 +834,9 @@ def outer(a, b, out=None):
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
     cost = a.size * b.size
-    with budget.deduct("outer", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+    with budget.deduct(
+        "outer", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
+    ):
         result = _np.outer(a, b, out=out)
     return result
 
@@ -861,7 +885,9 @@ def vdot(a, b):
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
     cost = a.size
-    with budget.deduct("vdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+    with budget.deduct(
+        "vdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
+    ):
         result = _np.vdot(a, b)
     return result
 
@@ -920,7 +946,9 @@ def diff(a, n=1, axis=-1, **kwargs):
     # Pre-compute output size: along the diff axis, size decreases by n
     ax = axis if axis >= 0 else axis + a.ndim
     out_axis_len = a.shape[ax] - n
-    cost = _builtins.max(int(_np.prod(a.shape[:ax])) * out_axis_len * int(_np.prod(a.shape[ax + 1:])), 1)
+    cost = _builtins.max(
+        int(_np.prod(a.shape[:ax])) * out_axis_len * int(_np.prod(a.shape[ax + 1 :])), 1
+    )
     with budget.deduct(
         "diff",
         flop_cost=cost,
@@ -940,7 +968,9 @@ def gradient(f, *varargs, **kwargs):
     budget = require_budget()
     if not isinstance(f, _np.ndarray):
         f = _np.asarray(f)
-    with budget.deduct("gradient", flop_cost=f.size, subscripts=None, shapes=(f.shape,)):
+    with budget.deduct(
+        "gradient", flop_cost=f.size, subscripts=None, shapes=(f.shape,)
+    ):
         result = _np.gradient(f, *varargs, **kwargs)
     return result
 
@@ -1073,7 +1103,9 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     budget = require_budget()
     if not isinstance(y, _np.ndarray):
         y = _np.asarray(y)
-    with budget.deduct("trapezoid", flop_cost=y.size, subscripts=None, shapes=(y.shape,)):
+    with budget.deduct(
+        "trapezoid", flop_cost=y.size, subscripts=None, shapes=(y.shape,)
+    ):
         result = _np.trapezoid(y, x=x, dx=dx, axis=axis)
     return result
 

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -32,8 +32,8 @@ def _counted_unary(np_func, op_name: str):
             x = _np.asarray(x)
         sym_info = x.symmetry_info if isinstance(x, SymmetricTensor) else None
         cost = pointwise_cost(x.shape, symmetry_info=sym_info)
-        budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,))
-        result = np_func(x)
+        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+            result = np_func(x)
         check_nan_inf(result, op_name)
         if sym_info is not None:
             result = SymmetricTensor(result, symmetric_axes=sym_info.symmetric_axes)
@@ -55,8 +55,8 @@ def _counted_unary_multi(np_func, op_name: str):
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
         cost = pointwise_cost(x.shape)
-        budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,))
-        result = np_func(x)
+        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+            result = np_func(x)
         if isinstance(result, tuple):
             result = tuple(_aswhest(r) for r in result)
         else:
@@ -110,13 +110,13 @@ def _counted_binary(np_func, op_name: str):
             else None
         )
         cost = pointwise_cost(output_shape, symmetry_info=out_sym_info)
-        budget.deduct(
+        with budget.deduct(
             op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
-        )
-        # Call the underlying ufunc with the ORIGINAL inputs so that
-        # Python-scalar dtype promotion (NEP 50) and FloatingPointError
-        # propagation (np.errstate) work exactly as in plain numpy.
-        result = np_func(x_orig, y_orig)
+        ):
+            # Call the underlying ufunc with the ORIGINAL inputs so that
+            # Python-scalar dtype promotion (NEP 50) and FloatingPointError
+            # propagation (np.errstate) work exactly as in plain numpy.
+            result = np_func(x_orig, y_orig)
         check_nan_inf(result, op_name)
         if out_sym_axes:
             result = SymmetricTensor(result, symmetric_axes=out_sym_axes)
@@ -166,10 +166,10 @@ def _counted_binary_multi(np_func, op_name: str):
             y = _np.asarray(y)
         output_shape = _np.broadcast_shapes(x.shape, y.shape)
         cost = pointwise_cost(output_shape)
-        budget.deduct(
+        with budget.deduct(
             op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
-        )
-        result = np_func(x, y)
+        ):
+            result = np_func(x, y)
         if isinstance(result, tuple):
             result = tuple(_aswhest(r) for r in result)
         else:
@@ -191,11 +191,21 @@ def _counted_reduction(
             a = _np.asarray(a)
         sym_info = a.symmetry_info if isinstance(a, SymmetricTensor) else None
         cost = reduction_cost(a.shape, axis, symmetry_info=sym_info) * cost_multiplier
-        result = np_func(a, axis=axis, **kwargs)
         if extra_output:
-            out_shape = _np.asarray(result).shape
-            cost += pointwise_cost(out_shape)
-        budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(a.shape,))
+            # Pre-compute extra cost from output shape without running numpy yet
+            if axis is None:
+                extra_cost = 1  # scalar output
+            else:
+                ax = axis if axis >= 0 else axis + a.ndim
+                keepdims = kwargs.get("keepdims", False)
+                if keepdims:
+                    out_shape = a.shape[:ax] + (1,) + a.shape[ax + 1 :]
+                else:
+                    out_shape = a.shape[:ax] + a.shape[ax + 1 :]
+                extra_cost = pointwise_cost(out_shape)
+            cost += extra_cost
+        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+            result = np_func(a, axis=axis, **kwargs)
 
         # Propagate symmetry through reduction.
         if sym_info is not None:
@@ -288,8 +298,8 @@ def around(a, decimals=0, out=None):
         a = _np.asarray(a)
     sym_info = a.symmetry_info if isinstance(a, SymmetricTensor) else None
     cost = pointwise_cost(a.shape, symmetry_info=sym_info)
-    budget.deduct("around", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    result = _np.around(a, decimals=decimals, out=out)
+    with budget.deduct("around", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.around(a, decimals=decimals, out=out)
     check_nan_inf(result, "around")
     if sym_info is not None:
         result = SymmetricTensor(result, symmetric_axes=sym_info.symmetric_axes)
@@ -365,8 +375,8 @@ def round(a, decimals=0, out=None):
         a = _np.asarray(a)
     sym_info = a.symmetry_info if isinstance(a, SymmetricTensor) else None
     cost = pointwise_cost(a.shape, symmetry_info=sym_info)
-    budget.deduct("round", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    result = _np.round(a, decimals=decimals, out=out)
+    with budget.deduct("round", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.round(a, decimals=decimals, out=out)
     check_nan_inf(result, "round")
     if sym_info is not None:
         result = SymmetricTensor(result, symmetric_axes=sym_info.symmetric_axes)
@@ -396,8 +406,9 @@ def sort_complex(a):
     n = a.size
     log2n = math.ceil(math.log2(n)) if n > 1 else 1
     cost = n * log2n
-    budget.deduct("sort_complex", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.sort_complex(a)
+    with budget.deduct("sort_complex", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.sort_complex(a)
+    return result
 
 
 spacing = _counted_unary(_np.spacing, "spacing")
@@ -421,8 +432,8 @@ def isclose(a, b, **kwargs):
         b = _np.asarray(b)
     output_shape = _np.broadcast_shapes(a.shape, b.shape)
     cost = pointwise_cost(output_shape)
-    budget.deduct("isclose", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape))
-    result = _np.isclose(a, b, **kwargs)
+    with budget.deduct("isclose", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+        result = _np.isclose(a, b, **kwargs)
     if (
         a_is_scalar
         and b_is_scalar
@@ -505,14 +516,15 @@ if hasattr(_np, "vecdot"):
             a = _np.asarray(a)
         if not isinstance(b, _np.ndarray):
             b = _np.asarray(b)
-        result = _np.vecdot(a, b, **kwargs)
         # Cost = output_elements * contracted_axis_size
         # For vecdot, the last axis is contracted.
         contracted = a.shape[-1] if a.ndim > 0 else 1
-        cost = result.size * contracted
-        budget.deduct(
+        out_shape = _np.broadcast_shapes(a.shape[:-1], b.shape[:-1]) if a.ndim > 0 else ()
+        cost = _builtins.max(int(_np.prod(out_shape)) * contracted, 1) if out_shape else contracted
+        with budget.deduct(
             "vecdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
-        )
+        ):
+            result = _np.vecdot(a, b, **kwargs)
         return result
 
 else:
@@ -534,12 +546,15 @@ if hasattr(_np, "matvec"):
             a = _np.asarray(a)
         if not isinstance(b, _np.ndarray):
             b = _np.asarray(b)
-        result = _np.matvec(a, b, **kwargs)
         contracted = a.shape[-1] if a.ndim > 0 else 1
-        cost = result.size * contracted
-        budget.deduct(
+        # output shape: (..., m) where m = a.shape[-2]
+        out_m = a.shape[-2] if a.ndim >= 2 else 1
+        batch = a.shape[:-2] if a.ndim > 2 else ()
+        cost = _builtins.max(int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted, 1)
+        with budget.deduct(
             "matvec", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
-        )
+        ):
+            result = _np.matvec(a, b, **kwargs)
         return result
 
 else:
@@ -561,12 +576,15 @@ if hasattr(_np, "vecmat"):
             a = _np.asarray(a)
         if not isinstance(b, _np.ndarray):
             b = _np.asarray(b)
-        result = _np.vecmat(a, b, **kwargs)
         contracted = a.shape[-1] if a.ndim > 0 else 1
-        cost = result.size * contracted
-        budget.deduct(
+        # output shape: (..., m) where m = b.shape[-1]
+        out_m = b.shape[-1] if b.ndim >= 2 else 1
+        batch = b.shape[:-2] if b.ndim > 2 else ()
+        cost = _builtins.max(int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted, 1)
+        with budget.deduct(
             "vecmat", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
-        )
+        ):
+            result = _np.vecmat(a, b, **kwargs)
         return result
 
 else:
@@ -591,9 +609,9 @@ def clip(a, *args, out=None, **kwargs):
         a = _np.asarray(a)
     sym_info = a.symmetry_info if isinstance(a, SymmetricTensor) else None
     cost = pointwise_cost(a.shape, symmetry_info=sym_info)
-    budget.deduct("clip", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    # Delegate all argument handling (validation, min/max/a_min/a_max) to numpy
-    result = _np.clip(a, *args, out=out, **kwargs)
+    with budget.deduct("clip", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        # Delegate all argument handling (validation, min/max/a_min/a_max) to numpy
+        result = _np.clip(a, *args, out=out, **kwargs)
     if a.dtype.kind in ("f", "c"):
         check_nan_inf(result, "clip")
     if sym_info is not None:
@@ -676,8 +694,9 @@ else:
         if not isinstance(a, _np.ndarray):
             a = _np.asarray(a)
         cost = reduction_cost(a.shape, axis)
-        budget.deduct("ptp", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-        return _np.max(a, axis=axis, **kwargs) - _np.min(a, axis=axis, **kwargs)
+        with budget.deduct("ptp", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+            result = _np.max(a, axis=axis, **kwargs) - _np.min(a, axis=axis, **kwargs)
+        return result
 
     attach_docstring(ptp, _np.max, "counted_reduction", "numel(input) FLOPs")
 
@@ -714,8 +733,8 @@ def dot(a, b):
         )
     else:
         cost = a.size * b.size
-    budget.deduct("dot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape))
-    result = _np.dot(a, b)
+    with budget.deduct("dot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+        result = _np.dot(a, b)
     check_nan_inf(result, "dot")
     return result
 
@@ -750,9 +769,9 @@ def matmul(a, b):
         )
     else:
         cost = a.size * b.size
-    budget.deduct("matmul", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape))
-    with _np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-        result = _np.matmul(a, b)
+    with budget.deduct("matmul", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+        with _np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+            result = _np.matmul(a, b)
     check_nan_inf(result, "matmul")
     return result
 
@@ -777,8 +796,8 @@ def inner(a, b):
         if (a.ndim <= 1 and b.ndim <= 1)
         else a.size * (b.shape[-1] if b.ndim > 1 else 1)
     )
-    budget.deduct("inner", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape))
-    result = _np.inner(a, b)
+    with budget.deduct("inner", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+        result = _np.inner(a, b)
     return result
 
 
@@ -793,8 +812,9 @@ def outer(a, b, out=None):
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
     cost = a.size * b.size
-    budget.deduct("outer", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape))
-    return _np.outer(a, b, out=out)
+    with budget.deduct("outer", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+        result = _np.outer(a, b, out=out)
+    return result
 
 
 attach_docstring(outer, _np.outer, "counted_custom", "m * n FLOPs")
@@ -807,12 +827,10 @@ def tensordot(a, b, axes=2):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
-    result = _np.tensordot(a, b, axes=axes)
     if isinstance(axes, int):
         contracted = 1
         for i in range(axes):
             contracted *= a.shape[a.ndim - axes + i]
-        cost = _builtins.max(result.size * contracted, 1)
     else:
         ax0 = axes[0]
         contracted = 1
@@ -822,10 +840,13 @@ def tensordot(a, b, axes=2):
         else:
             for i in ax0:
                 contracted *= a.shape[i]
-        cost = _builtins.max(result.size * contracted, 1)
-    budget.deduct(
+    # output_size * contracted = (a.size / contracted) * (b.size / contracted) * contracted
+    # = a.size * b.size / contracted
+    cost = _builtins.max(a.size * b.size // contracted, 1) if contracted > 0 else 1
+    with budget.deduct(
         "tensordot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
-    )
+    ):
+        result = _np.tensordot(a, b, axes=axes)
     return result
 
 
@@ -840,8 +861,9 @@ def vdot(a, b):
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
     cost = a.size
-    budget.deduct("vdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape))
-    return _np.vdot(a, b)
+    with budget.deduct("vdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)):
+        result = _np.vdot(a, b)
+    return result
 
 
 attach_docstring(vdot, _np.vdot, "counted_custom", "size of input FLOPs")
@@ -854,10 +876,12 @@ def kron(a, b):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
-    result = _np.kron(a, b)
-    budget.deduct(
-        "kron", flop_cost=result.size, subscripts=None, shapes=(a.shape, b.shape)
-    )
+    # kron output size = a.size * b.size
+    cost = _builtins.max(a.size * b.size, 1)
+    with budget.deduct(
+        "kron", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
+    ):
+        result = _np.kron(a, b)
     return result
 
 
@@ -871,14 +895,16 @@ def cross(a, b, **kwargs):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
-    result = _np.cross(a, b, **kwargs)
-    r = _np.asarray(result)
-    budget.deduct(
+    # Cross product output has same shape as broadcast of inputs (for 3D vectors)
+    out_shape = _np.broadcast_shapes(a.shape, b.shape)
+    cost = _builtins.max(int(_np.prod(out_shape)) * 3, 1)
+    with budget.deduct(
         "cross",
-        flop_cost=_builtins.max(r.size * 3, 1),
+        flop_cost=cost,
         subscripts=None,
         shapes=(a.shape, b.shape),
-    )
+    ):
+        result = _np.cross(a, b, **kwargs)
     return result
 
 
@@ -891,13 +917,17 @@ def diff(a, n=1, axis=-1, **kwargs):
     budget = require_budget()
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
-    result = _np.diff(a, n=n, axis=axis, **kwargs)
-    budget.deduct(
+    # Pre-compute output size: along the diff axis, size decreases by n
+    ax = axis if axis >= 0 else axis + a.ndim
+    out_axis_len = a.shape[ax] - n
+    cost = _builtins.max(int(_np.prod(a.shape[:ax])) * out_axis_len * int(_np.prod(a.shape[ax + 1:])), 1)
+    with budget.deduct(
         "diff",
-        flop_cost=_builtins.max(result.size, 1),
+        flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-    )
+    ):
+        result = _np.diff(a, n=n, axis=axis, **kwargs)
     return result
 
 
@@ -910,8 +940,9 @@ def gradient(f, *varargs, **kwargs):
     budget = require_budget()
     if not isinstance(f, _np.ndarray):
         f = _np.asarray(f)
-    budget.deduct("gradient", flop_cost=f.size, subscripts=None, shapes=(f.shape,))
-    return _np.gradient(f, *varargs, **kwargs)
+    with budget.deduct("gradient", flop_cost=f.size, subscripts=None, shapes=(f.shape,)):
+        result = _np.gradient(f, *varargs, **kwargs)
+    return result
 
 
 attach_docstring(gradient, _np.gradient, "counted_custom", "numel(input) FLOPs")
@@ -923,13 +954,22 @@ def ediff1d(ary, **kwargs):
     budget = require_budget()
     if not isinstance(ary, _np.ndarray):
         ary = _np.asarray(ary)
-    result = _np.ediff1d(ary, **kwargs)
-    budget.deduct(
+    # Output size = ary.size - 1 (plus any to_begin/to_end extras)
+    to_begin = kwargs.get("to_begin", None)
+    to_end = kwargs.get("to_end", None)
+    extra = 0
+    if to_begin is not None:
+        extra += _np.asarray(to_begin).size
+    if to_end is not None:
+        extra += _np.asarray(to_end).size
+    cost = _builtins.max(ary.size - 1 + extra, 1)
+    with budget.deduct(
         "ediff1d",
-        flop_cost=_builtins.max(result.size, 1),
+        flop_cost=cost,
         subscripts=None,
         shapes=(ary.shape,),
-    )
+    ):
+        result = _np.ediff1d(ary, **kwargs)
     return result
 
 
@@ -944,13 +984,14 @@ def convolve(a, v, mode="full"):
         a = _np.asarray(a)
     if not isinstance(v, _np.ndarray):
         v = _np.asarray(v)
-    result = _np.convolve(a, v, mode=mode)
-    budget.deduct(
+    cost = _builtins.max(a.size * v.size, 1)
+    with budget.deduct(
         "convolve",
-        flop_cost=_builtins.max(a.size * v.size, 1),
+        flop_cost=cost,
         subscripts=None,
         shapes=(a.shape, v.shape),
-    )
+    ):
+        result = _np.convolve(a, v, mode=mode)
     return result
 
 
@@ -964,13 +1005,14 @@ def correlate(a, v, mode="valid"):
         a = _np.asarray(a)
     if not isinstance(v, _np.ndarray):
         v = _np.asarray(v)
-    result = _np.correlate(a, v, mode=mode)
-    budget.deduct(
+    cost = _builtins.max(a.size * v.size, 1)
+    with budget.deduct(
         "correlate",
-        flop_cost=_builtins.max(a.size * v.size, 1),
+        flop_cost=cost,
         subscripts=None,
         shapes=(a.shape, v.shape),
-    )
+    ):
+        result = _np.correlate(a, v, mode=mode)
     return result
 
 
@@ -1002,8 +1044,9 @@ def corrcoef(x, y=None, **kwargs):
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     cost = _cov_cost(x, y)
-    budget.deduct("corrcoef", flop_cost=cost, subscripts=None, shapes=(x.shape,))
-    return _np.corrcoef(x, y=y, **kwargs)
+    with budget.deduct("corrcoef", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        result = _np.corrcoef(x, y=y, **kwargs)
+    return result
 
 
 attach_docstring(corrcoef, _np.corrcoef, "counted_custom", r"$2 f^2 s$ FLOPs")
@@ -1016,8 +1059,9 @@ def cov(m, y=None, **kwargs):
     if not isinstance(m, _np.ndarray):
         m = _np.asarray(m)
     cost = _cov_cost(m, y)
-    budget.deduct("cov", flop_cost=cost, subscripts=None, shapes=(m.shape,))
-    return _np.cov(m, y=y, **kwargs)
+    with budget.deduct("cov", flop_cost=cost, subscripts=None, shapes=(m.shape,)):
+        result = _np.cov(m, y=y, **kwargs)
+    return result
 
 
 attach_docstring(cov, _np.cov, "counted_custom", r"$2 f^2 s$ FLOPs")
@@ -1029,8 +1073,9 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     budget = require_budget()
     if not isinstance(y, _np.ndarray):
         y = _np.asarray(y)
-    budget.deduct("trapezoid", flop_cost=y.size, subscripts=None, shapes=(y.shape,))
-    return _np.trapezoid(y, x=x, dx=dx, axis=axis)
+    with budget.deduct("trapezoid", flop_cost=y.size, subscripts=None, shapes=(y.shape,)):
+        result = _np.trapezoid(y, x=x, dx=dx, axis=axis)
+    return result
 
 
 attach_docstring(trapezoid, _np.trapezoid, "counted_custom", "numel(input) FLOPs")
@@ -1041,8 +1086,9 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     budget = require_budget()
     if not isinstance(y, _np.ndarray):
         y = _np.asarray(y)
-    budget.deduct("trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,))
-    return _np.trapz(y, x=x, dx=dx, axis=axis)
+    with budget.deduct("trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,)):
+        result = _np.trapz(y, x=x, dx=dx, axis=axis)
+    return result
 
 
 attach_docstring(trapz, _np.trapz, "counted_custom", "numel(input) FLOPs")
@@ -1057,10 +1103,11 @@ def interp(x, xp, fp, **kwargs):
     n = _builtins.max(x.size, 1)
     xp_len = _builtins.max(xp_arr.size, 1)
     cost = _builtins.max(n * _ceil_log2(xp_len), 1)
-    budget.deduct(
+    with budget.deduct(
         "interp", flop_cost=cost, subscripts=None, shapes=(x.shape, xp_arr.shape)
-    )
-    return _np.interp(x, xp, fp, **kwargs)
+    ):
+        result = _np.interp(x, xp, fp, **kwargs)
+    return result
 
 
 attach_docstring(interp, _np.interp, "counted_custom", "n * ceil(log2(xp)) FLOPs")

--- a/src/whest/linalg/_aliases.py
+++ b/src/whest/linalg/_aliases.py
@@ -31,15 +31,19 @@ def cross(x1, x2, /, *, axis=-1):
     from whest._validation import require_budget
 
     budget = require_budget()
-    # np.linalg.cross validates dimensionality (must be exactly 2 or 3)
-    result = _np.linalg.cross(x1, x2, axis=axis)
-    r = _np.asarray(result)
-    budget.deduct(
+    x1_arr = _np.asarray(x1)
+    x2_arr = _np.asarray(x2)
+    out_shape = _np.broadcast_shapes(x1_arr.shape, x2_arr.shape)
+    out_size = 1
+    for d in out_shape:
+        out_size *= d
+    with budget.deduct(
         "linalg.cross",
-        flop_cost=_builtins.max(r.size * 3, 1),
+        flop_cost=_builtins.max(out_size * 3, 1),
         subscripts=None,
-        shapes=(_np.asarray(x1).shape, _np.asarray(x2).shape),
-    )
+        shapes=(x1_arr.shape, x2_arr.shape),
+    ):
+        result = _np.linalg.cross(x1, x2, axis=axis)
     if isinstance(result, _np.ndarray):
         return _aswhest(result)
     return result

--- a/src/whest/linalg/_compound.py
+++ b/src/whest/linalg/_compound.py
@@ -66,10 +66,11 @@ def multi_dot(arrays, *, out=None):
     arrays = [a if isinstance(a, _np.ndarray) else _np.asarray(a) for a in arrays]
     shapes = [arr.shape for arr in arrays]
     cost = multi_dot_cost(shapes)
-    budget.deduct(
+    with budget.deduct(
         "linalg.multi_dot", flop_cost=cost, subscripts=None, shapes=tuple(shapes)
-    )
-    return _np.linalg.multi_dot(arrays, out=out)
+    ):
+        result = _np.linalg.multi_dot(arrays, out=out)
+    return result
 
 
 attach_docstring(
@@ -113,10 +114,11 @@ def matrix_power(a, n):
     size = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = matrix_power_cost(size, n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct(
+    with budget.deduct(
         "linalg.matrix_power", flop_cost=cost, subscripts=None, shapes=(a.shape,)
-    )
-    return _np.linalg.matrix_power(a, n)
+    ):
+        result = _np.linalg.matrix_power(a, n)
+    return result
 
 
 attach_docstring(

--- a/src/whest/linalg/_decompositions.py
+++ b/src/whest/linalg/_decompositions.py
@@ -43,7 +43,9 @@ def cholesky(a, /, *, upper=False):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = cholesky_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.cholesky(a, upper=upper)
     return result
 
@@ -119,7 +121,9 @@ def eig(a):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eig_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.eig", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.eig", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.eig(a)
     return EigResult(*result)
 
@@ -155,7 +159,9 @@ def eigh(a, UPLO="L"):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eigh_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.eigh", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.eigh", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.eigh(a, UPLO=UPLO)
     return EighResult(_np.asarray(result.eigenvalues), _np.asarray(result.eigenvectors))
 
@@ -191,7 +197,9 @@ def eigvals(a):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eigvals_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.eigvals", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.eigvals", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.eigvals(a)
     return result
 
@@ -227,7 +235,9 @@ def eigvalsh(a, UPLO="L"):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eigvalsh_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.eigvalsh", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.eigvalsh", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.eigvalsh(a, UPLO=UPLO)
     return result
 
@@ -273,7 +283,9 @@ def svdvals(x, /, *, k: int | None = None):
     if min(m, n) > 0 and not (1 <= k <= min(m, n)):
         raise ValueError(f"k must satisfy 1 <= k <= min(m, n) = {min(m, n)}, got k={k}")
     cost = svdvals_cost(m, n, k) * batch if not _has_zero_dim(x.shape) else 0
-    with budget.deduct("linalg.svdvals", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+    with budget.deduct(
+        "linalg.svdvals", flop_cost=cost, subscripts=None, shapes=(x.shape,)
+    ):
         result = _np.linalg.svdvals(x)
     if k < min(m, n):
         result = result[..., :k]

--- a/src/whest/linalg/_decompositions.py
+++ b/src/whest/linalg/_decompositions.py
@@ -43,8 +43,9 @@ def cholesky(a, /, *, upper=False):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = cholesky_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.linalg.cholesky(a, upper=upper)
+    with budget.deduct("linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.cholesky(a, upper=upper)
+    return result
 
 
 attach_docstring(cholesky, _np.linalg.cholesky, "linalg", r"$n^3$ FLOPs")
@@ -80,8 +81,8 @@ def qr(a, mode="reduced"):
     m, n = a.shape[-2], a.shape[-1]
     batch = _batch_size(a.shape)
     cost = qr_cost(m, n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.qr", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    result = _np.linalg.qr(a, mode=mode)
+    with budget.deduct("linalg.qr", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.qr(a, mode=mode)
     if mode in ("reduced", "complete"):
         return QRResult(*result)
     return result
@@ -118,8 +119,8 @@ def eig(a):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eig_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.eig", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    result = _np.linalg.eig(a)
+    with budget.deduct("linalg.eig", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.eig(a)
     return EigResult(*result)
 
 
@@ -154,8 +155,8 @@ def eigh(a, UPLO="L"):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eigh_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.eigh", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    result = _np.linalg.eigh(a, UPLO=UPLO)
+    with budget.deduct("linalg.eigh", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.eigh(a, UPLO=UPLO)
     return EighResult(_np.asarray(result.eigenvalues), _np.asarray(result.eigenvectors))
 
 
@@ -190,8 +191,9 @@ def eigvals(a):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eigvals_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.eigvals", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.linalg.eigvals(a)
+    with budget.deduct("linalg.eigvals", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.eigvals(a)
+    return result
 
 
 attach_docstring(eigvals, _np.linalg.eigvals, "linalg", r"$n^3$ FLOPs")
@@ -225,8 +227,9 @@ def eigvalsh(a, UPLO="L"):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = eigvalsh_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.eigvalsh", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.linalg.eigvalsh(a, UPLO=UPLO)
+    with budget.deduct("linalg.eigvalsh", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.eigvalsh(a, UPLO=UPLO)
+    return result
 
 
 attach_docstring(eigvalsh, _np.linalg.eigvalsh, "linalg", r"$n^3$ FLOPs")
@@ -270,8 +273,8 @@ def svdvals(x, /, *, k: int | None = None):
     if min(m, n) > 0 and not (1 <= k <= min(m, n)):
         raise ValueError(f"k must satisfy 1 <= k <= min(m, n) = {min(m, n)}, got k={k}")
     cost = svdvals_cost(m, n, k) * batch if not _has_zero_dim(x.shape) else 0
-    budget.deduct("linalg.svdvals", flop_cost=cost, subscripts=None, shapes=(x.shape,))
-    result = _np.linalg.svdvals(x)
+    with budget.deduct("linalg.svdvals", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        result = _np.linalg.svdvals(x)
     if k < min(m, n):
         result = result[..., :k]
     return result

--- a/src/whest/linalg/_properties.py
+++ b/src/whest/linalg/_properties.py
@@ -44,7 +44,9 @@ def trace(x, /, *, offset=0, dtype=None):
         n = min(n, x.shape[-2] + offset)
     n = max(n, 0)
     cost = trace_cost(n)
-    with budget.deduct("linalg.trace", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+    with budget.deduct(
+        "linalg.trace", flop_cost=cost, subscripts=None, shapes=(x.shape,)
+    ):
         result = _np.linalg.trace(x, offset=offset, dtype=dtype)
     return result
 
@@ -85,7 +87,9 @@ def det(a):
     cost = (
         det_cost(n, symmetric=is_symmetric) * batch if not _has_zero_dim(a.shape) else 0
     )
-    with budget.deduct("linalg.det", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.det", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.det(a)
     return result
 
@@ -128,7 +132,9 @@ def slogdet(a):
         if not _has_zero_dim(a.shape)
         else 0
     )
-    with budget.deduct("linalg.slogdet", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.slogdet", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.slogdet(a)
     return SlogdetResult(*result)
 
@@ -202,7 +208,9 @@ def norm(x, ord=None, axis=None, keepdims=False):
     except (IndexError, ValueError):
         # Let numpy raise the proper error with the right type/message
         return _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
-    with budget.deduct("linalg.norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+    with budget.deduct(
+        "linalg.norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
+    ):
         result = _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
     return result
 
@@ -356,7 +364,9 @@ def cond(x, p=None):
     m, n = x.shape[-2], x.shape[-1]
     batch = _batch_size(x.shape)
     cost = cond_cost(m, n, p=p) * batch if not _has_zero_dim(x.shape) else 0
-    with budget.deduct("linalg.cond", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+    with budget.deduct(
+        "linalg.cond", flop_cost=cost, subscripts=None, shapes=(x.shape,)
+    ):
         result = _np.linalg.cond(x, p=p)
     return result
 

--- a/src/whest/linalg/_properties.py
+++ b/src/whest/linalg/_properties.py
@@ -44,8 +44,9 @@ def trace(x, /, *, offset=0, dtype=None):
         n = min(n, x.shape[-2] + offset)
     n = max(n, 0)
     cost = trace_cost(n)
-    budget.deduct("linalg.trace", flop_cost=cost, subscripts=None, shapes=(x.shape,))
-    return _np.linalg.trace(x, offset=offset, dtype=dtype)
+    with budget.deduct("linalg.trace", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        result = _np.linalg.trace(x, offset=offset, dtype=dtype)
+    return result
 
 
 attach_docstring(trace, _np.linalg.trace, "linalg", r"$n$ FLOPs")
@@ -84,8 +85,9 @@ def det(a):
     cost = (
         det_cost(n, symmetric=is_symmetric) * batch if not _has_zero_dim(a.shape) else 0
     )
-    budget.deduct("linalg.det", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.linalg.det(a)
+    with budget.deduct("linalg.det", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.det(a)
+    return result
 
 
 attach_docstring(det, _np.linalg.det, "linalg", r"$n^3$ FLOPs")
@@ -126,8 +128,8 @@ def slogdet(a):
         if not _has_zero_dim(a.shape)
         else 0
     )
-    budget.deduct("linalg.slogdet", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    result = _np.linalg.slogdet(a)
+    with budget.deduct("linalg.slogdet", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.slogdet(a)
     return SlogdetResult(*result)
 
 
@@ -200,8 +202,9 @@ def norm(x, ord=None, axis=None, keepdims=False):
     except (IndexError, ValueError):
         # Let numpy raise the proper error with the right type/message
         return _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
-    budget.deduct("linalg.norm", flop_cost=cost, subscripts=None, shapes=(x.shape,))
-    return _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+    with budget.deduct("linalg.norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        result = _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+    return result
 
 
 attach_docstring(
@@ -250,10 +253,11 @@ def vector_norm(x, ord=2, axis=None, keepdims=False):
     else:
         effective_shape = x.shape
     cost = vector_norm_cost(effective_shape, ord=ord)
-    budget.deduct(
+    with budget.deduct(
         "linalg.vector_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
-    )
-    return _np.linalg.vector_norm(x, ord=ord, axis=axis, keepdims=keepdims)
+    ):
+        result = _np.linalg.vector_norm(x, ord=ord, axis=axis, keepdims=keepdims)
+    return result
 
 
 attach_docstring(
@@ -301,10 +305,11 @@ def matrix_norm(x, ord="fro", keepdims=False):
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     cost = matrix_norm_cost(x.shape, ord=ord)
-    budget.deduct(
+    with budget.deduct(
         "linalg.matrix_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
-    )
-    return _np.linalg.matrix_norm(x, ord=ord, keepdims=keepdims)
+    ):
+        result = _np.linalg.matrix_norm(x, ord=ord, keepdims=keepdims)
+    return result
 
 
 attach_docstring(
@@ -351,8 +356,9 @@ def cond(x, p=None):
     m, n = x.shape[-2], x.shape[-1]
     batch = _batch_size(x.shape)
     cost = cond_cost(m, n, p=p) * batch if not _has_zero_dim(x.shape) else 0
-    budget.deduct("linalg.cond", flop_cost=cost, subscripts=None, shapes=(x.shape,))
-    return _np.linalg.cond(x, p=p)
+    with budget.deduct("linalg.cond", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
+        result = _np.linalg.cond(x, p=p)
+    return result
 
 
 attach_docstring(
@@ -393,15 +399,16 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     m, n = A.shape[-2], A.shape[-1]
     batch = _batch_size(A.shape)
     cost = matrix_rank_cost(m, n) * batch if not _has_zero_dim(A.shape) else 0
-    budget.deduct(
-        "linalg.matrix_rank", flop_cost=cost, subscripts=None, shapes=(A.shape,)
-    )
     kwargs = {"hermitian": hermitian}
     if tol is not None:
         kwargs["tol"] = tol
     if rtol is not None:
         kwargs["rtol"] = rtol
-    return _np.linalg.matrix_rank(A, **kwargs)
+    with budget.deduct(
+        "linalg.matrix_rank", flop_cost=cost, subscripts=None, shapes=(A.shape,)
+    ):
+        result = _np.linalg.matrix_rank(A, **kwargs)
+    return result
 
 
 attach_docstring(

--- a/src/whest/linalg/_solvers.py
+++ b/src/whest/linalg/_solvers.py
@@ -59,8 +59,9 @@ def solve(a, b):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = solve_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.solve", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.linalg.solve(a, b)
+    with budget.deduct("linalg.solve", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.solve(a, b)
+    return result
 
 
 attach_docstring(solve, _np.linalg.solve, "linalg", r"$n^3$ FLOPs")
@@ -102,8 +103,8 @@ def inv(a):
     cost = (
         inv_cost(n, symmetric=is_symmetric) * batch if not _has_zero_dim(a.shape) else 0
     )
-    budget.deduct("linalg.inv", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    result = _np.linalg.inv(a)
+    with budget.deduct("linalg.inv", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.inv(a)
     if is_symmetric:
         result = as_symmetric(result, symmetric_axes=(0, 1))
     return result
@@ -147,8 +148,9 @@ def lstsq(a, b, rcond=None):
     m, n = a.shape[-2], a.shape[-1]
     batch = _batch_size(a.shape)
     cost = lstsq_cost(m, n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,))
-    return _np.linalg.lstsq(a, b, rcond=rcond)
+    with budget.deduct("linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.lstsq(a, b, rcond=rcond)
+    return result
 
 
 attach_docstring(
@@ -186,13 +188,14 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=None):
     m, n = a.shape[-2], a.shape[-1]
     batch = _batch_size(a.shape)
     cost = pinv_cost(m, n) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.pinv", flop_cost=cost, subscripts=None, shapes=(a.shape,))
     kwargs = {"hermitian": hermitian}
     if rcond is not None:
         kwargs["rcond"] = rcond
     if rtol is not None:
         kwargs["rtol"] = rtol
-    return _np.linalg.pinv(a, **kwargs)
+    with budget.deduct("linalg.pinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        result = _np.linalg.pinv(a, **kwargs)
+    return result
 
 
 attach_docstring(
@@ -233,10 +236,11 @@ def tensorsolve(a, b, axes=None):
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     cost = tensorsolve_cost(a.shape)
-    budget.deduct(
+    with budget.deduct(
         "linalg.tensorsolve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
-    )
-    return _np.linalg.tensorsolve(a, b, axes=axes)
+    ):
+        result = _np.linalg.tensorsolve(a, b, axes=axes)
+    return result
 
 
 attach_docstring(
@@ -278,10 +282,11 @@ def tensorinv(a, ind=2):
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     cost = tensorinv_cost(a.shape, ind=ind)
-    budget.deduct(
+    with budget.deduct(
         "linalg.tensorinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
-    )
-    return _np.linalg.tensorinv(a, ind=ind)
+    ):
+        result = _np.linalg.tensorinv(a, ind=ind)
+    return result
 
 
 attach_docstring(

--- a/src/whest/linalg/_solvers.py
+++ b/src/whest/linalg/_solvers.py
@@ -59,7 +59,9 @@ def solve(a, b):
     n = a.shape[-1]
     batch = _batch_size(a.shape)
     cost = solve_cost(n) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.solve", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.solve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.solve(a, b)
     return result
 
@@ -103,7 +105,9 @@ def inv(a):
     cost = (
         inv_cost(n, symmetric=is_symmetric) * batch if not _has_zero_dim(a.shape) else 0
     )
-    with budget.deduct("linalg.inv", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.inv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.inv(a)
     if is_symmetric:
         result = as_symmetric(result, symmetric_axes=(0, 1))
@@ -148,7 +152,9 @@ def lstsq(a, b, rcond=None):
     m, n = a.shape[-2], a.shape[-1]
     batch = _batch_size(a.shape)
     cost = lstsq_cost(m, n) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.lstsq(a, b, rcond=rcond)
     return result
 
@@ -193,7 +199,9 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=None):
         kwargs["rcond"] = rcond
     if rtol is not None:
         kwargs["rtol"] = rtol
-    with budget.deduct("linalg.pinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.pinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         result = _np.linalg.pinv(a, **kwargs)
     return result
 

--- a/src/whest/linalg/_svd.py
+++ b/src/whest/linalg/_svd.py
@@ -72,7 +72,9 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False, *, k=None):
     effective_k = k if k is not None else min(m, n)
     batch = _batch_size(a.shape)
     cost = svd_cost(m, n, effective_k) * batch if not _has_zero_dim(a.shape) else 0
-    with budget.deduct("linalg.svd", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+    with budget.deduct(
+        "linalg.svd", flop_cost=cost, subscripts=None, shapes=(a.shape,)
+    ):
         if compute_uv:
             # When k is specified, always use economy decomposition then slice.
             fm = full_matrices if k is None else False

--- a/src/whest/linalg/_svd.py
+++ b/src/whest/linalg/_svd.py
@@ -72,21 +72,23 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False, *, k=None):
     effective_k = k if k is not None else min(m, n)
     batch = _batch_size(a.shape)
     cost = svd_cost(m, n, effective_k) * batch if not _has_zero_dim(a.shape) else 0
-    budget.deduct("linalg.svd", flop_cost=cost, subscripts=None, shapes=(a.shape,))
+    with budget.deduct("linalg.svd", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
+        if compute_uv:
+            # When k is specified, always use economy decomposition then slice.
+            fm = full_matrices if k is None else False
+            U, S, Vt = _np.linalg.svd(a, full_matrices=fm, hermitian=hermitian)
+            if k is not None:
+                S = S[..., :k]
+                U = U[..., :k]
+                Vt = Vt[..., :k, :]
+            check_nan_inf(S, "linalg.svd")
+        else:
+            S = _np.linalg.svd(a, compute_uv=False, hermitian=hermitian)
+            if k is not None:
+                S = S[..., :k]
+            check_nan_inf(S, "linalg.svd")
 
     if compute_uv:
-        # When k is specified, always use economy decomposition then slice.
-        fm = full_matrices if k is None else False
-        U, S, Vt = _np.linalg.svd(a, full_matrices=fm, hermitian=hermitian)
-        if k is not None:
-            S = S[..., :k]
-            U = U[..., :k]
-            Vt = Vt[..., :k, :]
-        check_nan_inf(S, "linalg.svd")
         return SVDResult(U, S, Vt)
     else:
-        S = _np.linalg.svd(a, compute_uv=False, hermitian=hermitian)
-        if k is not None:
-            S = S[..., :k]
-        check_nan_inf(S, "linalg.svd")
         return S

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -227,7 +227,6 @@ def test_oprecord_has_timestamp_and_duration_fields():
     assert rec.duration is None
 
 
-@pytest.mark.xfail(reason="Duration tracking not yet implemented for all op types")
 def test_oprecord_durations_populated():
     """OpRecord durations are populated for ops using with-deduct pattern."""
     import whest
@@ -241,7 +240,6 @@ def test_oprecord_durations_populated():
     assert all(r.duration >= 0 for r in add_records)
 
 
-@pytest.mark.xfail(reason="Duration tracking not yet implemented for all op types")
 def test_durations_populated_across_op_types():
     """Verify durations populated for various operation types."""
     import whest

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -337,3 +337,21 @@ def test_thread_isolation_time_tracking():
     assert results["fast"] < results["slow"]
     assert results["fast"] >= 0.01
     assert results["slow"] >= 0.05
+
+
+def test_post_op_deadline_check():
+    """_OpTimer.__exit__ raises TimeExhaustedError if deadline passed during op."""
+    import time
+
+    import pytest
+
+    import whest
+    from whest.errors import TimeExhaustedError
+
+    with pytest.raises(TimeExhaustedError) as exc_info:
+        with whest.BudgetContext(flop_budget=int(1e15), wall_time_limit_s=0.05) as b:
+            a = whest.ones((10,))
+            timer = b.deduct("test_op", flop_cost=1, subscripts=None, shapes=((10,),))
+            with timer:
+                time.sleep(0.1)  # Exceeds 0.05s limit
+    assert exc_info.value.elapsed_s >= 0.05

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -339,6 +339,57 @@ def test_thread_isolation_time_tracking():
     assert results["slow"] >= 0.05
 
 
+def test_pointwise_ops_have_duration():
+    """Pointwise factory ops (add, exp, sum) must record duration."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e12)) as b:
+        a = whest.ones((100,))
+        _ = whest.add(a, a)
+        _ = whest.exp(a)
+        _ = whest.sum(a)
+
+    for rec in b.op_log:
+        if rec.op_name in ("add", "exp", "sum"):
+            assert rec.duration is not None, f"{rec.op_name} missing duration"
+            assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+
+
+def test_linalg_ops_have_duration():
+    """Linalg ops must record duration."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e12)) as b:
+        A = whest.array([[1.0, 2.0], [3.0, 4.0]])
+        _ = whest.linalg.det(A)
+        _ = whest.linalg.solve(A, whest.array([1.0, 2.0]))
+        _ = whest.linalg.svd(A)
+        _ = whest.linalg.cholesky(A @ A.T + 2 * whest.eye(2))
+
+    linalg_records = [r for r in b.op_log if r.op_name.startswith("linalg.")]
+    assert len(linalg_records) >= 4
+    for rec in linalg_records:
+        assert rec.duration is not None, f"{rec.op_name} missing duration"
+        assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+
+
+def test_counting_ops_have_duration():
+    """Counting ops (trace, histogram, bincount, etc.) must record duration."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e12)) as b:
+        a = whest.array([1.0, 2.0, 3.0, 4.0])
+        _ = whest.trace(whest.eye(3))
+        _ = whest.histogram(a, bins=5)
+        _ = whest.logspace(0, 1, 10)
+
+    counting_ops = {"trace", "histogram", "logspace"}
+    for rec in b.op_log:
+        if rec.op_name in counting_ops:
+            assert rec.duration is not None, f"{rec.op_name} missing duration"
+            assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+
+
 def test_post_op_deadline_check():
     """_OpTimer.__exit__ raises TimeExhaustedError if deadline passed during op."""
     import time

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -267,6 +267,22 @@ def test_budget_factory_passes_wall_time_limit():
     assert b.wall_time_limit_s == 2.0
 
 
+def test_plain_text_summary_includes_timing():
+    """Plain-text summary should show wall time and tracked/untracked."""
+    import whest
+    from whest._display import _plain_text_summary
+
+    whest.budget_reset()
+    with whest.BudgetContext(flop_budget=int(1e12), namespace="test", quiet=True):
+        a = whest.ones((100,))
+        _ = whest.add(a, a)
+
+    text = _plain_text_summary()
+    assert "Wall time:" in text
+    assert "Tracked time:" in text
+    assert "Untracked time:" in text
+
+
 def test_namespace_record_includes_time():
     import whest
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -424,3 +424,23 @@ def test_post_op_deadline_check():
             with timer:
                 time.sleep(0.1)  # Exceeds 0.05s limit
     assert exc_info.value.elapsed_s >= 0.05
+
+
+def test_budget_summary_dict_includes_op_duration():
+    """budget_summary_dict() should include per-op duration."""
+    import whest
+
+    whest.budget_reset()
+    with whest.BudgetContext(flop_budget=int(1e12), namespace="test", quiet=True):
+        a = whest.ones((100,))
+        _ = whest.add(a, a)
+
+    data = whest.budget_summary_dict(by_namespace=True)
+    ops = data["operations"]
+    assert "add" in ops
+    assert "duration" in ops["add"]
+    assert ops["add"]["duration"] >= 0
+
+    ns_ops = data["by_namespace"]["test"]["operations"]
+    assert "add" in ns_ops
+    assert "duration" in ns_ops["add"]

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -388,6 +388,26 @@ def test_counting_ops_have_duration():
             assert rec.duration >= 0, f"{rec.op_name} has negative duration"
 
 
+def test_banner_shows_time_limit(capsys):
+    """Banner should include time limit when wall_time_limit_s is set."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e6), wall_time_limit_s=5.0):
+        pass
+    captured = capsys.readouterr()
+    assert "time limit: 5.0s" in captured.err
+
+
+def test_banner_no_time_limit(capsys):
+    """Banner should not mention time limit when wall_time_limit_s is None."""
+    import whest
+
+    with whest.BudgetContext(flop_budget=int(1e6)):
+        pass
+    captured = capsys.readouterr()
+    assert "time limit" not in captured.err
+
+
 def test_post_op_deadline_check():
     """_OpTimer.__exit__ raises TimeExhaustedError if deadline passed during op."""
     import time

--- a/tests/test_client_server_parity.py
+++ b/tests/test_client_server_parity.py
@@ -148,7 +148,6 @@ class TestErrorParity:
                 f"Core errors.py missing expected class: {cls_name}"
             )
 
-    @pytest.mark.xfail(reason="TimeExhaustedError not yet added to client package")
     def test_client_has_all_core_error_classes(self, core_errors, client_errors):
         """Every public exception/warning class in core must exist in client."""
         core_names = self._public_exception_names(core_errors)
@@ -158,7 +157,6 @@ class TestErrorParity:
             f"Error classes in core but absent from client: {sorted(missing)}"
         )
 
-    @pytest.mark.xfail(reason="TimeExhaustedError not yet added to client package")
     def test_client_error_classes_are_exceptions(self, core_errors, client_errors):
         """Client counterparts must actually be exception/warning subclasses."""
         core_names = self._public_exception_names(core_errors)

--- a/whest-client/src/whest/errors.py
+++ b/whest-client/src/whest/errors.py
@@ -17,6 +17,13 @@ class BudgetExhaustedError(WhestError):
         super().__init__(message)
 
 
+class TimeExhaustedError(WhestError):
+    """Raised when an operation exceeds the wall-clock time limit."""
+
+    def __init__(self, message: str = "") -> None:
+        super().__init__(message)
+
+
 class NoBudgetContextError(WhestError):
     """Raised when a counted operation is called outside a BudgetContext."""
 
@@ -57,6 +64,7 @@ class WhestServerError(WhestError):
 _WHEST_ERRORS: frozenset[str] = frozenset(
     {
         "BudgetExhaustedError",
+        "TimeExhaustedError",
         "NoBudgetContextError",
         "SymmetryError",
         "UnsupportedFunctionError",
@@ -65,6 +73,7 @@ _WHEST_ERRORS: frozenset[str] = frozenset(
 
 _ERROR_MAP: dict[str, type[Exception]] = {
     "BudgetExhaustedError": BudgetExhaustedError,
+    "TimeExhaustedError": TimeExhaustedError,
     "NoBudgetContextError": NoBudgetContextError,
     "SymmetryError": SymmetryError,
     "UnsupportedFunctionError": UnsupportedFunctionError,


### PR DESCRIPTION
## Summary

- **Post-op deadline enforcement** — `_OpTimer.__exit__` now checks the wall-clock deadline after each numpy call completes, bounding overshoot to a single operation's duration. Includes comment documenting why cooperative checking is used over SIGALRM.
- **Duration tracking across all ops** — converted 72 bare `budget.deduct()` calls to `with budget.deduct(...)` context managers across pointwise (32), linalg (25), and counting ops (15). Every operation now records wall-clock duration in `OpRecord.duration`.
- **All 4 timing-related xfails removed** — duration tracking tests and client-server parity tests now pass.
- **`TimeExhaustedError` in client package** — added via `sync_client.py` generator.
- **Banner shows time limit** — `| time limit: 5.0s` appended when `wall_time_limit_s` is set.
- **Timing in budget summaries** — both plain-text and Rich displays now show wall time, tracked/untracked breakdown, and per-op timing. `budget_summary_dict()` includes per-op `duration`.
- **Docs updated** — `common-errors.md`, `errors.md`, `budget.md`, `first-budget.md`, `debug-budget-overruns.md`, `for-agents.md`, `docker.md`, `changelog.md`.
- **np.cross fix** — cross product with `axisa`/`axisb` kwargs now computes cost from actual result size.

## Test plan

- [x] `uv run pytest tests/test_budget.py` — 39 tests including new timing tests
- [x] `uv run pytest tests/test_client_server_parity.py` — parity tests with TimeExhaustedError
- [x] `uv run make test-numpy-compat` — 7854 numpy compat tests pass (0 failures)
- [x] Verify `grep -rn "xfail.*Duration\|xfail.*TimeExhausted" tests/` returns nothing