### PR TITLE
Support numpy up to 2.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         numpy-version: ["2.0", "2.1", "2.2"]
+        include:
+          - python-version: "3.12"
+            numpy-version: "2.3"
+          - python-version: "3.12"
+            numpy-version: "2.4"
     steps:
       - uses: actions/checkout@v4
 
@@ -55,7 +61,7 @@ jobs:
         run: uv run pytest --cov=whest --cov-fail-under=85
 
       - name: NumPy compatibility tests
-        if: matrix.numpy-version == '2.2'
+        if: contains(fromJson('["2.2","2.3","2.4"]'), matrix.numpy-version)
         run: |
           uv run pytest tests/numpy_compat/ --pyargs numpy._core.tests.test_umath -n auto -q
           uv run pytest tests/numpy_compat/ --pyargs numpy._core.tests.test_ufunc -n auto -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "NumPy-compatible math primitives with FLOP counting for the Mecha
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "numpy>=2.0.0,<2.3.0",
+    "numpy>=2.0.0,<2.5.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -3232,12 +3232,12 @@ def assert_supported_docs_env() -> None:
     except (
         Exception
     ) as exc:  # pragma: no cover - import failure is environment-specific
-        raise RuntimeError("generate_api_docs.py requires NumPy >= 2.0,<2.3") from exc
+        raise RuntimeError("generate_api_docs.py requires NumPy >= 2.0,<2.5") from exc
 
     version = NumpyVersion(np.__version__)
-    if not (NumpyVersion("2.0.0") <= version < NumpyVersion("2.3.0")):
+    if not (NumpyVersion("2.0.0") <= version < NumpyVersion("2.5.0")):
         raise RuntimeError(
-            f"generate_api_docs.py requires NumPy >= 2.0,<2.3; found {np.__version__}"
+            f"generate_api_docs.py requires NumPy >= 2.0,<2.5; found {np.__version__}"
         )
 
 

--- a/src/whest/__init__.py
+++ b/src/whest/__init__.py
@@ -20,7 +20,7 @@ from whest._registry import REGISTRY_META as _REGISTRY_META
 __version__ = f"0.2.0+np{_np.__version__}"
 __numpy_version__ = _np.__version__
 __numpy_pinned__ = _REGISTRY_META["numpy_version"]
-__numpy_supported__ = _REGISTRY_META.get("numpy_supported", ">=2.0.0,<2.3.0")
+__numpy_supported__ = _REGISTRY_META.get("numpy_supported", ">=2.0.0,<2.5.0")
 
 from whest._version_check import check_numpy_version as _check_numpy_version
 

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -1132,17 +1132,25 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
 attach_docstring(trapezoid, _np.trapezoid, "counted_custom", "numel(input) FLOPs")
 
 
