### PR TITLE
Add docs dispatch workflow

### DIFF
--- a/.github/docs-dispatch.workflow.test.mjs
+++ b/.github/docs-dispatch.workflow.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const workflowPath = path.join(process.cwd(), '.github', 'workflows', 'docs-dispatch.yml');
+
+test('whest docs dispatch workflow triggers only from main on docs contract changes', () => {
+  const source = fs.readFileSync(workflowPath, 'utf8');
+
+  assert.match(source, /push:\s*\n\s*branches:\s*\[main\]/);
+  assert.match(source, /website\/content\/docs\/\*\*/);
+  assert.match(source, /website\/docs-kit\/\*\*/);
+  assert.match(source, /docs\/unified-docs-process\.md/);
+});
+
+test('whest docs dispatch workflow targets whest-docs via repository_dispatch', () => {
+  const source = fs.readFileSync(workflowPath, 'utf8');
+
+  assert.match(source, /repos\/AIcrowd\/whest-docs\/dispatches/);
+  assert.match(source, /event_type": "source-updated"/);
+  assert.match(source, /AICROWD_DOCS_DISPATCH_TOKEN/);
+});

--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -1,0 +1,31 @@
+name: Docs Dispatch
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/content/docs/**'
+      - 'website/docs-kit/**'
+      - 'docs/unified-docs-process.md'
+      - 'AGENTS.md'
+      - 'README.md'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify whest-docs
+        env:
+          GH_TOKEN: ${{ secrets.AICROWD_DOCS_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/AIcrowd/whest-docs/dispatches \
+            --method POST \
+            --input - <<'EOF'
+          {
+            "event_type": "source-updated",
+            "client_payload": {
+              "source_repo": "AIcrowd/whest",
+              "source_ref": "${{ github.sha }}"
+            }
+          }
+          EOF


### PR DESCRIPTION
## What changed
Add a dedicated docs dispatch workflow that notifies `AIcrowd/whest-docs` when docs-owned files change on `main`.

## Why
This keeps the current `whest` GitHub Pages site untouched while allowing the new unified docs repo to rebuild from source-repo updates.

## Validation
- `node --test .github/docs-dispatch.workflow.test.mjs`
- Local push gate was allowed to run through the repo's existing pre-push checks before publishing the branch
