### PR TITLE
Use npx next fallback in docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-numpy-compat:  ## Run NumPy's own tests against whest
 docs-build:  ## Generate API data and build website
 	$(UV) python scripts/generate_api_docs.py
 	$(UV) python scripts/generate_api_docs.py --verify
-	cd website && npm run build
+	cd website && (npm run build || (npx --yes next build && node scripts/generate-llmstxt.mjs))
 	cd website && npm run check:gh-pages
 
 .PHONY: docs-serve


### PR DESCRIPTION
## Summary
Follow-up fix to make docs build checks robust in environments without a global `next` binary.

## What changed
- Updated `Makefile` docs build step so `cd website && npm run build` falls back to `npx next build`.
- Kept existing behavior by running `node scripts/generate-llmstxt.mjs` after fallback build.
- Leaves existing local/dependency-first path unchanged when `next` is available from local dependencies.

## Validation
- `make docs-build` no longer requires a globally installed `next` CLI in PATH.
- Existing generated docs JSON artifacts remain local-only working-tree noise from earlier ad-hoc runs and are intentionally not part of this commit.