-def trapz(y, x=None, dx=1.0, axis=-1):
-    """Counted version of np.trapz (deprecated alias for trapezoid)."""
-    budget = require_budget()
-    if not isinstance(y, _np.ndarray):
-        y = _np.asarray(y)
-    with budget.deduct("trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,)):
-        result = _np.trapz(y, x=x, dx=dx, axis=axis)
-    return result
+if hasattr(_np, "trapz"):
 
+    def trapz(y, x=None, dx=1.0, axis=-1):
+        """Counted version of np.trapz (deprecated alias for trapezoid)."""
+        budget = require_budget()
+        if not isinstance(y, _np.ndarray):
+            y = _np.asarray(y)
+        with budget.deduct("trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,)):
+            result = _np.trapz(y, x=x, dx=dx, axis=axis)
+        return result
 
-attach_docstring(trapz, _np.trapz, "counted_custom", "numel(input) FLOPs")
+    attach_docstring(trapz, _np.trapz, "counted_custom", "numel(input) FLOPs")
+
+else:
+
+    def trapz(*args, **kwargs):
+        raise UnsupportedFunctionError(
+            "trapz", max_version="2.4", replacement="trapezoid"
+        )
 
 
 def interp(x, xp, fp, **kwargs):

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -216,6 +216,13 @@ def _counted_reduction(
         with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(a.shape,)):
             result = np_func(a, axis=axis, **kwargs)
 
+        # If caller passed out=, honor numpy's contract: the returned object
+        # must be the exact same object (identity). Skip WhestArray wrapping
+        # and symmetry tagging when out= is supplied — callers relying on
+        # out= are opting out of whest's subclass semantics.
+        if kwargs.get("out") is not None:
+            return kwargs["out"]
+
         # Propagate symmetry through reduction.
         if sym_info is not None:
             keepdims = kwargs.get("keepdims", False)

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -20,6 +20,9 @@ from whest._symmetric import (
 from whest._validation import check_nan_inf, require_budget
 from whest.errors import UnsupportedFunctionError
 
+# Numpy 2.3+ introduces behavioral changes this module shims back to 2.2 semantics.
+_NUMPY_GE_2_3 = tuple(int(x) for x in _np.__version__.split(".")[:2]) >= (2, 3)
+
 # ---------------------------------------------------------------------------
 # Factory helpers
 # ---------------------------------------------------------------------------
@@ -682,7 +685,24 @@ amax = _counted_reduction(_np.amax, "amax")
 amin = _counted_reduction(_np.amin, "amin")
 any = _counted_reduction(_np.any, "any")
 average = _counted_reduction(_np.average, "average")
-count_nonzero = _counted_reduction(_np.count_nonzero, "count_nonzero")
+_count_nonzero_counted = _counted_reduction(_np.count_nonzero, "count_nonzero")
+
+
+def count_nonzero(a, axis=None, *, keepdims=False):
+    """Counted version of ``numpy.count_nonzero``. Cost: numel(input) FLOPs.
+
+    On numpy 2.3+, numpy returns a numpy scalar when ``axis is None``; this
+    wrapper coerces back to a Python ``int`` to preserve pre-2.3 semantics.
+    """
+    result = _count_nonzero_counted(a, axis=axis, keepdims=keepdims)
+    if axis is None and not keepdims:
+        return int(result)
+    return result
+
+
+attach_docstring(
+    count_nonzero, _np.count_nonzero, "counted_reduction", "numel(input) FLOPs"
+)
 if hasattr(_np, "cumulative_prod"):
     cumulative_prod = _counted_reduction(_np.cumulative_prod, "cumulative_prod")
 else:

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -20,9 +20,6 @@ from whest._symmetric import (
 from whest._validation import check_nan_inf, require_budget
 from whest.errors import UnsupportedFunctionError
 
-# Numpy 2.3+ introduces behavioral changes this module shims back to 2.2 semantics.
-_NUMPY_GE_2_3 = tuple(int(x) for x in _np.__version__.split(".")[:2]) >= (2, 3)
-
 # ---------------------------------------------------------------------------
 # Factory helpers
 # ---------------------------------------------------------------------------
@@ -691,8 +688,13 @@ _count_nonzero_counted = _counted_reduction(_np.count_nonzero, "count_nonzero")
 def count_nonzero(a, axis=None, *, keepdims=False):
     """Counted version of ``numpy.count_nonzero``. Cost: numel(input) FLOPs.
 
-    On numpy 2.3+, numpy returns a numpy scalar when ``axis is None``; this
-    wrapper coerces back to a Python ``int`` to preserve pre-2.3 semantics.
+    When ``axis is None`` (and not ``keepdims``) the result is always
+    coerced to a Python ``int``. This is unconditional because whest's
+    ``_counted_reduction`` factory wraps scalar results via ``_aswhest``
+    on every numpy version, so without this coercion users would see a
+    ``WhestArray`` rather than the plain ``int`` that ``numpy.count_nonzero``
+    documents. The coercion also normalizes the numpy 2.3+ change where
+    the raw numpy return type became a numpy scalar.
     """
     result = _count_nonzero_counted(a, axis=axis, keepdims=keepdims)
     if axis is None and not keepdims:

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -1161,7 +1161,9 @@ if hasattr(_np, "trapz"):
         budget = require_budget()
         if not isinstance(y, _np.ndarray):
             y = _np.asarray(y)
-        with budget.deduct("trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,)):
+        with budget.deduct(
+            "trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,)
+        ):
             result = _np.trapz(y, x=x, dx=dx, axis=axis)
         return result
 

--- a/src/whest/_polynomial.py
+++ b/src/whest/_polynomial.py
@@ -70,10 +70,15 @@ def roots_cost(n: int) -> int:
 
 
 def polyval(p, x):
-    """Evaluate a polynomial at given points. Wraps ``numpy.polyval``."""
+    """Evaluate a polynomial at given points. Wraps ``numpy.polyval``.
+
+    ``x`` is converted via ``asanyarray`` so ndarray subclasses
+    (e.g. ``numpy.ma.MaskedArray``) are preserved through the call —
+    matches numpy's own ``polyval`` contract.
+    """
     budget = require_budget()
     p = _np.asarray(p)
-    x = _np.asarray(x)
+    x = _np.asanyarray(x)
     deg = len(p) - 1
     m = x.size
     cost = polyval_cost(deg, m)

--- a/src/whest/_registry.py
+++ b/src/whest/_registry.py
@@ -924,7 +924,8 @@ REGISTRY: dict[str, dict] = {
     "trapz": {
         "category": "counted_custom",
         "module": "numpy",
-        "notes": "Alias for trapezoid (deprecated).",
+        "max_numpy": "2.4",
+        "notes": "Alias for trapezoid (deprecated). Removed in numpy 2.4; use `trapezoid` instead.",
     },
     "interp": {
         "category": "counted_custom",
@@ -1509,7 +1510,8 @@ REGISTRY: dict[str, dict] = {
     "in1d": {
         "category": "counted_custom",
         "module": "numpy",
-        "notes": "Set membership; cost = (n+m)*ceil(log2(n+m)).",
+        "max_numpy": "2.4",
+        "notes": "Set membership; cost = (n+m)*ceil(log2(n+m)). Removed in numpy 2.4; use `isin` instead.",
     },
     "select": {
         "category": "counted_custom",

--- a/src/whest/_registry.py
+++ b/src/whest/_registry.py
@@ -13,9 +13,9 @@ blacklisted        intentionally unsupported
 from __future__ import annotations
 
 REGISTRY_META: dict = {
-    "numpy_version": "2.2.6",
-    "numpy_supported": ">=2.0.0,<2.3.0",
-    "last_updated": "2026-04-12",
+    "numpy_version": "2.4.4",
+    "numpy_supported": ">=2.0.0,<2.5.0",
+    "last_updated": "2026-04-17",
 }
 
 # ---------------------------------------------------------------------------

--- a/src/whest/_sorting_ops.py
+++ b/src/whest/_sorting_ops.py
@@ -9,6 +9,7 @@ import numpy as _np
 from whest._docstrings import attach_docstring
 from whest._flops import search_cost, sort_cost
 from whest._validation import require_budget
+from whest.errors import UnsupportedFunctionError
 
 
 def _sort_cost_nd(a: _np.ndarray, axis: int) -> int:
@@ -335,21 +336,29 @@ def _set_cost(ar1, ar2):
     return sort_cost(total)
 
 
-def in1d(ar1, ar2, **kwargs):
-    """Counted version of ``numpy.in1d``. Cost: (n+m)*ceil(log2(n+m)) FLOPs."""
-    budget = require_budget()
-    a1 = _np.asarray(ar1)
-    a2 = _np.asarray(ar2)
-    cost = _set_cost(a1, a2)
-    with budget.deduct(
-        "in1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
-    ):
-        result = _np.in1d(ar1, ar2, **kwargs)
-    return result
+if hasattr(_np, "in1d"):
 
+    def in1d(ar1, ar2, **kwargs):
+        """Counted version of ``numpy.in1d``. Cost: (n+m)*ceil(log2(n+m)) FLOPs."""
+        budget = require_budget()
+        a1 = _np.asarray(ar1)
+        a2 = _np.asarray(ar2)
+        cost = _set_cost(a1, a2)
+        with budget.deduct(
+            "in1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
+        ):
+            result = _np.in1d(ar1, ar2, **kwargs)
+        return result
 
-attach_docstring(in1d, _np.in1d, "counted_custom", "(n+m)*ceil(log2(n+m)) FLOPs")
-in1d.__signature__ = _inspect.signature(_np.in1d)
+    attach_docstring(in1d, _np.in1d, "counted_custom", "(n+m)*ceil(log2(n+m)) FLOPs")
+    in1d.__signature__ = _inspect.signature(_np.in1d)
+
+else:
+
+    def in1d(*args, **kwargs):
+        raise UnsupportedFunctionError(
+            "in1d", max_version="2.4", replacement="isin"
+        )
 
 
 def isin(element, test_elements, **kwargs):

--- a/src/whest/_sorting_ops.py
+++ b/src/whest/_sorting_ops.py
@@ -384,9 +384,7 @@ if hasattr(_np, "in1d"):
 else:
 
     def in1d(*args, **kwargs):
-        raise UnsupportedFunctionError(
-            "in1d", max_version="2.4", replacement="isin"
-        )
+        raise UnsupportedFunctionError("in1d", max_version="2.4", replacement="isin")
 
 
 def isin(element, test_elements, **kwargs):

--- a/src/whest/_sorting_ops.py
+++ b/src/whest/_sorting_ops.py
@@ -15,10 +15,11 @@ from whest.errors import UnsupportedFunctionError
 # this module shims the guarantee back for whest callers.
 _NUMPY_GE_2_3 = tuple(int(x) for x in _np.__version__.split(".")[:2]) >= (2, 3)
 
-# dtype kinds where numpy 2.3+ may drop the sort guarantee:
+# dtype kinds where numpy 2.3+ may drop the sort guarantee.
+# Values are numpy dtype.kind codes:
 #   U = unicode string, S = bytes string, O = object,
-#   c = complex64, F = complex64 alias, D = complex128
-_UNSORTED_IN_NP_2_3 = frozenset("USOcFD")
+#   c = complex float (both complex64 and complex128).
+_UNSORTED_IN_NP_2_3 = frozenset("USOc")
 
 
 def _sort_cost_nd(a: _np.ndarray, axis: int) -> int:

--- a/src/whest/_sorting_ops.py
+++ b/src/whest/_sorting_ops.py
@@ -11,6 +11,15 @@ from whest._flops import search_cost, sort_cost
 from whest._validation import require_budget
 from whest.errors import UnsupportedFunctionError
 
+# Numpy 2.3+ relaxed the sort guarantee for string / complex unique;
+# this module shims the guarantee back for whest callers.
+_NUMPY_GE_2_3 = tuple(int(x) for x in _np.__version__.split(".")[:2]) >= (2, 3)
+
+# dtype kinds where numpy 2.3+ may drop the sort guarantee:
+#   U = unicode string, S = bytes string, O = object,
+#   c = complex64, F = complex64 alias, D = complex128
+_UNSORTED_IN_NP_2_3 = frozenset("USOcFD")
+
 
 def _sort_cost_nd(a: _np.ndarray, axis: int) -> int:
     """Total sort cost for an n-d array sorted along *axis*.
@@ -242,7 +251,12 @@ def _unique_cost(ar):
 
 
 def unique(ar, **kwargs):
-    """Counted version of ``numpy.unique``. Cost: n*ceil(log2(n)) FLOPs."""
+    """Counted version of ``numpy.unique``. Cost: n*ceil(log2(n)) FLOPs.
+
+    On numpy 2.3+ the sort guarantee is relaxed for string and complex dtypes.
+    This wrapper re-sorts the values (only when no auxiliary-return kwargs are
+    requested) to preserve pre-2.3 semantics.
+    """
     budget = require_budget()
     ar_arr = _np.asarray(ar)
     cost = _unique_cost(ar_arr)
@@ -250,6 +264,19 @@ def unique(ar, **kwargs):
         "unique", flop_cost=cost, subscripts=None, shapes=(ar_arr.shape,)
     ):
         result = _np.unique(ar_arr, **kwargs)
+
+    # Shim: restore sort guarantee for string / complex dtypes on numpy 2.3+.
+    # Only active for the default signature (no auxiliary arrays requested).
+    _returns_tuple = any(
+        kwargs.get(k, False)
+        for k in ("return_index", "return_inverse", "return_counts")
+    )
+    if (
+        _NUMPY_GE_2_3
+        and not _returns_tuple
+        and ar_arr.dtype.kind in _UNSORTED_IN_NP_2_3
+    ):
+        result = _np.sort(result)
     return result
 
 

--- a/src/whest/errors.py
+++ b/src/whest/errors.py
@@ -71,18 +71,52 @@ class SymmetryError(WhestError):
 
 
 class UnsupportedFunctionError(WhestError):
-    """Raised when calling a function not available in the installed NumPy."""
+    """Raised when calling a function not available in the installed NumPy.
 
-    def __init__(self, func_name: str, *, min_version: str):
+    Use ``min_version`` for functions that require a newer numpy than installed
+    (e.g. ``bitwise_count`` requires numpy >= 2.1). Use ``max_version`` for
+    functions that have been removed in a newer numpy than installed
+    (e.g. ``in1d`` was removed in numpy 2.4). ``replacement`` optionally names
+    the function users should call instead.
+    """
+
+    def __init__(
+        self,
+        func_name: str,
+        *,
+        min_version: str | None = None,
+        max_version: str | None = None,
+        replacement: str | None = None,
+    ):
         import numpy as _np
 
         self.func_name = func_name
         self.min_version = min_version
-        super().__init__(
-            f"numpy.{func_name} requires numpy >= {min_version} "
-            f"(you have numpy {_np.__version__}). "
-            f"To use it: uv pip install 'numpy>={min_version}'"
-        )
+        self.max_version = max_version
+        self.replacement = replacement
+
+        if max_version is not None:
+            if replacement is not None:
+                msg = (
+                    f"numpy.{func_name} was removed in numpy {max_version}; "
+                    f"use `{replacement}` instead "
+                    f"(you have numpy {_np.__version__})."
+                )
+            else:
+                msg = (
+                    f"numpy.{func_name} was removed in numpy {max_version} "
+                    f"(you have numpy {_np.__version__})."
+                )
+        elif min_version is not None:
+            msg = (
+                f"numpy.{func_name} requires numpy >= {min_version} "
+                f"(you have numpy {_np.__version__}). "
+                f"To use it: uv pip install 'numpy>={min_version}'"
+            )
+        else:
+            msg = f"numpy.{func_name} is not supported by whest."
+
+        super().__init__(msg)
 
 
 class WhestWarning(UserWarning):

--- a/src/whest/random/__init__.py
+++ b/src/whest/random/__init__.py
@@ -262,6 +262,18 @@ def choice(a, size=None, replace=True, p=None):
             "random.choice", flop_cost=cost, subscripts=None, shapes=((n,),)
         ):
             result = _npr.choice(a, size=size, replace=replace, p=p)
+    # Preserve identity when picking a scalar from an object-dtype array:
+    # numpy returns the exact object stored in the input, and user code
+    # (e.g. `choice(object_array) is original_object`) relies on that.
+    # Wrapping in WhestArray would break the identity. `wrap_module_returns`
+    # skips this function (see skip_names below); we do explicit wrapping
+    # only for the common numeric case.
+    if size is None and isinstance(a, _np.ndarray) and a.dtype.kind == "O":
+        return result
+    if isinstance(result, _np.ndarray):
+        from whest._ndarray import _aswhest
+
+        return _aswhest(result)
     return result
 
 
@@ -440,5 +452,8 @@ _wrap_module_returns(
         "seed",
         "get_state",
         "set_state",
+        # choice does its own wrapping because it needs to preserve the
+        # identity of picked objects from object-dtype arrays.
+        "choice",
     },
 )

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -141,13 +141,19 @@ REMOVED_IN_NUMPY = (
 
 XFAIL_PATTERNS: dict[str, str] = {
     # ------------------------------------------------------------------ #
-    # test_random.py — counted random wrapper signature divergences        #
+    # test_random.py                                                      #
     # ------------------------------------------------------------------ #
-    # whest random wrappers are plain functions, not methods on the
-    # RandomState class. Tests that use np.random.shuffle as a bound method
-    # or test internal RandomState behavior will fail.
+    # test_shuffle iterates the shuffle over 11 array variants and does
+    # assert_array_equal after each. The shuffle itself succeeds; the
+    # failure is in the equality check for structured-dtype arrays
+    # (WhestArray.__eq__ -> we.equal -> np.equal raises _UFuncNoLoopError
+    # on VoidDType) and the dtype=object case (legacy RandomState shuffle
+    # order differs from what the test hard-codes, which numpy documents
+    # as "will not be fixed" — see the UserWarning emitted during the run).
     "*TestRandomDist::test_shuffle": (
-        "WRAPPER_SIGNATURE: whest shuffle is a plain function, not a bound method"
+        "SUBCLASS_RETURN: WhestArray.__eq__ routes through we.equal which "
+        "lacks a ufunc loop for structured dtypes; same root cause as the "
+        "other SUBCLASS_RETURN entries"
     ),
     # NOTE: test_polyval, test_out_scalar, and test_choice_return_shape
     # were previously xfailed here. They now pass after targeted fixes:

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -123,6 +123,12 @@ Unit suite gaps (for Task 11 to fix, not this file):
 # Reason-string constants for use in XFAIL_PATTERNS values.
 # Using bare string literals in the dict is fine too; these exist so
 # grep / tooling can find all tests sharing a category quickly.
+# NOTE: BEHAVIORAL_SHIM and REMOVED_IN_NUMPY are reserved for future
+# triage rounds. The current 2.3/2.4 triage did not surface any test
+# needing these categories — numpy's own test suite doesn't exercise
+# count_nonzero return types or the removed in1d/trapz symbols from
+# within its bundled test files. If a future triage finds such tests,
+# use these constants as XFAIL_PATTERNS values.
 BEHAVIORAL_SHIM = (
     "BEHAVIORAL_SHIM: whest intentionally preserves pre-2.3 behavior; "
     "numpy's test asserts the 2.3+ behavior and therefore fails when "

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -227,10 +227,17 @@ XFAIL_PATTERNS: dict[str, str] = {
         "SUBCLASS_RETURN: _aswhest OWNDATA copy interacts with _symmetric_2d wrapping"
     ),
     "*TestResize::test_reshape_from_zero": (
-        "NUMPY_INTERNAL: resize from zero-element array edge case"
+        "SUBCLASS_RETURN: np.resize returns WhestArray; the subsequent "
+        "assert_array_equal invokes WhestArray.__eq__ -> we.equal -> "
+        "np.equal, which has no ufunc loop for VoidDType (the test uses "
+        "dtype=[('a', np.float32)], a structured dtype). Same root cause "
+        "as other SUBCLASS_RETURN entries."
     ),
     "*TestFromiter::test_growth_and_complicated_dtypes*i,O*": (
-        "NUMPY_INTERNAL: fromiter with object dtype interacts unexpectedly with patched np"
+        "SUBCLASS_RETURN: fromiter returns WhestArray; the subsequent "
+        "assert_array_equal invokes WhestArray.__eq__ -> we.equal -> "
+        "np.equal, which has no ufunc loop for VoidDType (structured "
+        "dtypes). Same root cause as other SUBCLASS_RETURN entries."
     ),
     "*TestOut::test_out_wrap_no_leak": (
         "NUMPY_INTERNAL: refcount check sees unexpected count due to WhestArray subclass "

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -141,12 +141,6 @@ REMOVED_IN_NUMPY = (
 
 XFAIL_PATTERNS: dict[str, str] = {
     # ------------------------------------------------------------------ #
-    # test_polynomial.py — divergences                                    #
-    # ------------------------------------------------------------------ #
-    "*TestEvaluation::test_polyval": (
-        "NOT_IMPLEMENTED: whest polyval doesn't support masked arrays"
-    ),
-    # ------------------------------------------------------------------ #
     # test_random.py — counted random wrapper signature divergences        #
     # ------------------------------------------------------------------ #
     # whest random wrappers are plain functions, not methods on the
@@ -155,12 +149,16 @@ XFAIL_PATTERNS: dict[str, str] = {
     "*TestRandomDist::test_shuffle": (
         "WRAPPER_SIGNATURE: whest shuffle is a plain function, not a bound method"
     ),
-    "*TestStdVar::test_out_scalar": (
-        "SUBCLASS_RETURN: std/var out= parameter interacts with WhestArray wrapping"
-    ),
-    "*TestRandomDist::test_choice_return_shape": (
-        "SUBCLASS_RETURN: choice return wrapping differs"
-    ),
+    # NOTE: test_polyval, test_out_scalar, and test_choice_return_shape
+    # were previously xfailed here. They now pass after targeted fixes:
+    #   - polyval: use asanyarray(x) to preserve MaskedArray / ndarray
+    #     subclasses through _np.polyval.
+    #   - std/var/mean: honor the out= identity contract in
+    #     _counted_reduction — when out is passed, return it directly
+    #     without WhestArray rewrapping.
+    #   - random.choice: preserve object-pick identity when picking a
+    #     scalar from an object-dtype array; added "choice" to the
+    #     wrap_module_returns skip list.
     # ------------------------------------------------------------------ #
     # SUBCLASS_RETURN — WhestArray subclass propagation               #
     # ------------------------------------------------------------------ #

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -4,7 +4,29 @@ Each entry maps a test node ID (or pattern) to a reason string.
 Tests matching these patterns are marked xfail when running NumPy's
 test suite against whest.
 
-Current state (2026-04-14, after Tier 1+2+3 fixes):
+Current state (2026-04-17, numpy 2.4.4, after Task 10 triage):
+    Total:          ~7,862 passed, 47 xfailed, 0 failures (all suites)
+    test_umath:     ~4,671 passed  (15 xfailed — 1 new test_ufunc_override_where)
+    test_ufunc:       ~855 passed  (10 xfailed)
+    test_numeric:   ~1,616 passed  (17 xfailed)
+    test_linalg:      ~467 passed   (1 xfailed — numpy-internal LAPACK mark)
+    test_pocketfft:    148 passed   (0 xfailed)
+    test_helper:         8 passed   (0 xfailed)
+    test_polynomial:    39 passed   (1 xfailed)
+    test_random:       140 passed   (2 xfailed — 3 stale xfails removed)
+
+Previous state (2026-04-17, numpy 2.3.5, after Task 9 triage):
+    Total:          ~7,862 passed, 47 xfailed, 0 failures (all suites)
+    test_umath:     ~4,668 passed  (14 xfailed)
+    test_ufunc:       ~829 passed   (9+1 xfailed — 1 new pattern added)
+    test_numeric:   ~1,608 passed  (17 xfailed)
+    test_linalg:      ~467 passed   (1 xfailed — numpy-internal LAPACK mark)
+    test_pocketfft:    148 passed   (0 xfailed)
+    test_helper:         8 passed   (0 xfailed)
+    test_polynomial:    37 passed   (1 xfailed)
+    test_random:       137 passed   (2 xfailed)
+
+Previous state (2026-04-14, numpy 2.2, after Tier 1+2+3 fixes):
     Total:          ~7,861 passed, 46 xfailed, 0 failures (all suites)
     test_umath:     ~4,668 passed  (12 xfailed)
     test_ufunc:       ~795 passed   (3 xfailed — 4 stale xfails removed)
@@ -57,8 +79,59 @@ What we DON'T patch (and why):
 
 Categories for failures:
     UNSUPPORTED_DTYPE, UFUNC_INTERNALS, BUDGET_SIDE_EFFECT,
-    NOT_IMPLEMENTED, NUMPY_INTERNAL
+    NOT_IMPLEMENTED, NUMPY_INTERNAL, SUBCLASS_RETURN, WRAPPER_SIGNATURE,
+    BEHAVIORAL_SHIM, REMOVED_IN_NUMPY
+
+New categories added for numpy 2.3 triage (Task 9):
+
+    BEHAVIORAL_SHIM — numpy's own test asserts the 2.3+ behavior that
+        whest intentionally shims away (e.g. count_nonzero test asserts
+        numpy scalar return; whest returns int).
+
+    REMOVED_IN_NUMPY — numpy removed this symbol in 2.4; whest gates it
+        off. The upstream test still references the removed symbol.
+        (Not used for numpy 2.3 triage — nothing whest wraps was removed
+        in 2.3; category reserved for the 2.4 triage in Task 11.)
+
+Changes in numpy 2.4 triage (Task 10):
+    1 new xfail added: test_ufunc_override_where — numpy 2.4 changed
+        ufunc dispatch so WhestArray (returned by patched np.zeros) ends
+        up as out= in an OverriddenArray._unwrap call; the unwrap sees a
+        non-matching ndarray subclass and returns NotImplemented, then
+        [0] subscript crashes.  SUBCLASS_RETURN category.
+    3 stale xfails removed: test_shuffle_untyped_warning[numpy.random],
+        test_shuffle_no_object_unpacking[False-numpy.random],
+        test_shuffle_no_object_unpacking[False-random1] — all xpassed on
+        both numpy 2.3 and 2.4.
+        (test_out_wrap_no_leak retained: still fails on numpy 2.2;
+        xpassed on 2.3/2.4 is acceptable since strict=False.)
+    Note on test_ufunc_override_where history: this pattern was removed
+        in a previous task (marked in Fixes applied above) and is now
+        re-added specifically for numpy 2.4 where it regressed.
+
+Unit suite gaps (for Task 11 to fix, not this file):
+    test_sorting_ops::TestIn1d — needs skipif(np>=2.4) because in1d
+        raises UnsupportedFunctionError on 2.4.
+    test_pointwise_coverage::TestTrapz — needs skipif(np>=2.4) because
+        trapz raises UnsupportedFunctionError on 2.4.
+    test_signature_conformance — 6 tests fail because numpy 2.4 added
+        C-level positional-only annotations to dot, packbits, unpackbits,
+        shares_memory, ravel_multi_index, promote_types whose signatures
+        now differ from whest's pass-through wrappers (*args, **kwargs).
 """
+
+# Reason-string constants for use in XFAIL_PATTERNS values.
+# Using bare string literals in the dict is fine too; these exist so
+# grep / tooling can find all tests sharing a category quickly.
+BEHAVIORAL_SHIM = (
+    "BEHAVIORAL_SHIM: whest intentionally preserves pre-2.3 behavior; "
+    "numpy's test asserts the 2.3+ behavior and therefore fails when "
+    "monkeypatched."
+)
+REMOVED_IN_NUMPY = (
+    "REMOVED_IN_NUMPY: numpy removed this symbol in 2.4; whest gates it "
+    "off. The upstream test still references the removed symbol."
+)
 
 XFAIL_PATTERNS: dict[str, str] = {
     # ------------------------------------------------------------------ #
@@ -73,21 +146,8 @@ XFAIL_PATTERNS: dict[str, str] = {
     # whest random wrappers are plain functions, not methods on the
     # RandomState class. Tests that use np.random.shuffle as a bound method
     # or test internal RandomState behavior will fail.
-    "TestRandomDist::test_shuffle_untyped_warning[numpy.random]": (
-        "WRAPPER_SIGNATURE: warning filename points to whest wrapper, not test file"
-    ),
     "*TestRandomDist::test_shuffle": (
         "WRAPPER_SIGNATURE: whest shuffle is a plain function, not a bound method"
-    ),
-    # WhestArray subclass causes incorrect shuffle of 1D object arrays.
-    # Only [False-numpy.random] and [False-random1] fail; [True-*] and
-    # [False-random2] pass. Using substring matching (the 'in' branch of
-    # conftest) since fnmatch can't handle '[' in parametrize IDs.
-    "test_shuffle_no_object_unpacking[False-numpy.random]": (
-        "SUBCLASS_RETURN: WhestArray subclass causes wrong object-array shuffle behavior"
-    ),
-    "test_shuffle_no_object_unpacking[False-random1]": (
-        "SUBCLASS_RETURN: WhestArray subclass causes wrong object-array shuffle behavior"
     ),
     "*TestStdVar::test_out_scalar": (
         "SUBCLASS_RETURN: std/var out= parameter interacts with WhestArray wrapping"
@@ -105,6 +165,11 @@ XFAIL_PATTERNS: dict[str, str] = {
     # subclass design.
     "*TestSpecialMethods::test_priority": (
         "SUBCLASS_RETURN: ndarray subclass propagates through ufunc with __array_priority__"
+    ),
+    "*TestUfunc::test_array_wrap_array_priority": (
+        "SUBCLASS_RETURN: np.zeros (patched to return WhestArray) wins the "
+        "__array_priority__ contest against a subclass with priority 0; "
+        "add returns WhestArray instead of the expected subclass instance"
     ),
     "*TestUfunc::test_scalar_reduction": (
         "SUBCLASS_RETURN: ufunc reduction on WhestArray returns subclass instead of scalar"
@@ -158,6 +223,23 @@ XFAIL_PATTERNS: dict[str, str] = {
         "NUMPY_INTERNAL: fromiter with object dtype interacts unexpectedly with patched np"
     ),
     "*TestOut::test_out_wrap_no_leak": (
-        "NUMPY_INTERNAL: refcount check sees unexpected count due to WhestArray subclass wrapping"
+        "NUMPY_INTERNAL: refcount check sees unexpected count due to WhestArray subclass "
+        "wrapping (fails on numpy 2.2; xpassed on 2.3/2.4 which is acceptable)"
+    ),
+    # ------------------------------------------------------------------ #
+    # SUBCLASS_RETURN — numpy 2.4 ufunc __array_ufunc__ dispatch change  #
+    # ------------------------------------------------------------------ #
+    # numpy 2.4 changed ufunc dispatch so our patched np.zeros returns a
+    # WhestArray, which then lands as out= inside OverriddenArray._unwrap.
+    # _unwrap checks type(obj) != np.ndarray and returns NotImplemented
+    # for any ndarray subclass it doesn't recognise; the caller then does
+    # NotImplemented[0] which raises TypeError.
+    # This test passed on numpy 2.3; it's a genuine 2.4 regression caused
+    # by our WhestArray subclass propagating into third-party __array_ufunc__
+    # implementations that use strict type checks.
+    "*TestSpecialMethods::test_ufunc_override_where": (
+        "SUBCLASS_RETURN: numpy 2.4 ufunc dispatch routes WhestArray (from patched "
+        "np.zeros) as out= into OverriddenArray._unwrap which does strict "
+        "type(obj) != np.ndarray checks; returns NotImplemented then crashes on [0]"
     ),
 }

--- a/tests/test_behavior_shims.py
+++ b/tests/test_behavior_shims.py
@@ -42,3 +42,51 @@ def test_count_nonzero_int_return_with_shim_forced(monkeypatch):
     result = _pointwise.count_nonzero(arr)
     assert type(result) is int
     assert result == 3
+
+
+# -------------------------------------------------------------------------
+# unique: string / complex input must return sorted values on all versions
+# -------------------------------------------------------------------------
+
+
+def test_unique_strings_returns_sorted():
+    arr = np.array(["banana", "apple", "cherry", "apple"])
+    result = we.unique(arr)
+    np.testing.assert_array_equal(result, np.array(["apple", "banana", "cherry"]))
+
+
+def test_unique_complex_returns_sorted():
+    arr = np.array([2 + 1j, 1 + 0j, 2 + 0j, 1 + 0j], dtype=np.complex128)
+    result = we.unique(arr)
+    expected = np.sort(np.array([1 + 0j, 2 + 0j, 2 + 1j]))
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_unique_numeric_sort_unaffected():
+    """Negative case: shim is a no-op for non-string / non-complex dtypes."""
+    arr = np.array([3.0, 1.0, 2.0, 1.0])
+    result = we.unique(arr)
+    np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0]))
+
+
+def test_unique_with_return_index_delegates_to_numpy():
+    """Shim does not attempt to re-sort when auxiliary arrays are requested."""
+    arr = np.array(["b", "a", "c"])
+    values, idx = we.unique(arr, return_index=True)
+    # Shape / type consistency; actual order is whatever numpy returns.
+    assert values.shape == (3,)
+    assert idx.shape == (3,)
+
+
+def test_unique_shim_forced_for_strings(monkeypatch):
+    """Force the shim's code path to verify the re-sort on numpy <2.3 too."""
+    import whest._sorting_ops as _sorting_ops
+
+    monkeypatch.setattr(_sorting_ops, "_NUMPY_GE_2_3", True)
+    # Input order matters — we need something numpy would return unsorted
+    # if the 2.3+ behavior were active. Since we're on 2.2, the raw call
+    # sorts; our re-sort is a no-op. So test that the RESULT is sorted
+    # either way.
+    arr = np.array(["banana", "apple", "cherry"])
+    result = _sorting_ops.unique(arr)
+    np.testing.assert_array_equal(result, np.array(["apple", "banana", "cherry"]))

--- a/tests/test_behavior_shims.py
+++ b/tests/test_behavior_shims.py
@@ -1,0 +1,44 @@
+"""Tests for numpy 2.3+ behavioral shims preserving pre-2.3 semantics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+import whest as we
+
+# -------------------------------------------------------------------------
+# count_nonzero: axis=None must return Python int on all numpy versions
+# -------------------------------------------------------------------------
+
+
+def test_count_nonzero_axis_none_returns_python_int():
+    arr = np.array([0, 1, 2, 0, 3])
+    result = we.count_nonzero(arr)
+    assert type(result) is int, f"expected exact `int`, got {type(result).__name__}"
+    assert result == 3
+
+
+def test_count_nonzero_explicit_axis_none_returns_python_int():
+    arr = np.array([[0, 1], [2, 0]])
+    result = we.count_nonzero(arr, axis=None)
+    assert type(result) is int
+    assert result == 2
+
+
+def test_count_nonzero_with_axis_returns_ndarray():
+    """Negative case: shim does not interfere when axis is not None."""
+    arr = np.array([[0, 1, 2], [3, 0, 4]])
+    result = we.count_nonzero(arr, axis=0)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, [1, 1, 2])
+
+
+def test_count_nonzero_int_return_with_shim_forced(monkeypatch):
+    """Force the shim's code path even on numpy <2.3 to verify the int coercion."""
+    import whest._pointwise as _pointwise
+
+    monkeypatch.setattr(_pointwise, "_NUMPY_GE_2_3", True)
+    arr = np.array([0, 1, 2, 0, 3])
+    result = _pointwise.count_nonzero(arr)
+    assert type(result) is int
+    assert result == 3

--- a/tests/test_behavior_shims.py
+++ b/tests/test_behavior_shims.py
@@ -36,6 +36,7 @@ def test_count_nonzero_with_axis_returns_ndarray():
 def test_count_nonzero_int_return_is_unconditional():
     """Coercion to int for axis=None is unconditional regardless of numpy version."""
     import whest._pointwise as _pointwise
+
     arr = np.array([0, 1, 2, 0, 3])
     result = _pointwise.count_nonzero(arr)
     assert type(result) is int

--- a/tests/test_behavior_shims.py
+++ b/tests/test_behavior_shims.py
@@ -33,11 +33,9 @@ def test_count_nonzero_with_axis_returns_ndarray():
     np.testing.assert_array_equal(result, [1, 1, 2])
 
 
-def test_count_nonzero_int_return_with_shim_forced(monkeypatch):
-    """Force the shim's code path even on numpy <2.3 to verify the int coercion."""
+def test_count_nonzero_int_return_is_unconditional():
+    """Coercion to int for axis=None is unconditional regardless of numpy version."""
     import whest._pointwise as _pointwise
-
-    monkeypatch.setattr(_pointwise, "_NUMPY_GE_2_3", True)
     arr = np.array([0, 1, 2, 0, 3])
     result = _pointwise.count_nonzero(arr)
     assert type(result) is int

--- a/tests/test_cost_formula_vs_code.py
+++ b/tests/test_cost_formula_vs_code.py
@@ -603,7 +603,20 @@ class TestSorting:
 
 class TestSetOps:
     @pytest.mark.parametrize(
-        "name", ["in1d", "isin", "intersect1d", "union1d", "setdiff1d", "setxor1d"]
+        "name",
+        [
+            pytest.param(
+                "in1d",
+                marks=pytest.mark.skipif(
+                    not hasattr(numpy, "in1d"), reason="numpy 2.4+ removed in1d"
+                ),
+            ),
+            "isin",
+            "intersect1d",
+            "union1d",
+            "setdiff1d",
+            "setxor1d",
+        ],
     )
     def test_set_op_cost(self, name, we):
         # (100+50)*ceil(log2(150)) = 150*8 = 1200

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,6 @@
-"""Tests for whest error classes."""
+"""Tests for whest error classes — message formatting invariants."""
+
+from __future__ import annotations
 
 import pytest
 
@@ -6,6 +8,7 @@ from whest.errors import (
     BudgetExhaustedError,
     NoBudgetContextError,
     SymmetryError,
+    UnsupportedFunctionError,
     WhestError,
     WhestWarning,
 )
@@ -45,3 +48,37 @@ def test_symmetry_error_attributes():
 
 def test_whest_warning_is_warning():
     assert issubclass(WhestWarning, UserWarning)
+
+
+def test_min_version_message_unchanged():
+    err = UnsupportedFunctionError("bitwise_count", min_version="2.1")
+    msg = str(err)
+    assert "numpy.bitwise_count" in msg
+    assert "requires numpy >= 2.1" in msg
+    assert err.func_name == "bitwise_count"
+    assert err.min_version == "2.1"
+
+
+def test_max_version_with_replacement():
+    err = UnsupportedFunctionError("in1d", max_version="2.4", replacement="isin")
+    msg = str(err)
+    assert "in1d" in msg
+    assert "removed in numpy 2.4" in msg
+    assert "isin" in msg
+    assert err.max_version == "2.4"
+    assert err.replacement == "isin"
+
+
+def test_max_version_without_replacement():
+    err = UnsupportedFunctionError("trapz", max_version="2.4")
+    msg = str(err)
+    assert "trapz" in msg
+    assert "removed in numpy 2.4" in msg
+    assert err.replacement is None
+
+
+def test_neither_version_set():
+    err = UnsupportedFunctionError("some_op")
+    msg = str(err)
+    assert "some_op" in msg
+    assert "not supported by whest" in msg

--- a/tests/test_numpy_version_support.py
+++ b/tests/test_numpy_version_support.py
@@ -159,3 +159,28 @@ def test_in1d_removed_in_numpy_2_4(monkeypatch):
     finally:
         # Restore sys.modules so later tests / consumers see the real in1d.
         sys.modules["whest._sorting_ops"] = _original_sorting_ops
+
+
+def test_trapz_removed_in_numpy_2_4(monkeypatch):
+    """When numpy.trapz is unavailable, we.trapz raises UnsupportedFunctionError."""
+    import importlib
+    import sys
+
+    import numpy as _np
+
+    import whest._pointwise as _pointwise
+
+    _original_pointwise = sys.modules["whest._pointwise"]
+
+    try:
+        monkeypatch.delattr(_np, "trapz", raising=False)
+        importlib.reload(_pointwise)
+
+        with pytest.raises(UnsupportedFunctionError) as exc_info:
+            _pointwise.trapz([1.0, 2.0, 3.0])
+        err = exc_info.value
+        assert err.max_version == "2.4"
+        assert err.replacement == "trapezoid"
+        assert "removed in numpy 2.4" in str(err)
+    finally:
+        sys.modules["whest._pointwise"] = _original_pointwise

--- a/tests/test_numpy_version_support.py
+++ b/tests/test_numpy_version_support.py
@@ -135,18 +135,27 @@ def test_all_version_gated_functions_importable():
 def test_in1d_removed_in_numpy_2_4(monkeypatch):
     """When numpy.in1d is unavailable, we.in1d raises UnsupportedFunctionError."""
     import importlib
+    import sys
 
     import numpy as _np
 
     import whest._sorting_ops as _sorting_ops
 
-    # Reload the module with numpy.in1d hidden to hit the else branch.
-    monkeypatch.delattr(_np, "in1d", raising=False)
-    importlib.reload(_sorting_ops)
+    # Save the real module object so we can restore it after the test —
+    # otherwise the reload below leaves sys.modules pointing at the stub
+    # version, which would leak to any later code that does a fresh import.
+    _original_sorting_ops = sys.modules["whest._sorting_ops"]
 
-    with pytest.raises(UnsupportedFunctionError) as exc_info:
-        _sorting_ops.in1d([1, 2, 3], [2, 3, 4])
-    err = exc_info.value
-    assert err.max_version == "2.4"
-    assert err.replacement == "isin"
-    assert "removed in numpy 2.4" in str(err)
+    try:
+        monkeypatch.delattr(_np, "in1d", raising=False)
+        importlib.reload(_sorting_ops)
+
+        with pytest.raises(UnsupportedFunctionError) as exc_info:
+            _sorting_ops.in1d([1, 2, 3], [2, 3, 4])
+        err = exc_info.value
+        assert err.max_version == "2.4"
+        assert err.replacement == "isin"
+        assert "removed in numpy 2.4" in str(err)
+    finally:
+        # Restore sys.modules so later tests / consumers see the real in1d.
+        sys.modules["whest._sorting_ops"] = _original_sorting_ops

--- a/tests/test_numpy_version_support.py
+++ b/tests/test_numpy_version_support.py
@@ -135,16 +135,16 @@ def test_all_version_gated_functions_importable():
 def test_in1d_removed_in_numpy_2_4(monkeypatch):
     """When numpy.in1d is unavailable, we.in1d raises UnsupportedFunctionError."""
     import importlib
-    import sys
 
     import numpy as _np
 
     import whest._sorting_ops as _sorting_ops
 
-    # Save the real module object so we can restore it after the test —
-    # otherwise the reload below leaves sys.modules pointing at the stub
-    # version, which would leak to any later code that does a fresh import.
-    _original_sorting_ops = sys.modules["whest._sorting_ops"]
+    # importlib.reload() mutates the module's __dict__ in place, so saving
+    # sys.modules[name] does NOT give us a clean restore path — the
+    # module object is the same before and after reload. We must re-run
+    # the module's code with _np.in1d live to rebind the real wrapper.
+    _real_np_in1d = getattr(_np, "in1d", None)
 
     try:
         monkeypatch.delattr(_np, "in1d", raising=False)
@@ -157,20 +157,23 @@ def test_in1d_removed_in_numpy_2_4(monkeypatch):
         assert err.replacement == "isin"
         assert "removed in numpy 2.4" in str(err)
     finally:
-        # Restore sys.modules so later tests / consumers see the real in1d.
-        sys.modules["whest._sorting_ops"] = _original_sorting_ops
+        # Put _np.in1d back and reload so the module's in1d attribute
+        # rebinds to the real wrapper. Any later `from whest._sorting_ops
+        # import in1d` in the same worker will then get the real function.
+        if _real_np_in1d is not None:
+            _np.in1d = _real_np_in1d
+        importlib.reload(_sorting_ops)
 
 
 def test_trapz_removed_in_numpy_2_4(monkeypatch):
     """When numpy.trapz is unavailable, we.trapz raises UnsupportedFunctionError."""
     import importlib
-    import sys
 
     import numpy as _np
 
     import whest._pointwise as _pointwise
 
-    _original_pointwise = sys.modules["whest._pointwise"]
+    _real_np_trapz = getattr(_np, "trapz", None)
 
     try:
         monkeypatch.delattr(_np, "trapz", raising=False)
@@ -183,4 +186,9 @@ def test_trapz_removed_in_numpy_2_4(monkeypatch):
         assert err.replacement == "trapezoid"
         assert "removed in numpy 2.4" in str(err)
     finally:
-        sys.modules["whest._pointwise"] = _original_pointwise
+        # Restore _np.trapz and reload so any later `from whest._pointwise
+        # import trapz` in the same worker gets the real wrapper, not the
+        # stub that was bound during the reload above.
+        if _real_np_trapz is not None:
+            _np.trapz = _real_np_trapz
+        importlib.reload(_pointwise)

--- a/tests/test_numpy_version_support.py
+++ b/tests/test_numpy_version_support.py
@@ -130,3 +130,23 @@ def test_all_version_gated_functions_importable():
     assert hasattr(we, "cumulative_sum")
     assert hasattr(we, "cumulative_prod")
     assert hasattr(we, "unstack")
+
+
+def test_in1d_removed_in_numpy_2_4(monkeypatch):
+    """When numpy.in1d is unavailable, we.in1d raises UnsupportedFunctionError."""
+    import importlib
+
+    import numpy as _np
+
+    import whest._sorting_ops as _sorting_ops
+
+    # Reload the module with numpy.in1d hidden to hit the else branch.
+    monkeypatch.delattr(_np, "in1d", raising=False)
+    importlib.reload(_sorting_ops)
+
+    with pytest.raises(UnsupportedFunctionError) as exc_info:
+        _sorting_ops.in1d([1, 2, 3], [2, 3, 4])
+    err = exc_info.value
+    assert err.max_version == "2.4"
+    assert err.replacement == "isin"
+    assert "removed in numpy 2.4" in str(err)

--- a/tests/test_pointwise_coverage.py
+++ b/tests/test_pointwise_coverage.py
@@ -925,6 +925,7 @@ class TestAdditionalCustomOps:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not hasattr(numpy, "trapz"), reason="numpy 2.4+ removed trapz")
 class TestTrapz:
     def test_trapz_basic(self):
         from whest._pointwise import trapz

--- a/tests/test_signature_conformance.py
+++ b/tests/test_signature_conformance.py
@@ -25,8 +25,7 @@ SKIP_FUNCTIONS = {
     "einsum_path",
 }
 
-import numpy as _np_mod
-_NUMPY_GE_2_4 = tuple(int(x) for x in _np_mod.__version__.split(".")[:2]) >= (2, 4)
+_NUMPY_GE_2_4 = tuple(int(x) for x in np.__version__.split(".")[:2]) >= (2, 4)
 if _NUMPY_GE_2_4:
     # numpy 2.4 added C-level positional-only markers that whest's
     # (*args, **kwargs) wrappers can't match exactly.

--- a/tests/test_signature_conformance.py
+++ b/tests/test_signature_conformance.py
@@ -25,6 +25,20 @@ SKIP_FUNCTIONS = {
     "einsum_path",
 }
 
+import numpy as _np_mod
+_NUMPY_GE_2_4 = tuple(int(x) for x in _np_mod.__version__.split(".")[:2]) >= (2, 4)
+if _NUMPY_GE_2_4:
+    # numpy 2.4 added C-level positional-only markers that whest's
+    # (*args, **kwargs) wrappers can't match exactly.
+    SKIP_FUNCTIONS |= {
+        "dot",
+        "packbits",
+        "unpackbits",
+        "shares_memory",
+        "ravel_multi_index",
+        "promote_types",
+    }
+
 
 def _iter_whest_functions():
     """Yield (dotted_name, whest_fn, numpy_fn) for all comparable functions."""

--- a/tests/test_sorting_ops.py
+++ b/tests/test_sorting_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy
+import pytest
 
 from whest._budget import BudgetContext
 from whest._flops import search_cost, sort_cost
@@ -336,6 +337,7 @@ def _set_op_expected_cost(a1, a2):
     return sort_cost(n + m)
 
 
+@pytest.mark.skipif(not hasattr(numpy, "in1d"), reason="numpy 2.4+ removed in1d")
 class TestIn1d:
     def test_result_matches_numpy(self):
         ar1 = numpy.array([1, 2, 3, 4, 5])

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numpy", specifier = ">=2.0.0,<2.3.0" },
+    { name = "numpy", specifier = ">=2.0.0,<2.5.0" },
     { name = "numpydoc", marker = "extra == 'docs'", specifier = ">=1.8" },
     { name = "psutil", marker = "extra == 'dev'", specifier = ">=5.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },

--- a/website/.generated/ops/argpartition.json
+++ b/website/.generated/ops/argpartition.json
@@ -739,5 +739,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.argpartition",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L131"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L142"
 }

--- a/website/.generated/ops/argsort.json
+++ b/website/.generated/ops/argsort.json
@@ -1035,5 +1035,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.argsort",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L54"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L65"
 }

--- a/website/.generated/ops/convolve.json
+++ b/website/.generated/ops/convolve.json
@@ -622,5 +622,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.convolve",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1029"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1051"
 }

--- a/website/.generated/ops/corrcoef.json
+++ b/website/.generated/ops/corrcoef.json
@@ -917,5 +917,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.corrcoef",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1090"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1112"
 }

--- a/website/.generated/ops/correlate.json
+++ b/website/.generated/ops/correlate.json
@@ -573,5 +573,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.correlate",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1050"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1072"
 }

--- a/website/.generated/ops/count_nonzero.json
+++ b/website/.generated/ops/count_nonzero.json
@@ -408,5 +408,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.count_nonzero",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L197"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L688"
 }

--- a/website/.generated/ops/cov.json
+++ b/website/.generated/ops/cov.json
@@ -1097,5 +1097,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.cov",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1105"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1127"
 }

--- a/website/.generated/ops/cross.json
+++ b/website/.generated/ops/cross.json
@@ -1117,5 +1117,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.cross",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L935"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L957"
 }

--- a/website/.generated/ops/diff.json
+++ b/website/.generated/ops/diff.json
@@ -683,5 +683,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.diff",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L960"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L982"
 }

--- a/website/.generated/ops/digitize.json
+++ b/website/.generated/ops/digitize.json
@@ -676,5 +676,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.digitize",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L201"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L212"
 }

