### PR TITLE
Use sitewide logo for docs favicon

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,11 +1,20 @@
 import { Inter, Geist } from 'next/font/google';
 import { Provider } from '@/components/provider';
+import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import 'katex/dist/katex.css';
 import './global.css';
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils';
+import { withBasePath } from '@/lib/base-path';
 
-const geist = Geist({subsets:['latin'],variable:'--font-sans'});
+export const metadata: Metadata = {
+  icons: {
+    icon: withBasePath('/logo.png'),
+    apple: withBasePath('/logo.png'),
+  },
+};
+
+const geist = Geist({ subsets: ['latin'], variable: '--font-sans' });
 
 const inter = Inter({
   subsets: ['latin'],
@@ -13,7 +22,7 @@ const inter = Inter({
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={cn(inter.className, "font-sans", geist.variable)} suppressHydrationWarning>
+    <html lang="en" className={cn(inter.className, 'font-sans', geist.variable)} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
         <Provider>{children}</Provider>
       </body>

--- a/website/layout.shared.test.mjs
+++ b/website/layout.shared.test.mjs
@@ -14,3 +14,13 @@ test('shared layout logo path is base-path neutral', async () => {
   assert.doesNotMatch(source, /src="\/logo\.png"/);
   assert.doesNotMatch(source, /src="\/whest\/logo\.png"/);
 });
+
+test('root layout metadata points the favicon at the shared site logo', async () => {
+  const file = path.join(websiteRoot, 'app', 'layout.tsx');
+  const source = await readFile(file, 'utf8');
+
+  assert.match(source, /export const metadata/);
+  assert.match(source, /icons:\s*\{/);
+  assert.match(source, /icon:\s*withBasePath\('\/logo\.png'\)/);
+  assert.match(source, /apple:\s*withBasePath\('\/logo\.png'\)/);
+});


### PR DESCRIPTION
## Summary
- point the root docs app metadata icons at the shared sitewide `logo.png`
- keep favicon paths base-path aware for the static `/whest` deploy
- add a regression test covering the root layout favicon metadata

## Validation
- `npm test -- layout.shared.test.mjs deployed-docs-recovery.test.mjs`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest --cov=whest --cov-fail-under=90`
- `uv run pytest tests/numpy_compat/ -n auto -q --pyargs numpy._core.tests.test_umath numpy._core.tests.test_ufunc numpy._core.tests.test_numeric numpy.linalg.tests.test_linalg numpy.fft.tests.test_pocketfft numpy.fft.tests.test_helper numpy.polynomial.tests.test_polynomial numpy.random.tests.test_random`
- `uv run python scripts/sync_client.py --check`
- `uv run pytest tests/test_client_server_parity.py tests/test_serialization_parity.py -v`
- `uv run python scripts/generate_api_docs.py --verify`
- `cd website && npm run build`
- `cd website && npm run check:gh-pages`
