### PR TITLE
docs: explain budget time limits and summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ import whest as we
 
 depth, width = 5, 256
 
-with we.BudgetContext(flop_budget=10**8) as budget:
+with we.BudgetContext(flop_budget=10**8, wall_time_limit_s=5.0) as budget:
     # Weight init
     scale = we.sqrt(2 / width)
     weights = [we.random.randn(width, width) * scale
@@ -132,10 +132,18 @@ with we.BudgetContext(flop_budget=10**8) as budget:
         if i < depth - 1:
             h = we.maximum(h, 0)
 
-    print(budget.summary())
+    print(budget.summary())   # current context summary
+
+we.budget_summary()           # session/global summary
 ```
 
 ```
+
+`wall_time_limit_s` starts when the context is entered and is checked before
+and after each counted NumPy call. If the limit is exceeded, whest raises
+`TimeExhaustedError` with the operation name, elapsed time, and configured
+limit. Use `budget.summary()` for the current context and
+`we.budget_summary()` when you want the accumulated session/global view.
 whest FLOP Budget Summary
 =========================
   Total budget:     100,000,000

--- a/src/whest/_budget.py
+++ b/src/whest/_budget.py
@@ -203,6 +203,17 @@ class BudgetContext:
         Maximum number of FLOPs allowed. Must be > 0.
     flop_multiplier : float, optional
         Multiplier applied to all FLOP costs. Default 1.
+    quiet : bool, optional
+        When ``True``, suppress the startup banner printed on context entry.
+    namespace : str | None, optional
+        Root namespace prefix used for operation attribution inside this
+        context. Nested ``we.namespace(...)`` scopes append dotted segments.
+    wall_time_limit_s : float | None, optional
+        Cooperative wall-clock limit for the entire context. The timer starts
+        when the context is entered and is checked before and after each
+        counted NumPy call. If the deadline is exceeded, whest raises
+        ``TimeExhaustedError`` at the next operation boundary. This is a
+        diagnostic UX limit, not a hard preemptive kill.
     """
 
     def __init__(
@@ -456,7 +467,12 @@ def budget(
     namespace: str | None = None,
     wall_time_limit_s: float | None = None,
 ) -> BudgetContext:
-    """Create a BudgetContext usable as both a context manager and decorator."""
+    """Create a ``BudgetContext`` usable as a context manager or decorator.
+
+    This helper accepts the same arguments as ``BudgetContext(...)``,
+    including ``namespace=...`` for attribution and ``wall_time_limit_s=...``
+    for cooperative wall-clock limits.
+    """
     return BudgetContext(
         flop_budget=flop_budget,
         flop_multiplier=flop_multiplier,

--- a/website/content/docs/getting-started/competition.mdx
+++ b/website/content/docs/getting-started/competition.mdx
@@ -61,6 +61,13 @@ with we.BudgetContext(flop_budget=10**9, wall_time_limit_s=60.0) as budget:
 
 If the wall-clock time is exceeded, whest raises `TimeExhaustedError`. The timer starts when the context is entered and is checked after each counted operation.
 
+What `wall_time_limit_s` does and does not do:
+
+- It is a `BudgetContext` setting, so you configure it in the same place you set `flop_budget`.
+- It measures total wall-clock time for the active context, not FLOPs.
+- It is checked cooperatively before and after counted NumPy calls, so overshoot is bounded by the duration of one NumPy call.
+- It is a clean diagnostic limit inside whest. Hard process/container kills still belong to the outer execution environment.
+
 ## Reading the budget summary
 
 Call `budget.summary()` when you want the current context's summary, or `we.budget_summary()` for the accumulated session/global view. Both stay flat by default; use `by_namespace=True` only when you want a namespace breakdown:
@@ -71,6 +78,12 @@ print(budget.summary(by_namespace=True))  # context summary with namespaces
 we.budget_summary()                       # session/global summary
 we.budget_summary(by_namespace=True)      # session/global summary with namespaces
 ```
+
+Use these forms for different questions:
+
+- `budget.summary()` answers "what did this one explicit context spend?"
+- `we.budget_summary()` answers "what has this process/session spent overall?"
+- `budget.summary_dict(...)` and `we.budget_summary_dict(...)` return the same information as structured data instead of formatted text.
 
 The block below shows `print(budget.summary(by_namespace=True))` for the `solver` context:
 
@@ -104,6 +117,7 @@ Key things to look for:
 - **Budget / Used / Remaining:** the top rows show the explicit competition budget, current spend, and remaining headroom
 - **By namespace:** `solver` is the root prefix, and nested scopes show up as dotted paths like `solver.precompute`. Use `budget.summary(by_namespace=True)` for the current context or `we.budget_summary(by_namespace=True)` for the accumulated session/global view
 - **By operation:** this toy pass is dominated by the single `einsum`; `exp` and `sum` are tiny by comparison
+- **Wall / tracked / untracked time:** wall time is total elapsed time for the context, tracked time is time spent inside counted NumPy calls, and untracked time is everything else in the context (`wall_time - tracked_time`)
 - **Flat default:** the default summary stays flat unless you opt into `by_namespace=True`
 
 For programmatic access, use `we.budget_summary_dict()`:

--- a/website/content/docs/guides/budget-planning.mdx
+++ b/website/content/docs/guides/budget-planning.mdx
@@ -106,6 +106,34 @@ data = budget.summary_dict(by_namespace=True)
 print(data["by_namespace"]["predict.fallback.sampling"]["flops_used"])
 ```
 
+## Add a time limit when FLOPs are not the only risk
+
+Some operations are analytically cheap enough to fit the FLOP budget but still
+slow in practice. Use `wall_time_limit_s` on the same `BudgetContext` when you
+want a cooperative wall-clock deadline in addition to the FLOP cap:
+
+```python
+with we.BudgetContext(
+    flop_budget=10_000_000,
+    wall_time_limit_s=2.0,
+    namespace="predict",
+) as budget:
+    # computation must stay within both limits
+    ...
+
+print(budget.summary())
+```
+
+When the time limit is exceeded, whest raises `TimeExhaustedError` at the next
+operation boundary. The summary exposes three timing views:
+
+- `wall_time_s`: total elapsed time for the context
+- `tracked_time_s`: time spent inside counted NumPy calls
+- `untracked_time_s`: everything else in the context (`wall_time_s - tracked_time_s`)
+
+Use `budget.summary()` when you want the current context's timings, and
+`we.budget_summary()` when you want the accumulated session/global view.
+
 ## Diagnose overruns
 
 When you hit a `BudgetExhaustedError`, the budget's operation log gives per-call detail:


### PR DESCRIPTION
## Summary
- document `wall_time_limit_s` directly on `BudgetContext` and `we.budget(...)`
- clarify when to use `budget.summary()` versus `we.budget_summary()`
- expand the docs-site budget guides with tracked, untracked, and wall-time explanations

## Testing
- `git diff --check`
- `uv run ruff check src/whest/_budget.py`
- `npm test -- docs-tree.test.mjs docs-whest-examples.test.mjs rich-output.test.mjs`

## Notes
- branch is already rebased onto current `main`; no additional rebase was needed.