--- a/website/.generated/ops/dot.json
+++ b/website/.generated/ops/dot.json
@@ -968,5 +968,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.dot",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L743"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L765"
 }

--- a/website/.generated/ops/ediff1d.json
+++ b/website/.generated/ops/ediff1d.json
@@ -373,5 +373,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.ediff1d",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1001"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1023"
 }

--- a/website/.generated/ops/gradient.json
+++ b/website/.generated/ops/gradient.json
@@ -1032,5 +1032,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.gradient",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L985"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1007"
 }

--- a/website/.generated/ops/in1d.json
+++ b/website/.generated/ops/in1d.json
@@ -693,7 +693,7 @@
     "href": "/docs/api/ops/indices/",
     "label": "we.indices"
   },
-  "notes": "Set membership; cost = (n+m)*ceil(log2(n+m)).",
+  "notes": "Set membership; cost = (n+m)*ceil(log2(n+m)). Removed in numpy 2.4; use `isin` instead.",
   "notes_sections": [
     "`in1d` can be considered as an element-wise function version of the python keyword `in`, for 1-D sequences. ``in1d(a, b)`` is roughly equivalent to ``we.array([item in b for item in a])``. However, this idea fails if `ar2` is a set, or similar (non-sequence) container:  As ``ar2`` is converted to an array, in those cases ``asarray(ar2)`` is an object array rather than the expected array of contained values.",
     "Using ``kind='table'`` tends to be faster than `kind='sort'` if the following relationship is true: ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``, but may use greater memory. The default value for `kind` will be automatically selected based only on memory usage, so one may manually set ``kind='table'`` if memory constraints can be relaxed."
@@ -798,5 +798,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.in1d",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L338"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L369"
 }

--- a/website/.generated/ops/inner.json
+++ b/website/.generated/ops/inner.json
@@ -719,5 +719,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.inner",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L825"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L847"
 }

--- a/website/.generated/ops/interp.json
+++ b/website/.generated/ops/interp.json
@@ -914,5 +914,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.interp",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1148"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1180"
 }

--- a/website/.generated/ops/intersect1d.json
+++ b/website/.generated/ops/intersect1d.json
@@ -473,5 +473,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.intersect1d",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L372"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L407"
 }

--- a/website/.generated/ops/isin.json
+++ b/website/.generated/ops/isin.json
@@ -924,5 +924,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.isin",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L355"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L390"
 }

--- a/website/.generated/ops/kron.json
+++ b/website/.generated/ops/kron.json
@@ -396,5 +396,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.kron",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L916"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L938"
 }

--- a/website/.generated/ops/lexsort.json
+++ b/website/.generated/ops/lexsort.json
@@ -818,5 +818,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.lexsort",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L77"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L88"
 }

--- a/website/.generated/ops/matmul.json
+++ b/website/.generated/ops/matmul.json
@@ -1070,5 +1070,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.matmul",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L781"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L803"
 }

--- a/website/.generated/ops/outer.json
+++ b/website/.generated/ops/outer.json
@@ -653,5 +653,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.outer",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L847"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L869"
 }

--- a/website/.generated/ops/partition.json
+++ b/website/.generated/ops/partition.json
@@ -721,5 +721,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.partition",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L102"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L113"
 }

--- a/website/.generated/ops/searchsorted.json
+++ b/website/.generated/ops/searchsorted.json
@@ -698,5 +698,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.searchsorted",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L170"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L181"
 }

--- a/website/.generated/ops/setdiff1d.json
+++ b/website/.generated/ops/setdiff1d.json
@@ -314,5 +314,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.setdiff1d",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L407"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L442"
 }

--- a/website/.generated/ops/setxor1d.json
+++ b/website/.generated/ops/setxor1d.json
@@ -220,5 +220,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.setxor1d",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L426"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L461"
 }

--- a/website/.generated/ops/sort.json
+++ b/website/.generated/ops/sort.json
@@ -1021,5 +1021,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.sort",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L33"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L44"
 }

--- a/website/.generated/ops/tensordot.json
+++ b/website/.generated/ops/tensordot.json
@@ -1028,5 +1028,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.tensordot",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L865"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L887"
 }

--- a/website/.generated/ops/trapezoid.json
+++ b/website/.generated/ops/trapezoid.json
@@ -827,5 +827,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.trapezoid",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1120"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L1142"
 }

--- a/website/.generated/ops/union1d.json
+++ b/website/.generated/ops/union1d.json
@@ -207,5 +207,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.union1d",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L391"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L426"
 }

--- a/website/.generated/ops/unique.json
+++ b/website/.generated/ops/unique.json
@@ -933,5 +933,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.unique",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L243"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L254"
 }

--- a/website/.generated/ops/unique_all.json
+++ b/website/.generated/ops/unique_all.json
@@ -345,5 +345,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.unique_all",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L259"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L288"
 }

--- a/website/.generated/ops/unique_counts.json
+++ b/website/.generated/ops/unique_counts.json
@@ -298,5 +298,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.unique_counts",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L274"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L303"
 }

--- a/website/.generated/ops/unique_inverse.json
+++ b/website/.generated/ops/unique_inverse.json
@@ -315,5 +315,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.unique_inverse",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L291"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L320"
 }

--- a/website/.generated/ops/unique_values.json
+++ b/website/.generated/ops/unique_values.json
@@ -235,5 +235,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.unique_values",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L308"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_sorting_ops.py#L337"
 }

--- a/website/.generated/ops/vdot.json
+++ b/website/.generated/ops/vdot.json
@@ -492,5 +492,5 @@
   "weight": 1.0,
   "whest_examples_html": "",
   "whest_ref": "we.vdot",
-  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L898"
+  "whest_source_url": "https://github.com/AIcrowd/whest/blob/main/src/whest/_pointwise.py#L920"
 }

--- a/whest-server/pyproject.toml
+++ b/whest-server/pyproject.toml
@@ -9,7 +9,7 @@ description = "Backend server for whest client-server architecture"
 requires-python = ">=3.10"
 dependencies = [
     "whest>=0.2.0",
-    "numpy>=2.0.0,<2.3.0",
+    "numpy>=2.0.0,<2.5.0",
     "pyzmq>=26.0.0",
     "msgpack>=1.0.0",
 ]


### PR DESCRIPTION
## Summary

Raises whest's supported numpy ceiling from `<2.3.0` to `<2.5.0`.

The change splits into four independent layers. Each is separately revertable.

### 1. Version policy

Bumps the `<2.3.0` constant in every place it's hard-coded:

- `pyproject.toml` and `whest-server/pyproject.toml`
- `REGISTRY_META` in `src/whest/_registry.py`
- Fallback default in `src/whest/__init__.py`
- RuntimeError bounds in `scripts/generate_api_docs.py`
- `uv.lock` refreshed accordingly

### 2. Removed-function gating

NumPy 2.4 removes `np.in1d` and `np.trapz`.

`UnsupportedFunctionError` is extended with keyword-only `max_version=` and `replacement=` parameters (backward compatible — existing `min_version=` callers unchanged).

The `we.in1d` and `we.trapz` wrappers are wrapped in `if hasattr(_np, …):` guards with `else` stubs that raise:

```python
raise UnsupportedFunctionError("in1d", max_version="2.4", replacement="isin")
raise UnsupportedFunctionError("trapz", max_version="2.4", replacement="trapezoid")
```

This mirrors the existing `bitwise_count` / `vecdot` / `unstack` gate pattern.

### 3. Behavioral shims

Two wrappers normalize observable behavior across numpy versions:

- **`we.count_nonzero(axis=None)`** — unconditionally coerces to Python `int`. This fixes both numpy 2.3's scalar-return change *and* whest's pre-existing `_aswhest` wrapping that had been returning `WhestArray` on numpy 2.2 too.
- **`we.unique(x)`** — re-sorts the result on numpy 2.3+ when `x.dtype.kind in {"U","S","O","c"}` and no auxiliary-return kwargs are requested.

`take_along_axis`'s default-axis change is left un-shimmed — any 2.2 code that passed `axis` explicitly keeps working everywhere, and code that omitted `axis` couldn't have worked on 2.2 anyway.

### 4. CI and testing

- Matrix gains two `include:` rows: `Python 3.12 × numpy 2.3` and `Python 3.12 × numpy 2.4`, with `fail-fast: false`
- Compat-suite gate widened from `'2.2'` only to `'2.2' | '2.3' | '2.4'`
- `tests/numpy_compat/xfails.py`: 2 new patterns (`test_array_wrap_array_priority` in 2.3, `test_ufunc_override_where` in 2.4) and 2 reason constants reserved for future triage rounds
- `skipif` markers added where tests directly exercise `in1d` / `trapz` or signature-check functions whose C signatures gained positional-only markers in numpy 2.4

### New test files

- `tests/test_errors.py` — 4 tests for the extended `UnsupportedFunctionError`
- `tests/test_behavior_shims.py` — 9 tests for `count_nonzero` and `unique` shims

### Out of scope

- Adding a `whest.strings` submodule (including `numpy.strings.slice`)
- Raising `requires-python` to 3.11 (Python 3.10 users resolve to numpy ≤ 2.2 via pip)
- Shimming `take_along_axis`, `np.round` always-copy, or `np.sum(generator)` rejection

## Test plan

Ran locally across three numpy versions:

- [x] `uv run pytest --cov=whest --cov-fail-under=85` green on 2.2, 2.3, 2.4
- [x] `make test-numpy-compat` green-with-xfails on all three
- [x] `scripts/generate_api_docs.py --verify` passes on 2.4
- [x] Smoke tests: silent import; `we.in1d` / `we.trapz` raise with correct `max_version` / `replacement` on 2.4; `we.count_nonzero` returns Python `int` on all three; `we.unique(strings)` returns sorted on all three