### PR TITLE
Enable Ruff B/C4/UP lint codes and fix violations

### DIFF
--- a/benchmarks/_bitwise.py
+++ b/benchmarks/_bitwise.py
@@ -46,7 +46,7 @@ BITWISE_OPS: list[str] = UNARY_OPS + BINARY_OPS + SHIFT_OPS + SPECIAL_OPS
 
 # --- Analytical formula strings (all cost = n) ----------------------------
 
-_FORMULA_STRINGS: dict[str, str] = {op: "n" for op in BITWISE_OPS}
+_FORMULA_STRINGS: dict[str, str] = dict.fromkeys(BITWISE_OPS, "n")
 
 
 def _analytical_cost(op: str, n: int) -> int:  # noqa: ARG001

--- a/benchmarks/_linalg.py
+++ b/benchmarks/_linalg.py
@@ -155,14 +155,10 @@ def benchmark_linalg(
 
         # Build bench code
         if op == "linalg.solve":
-            bench_suffix = "; b = np.ones({n}, dtype=np.{dtype})".format(
-                n=n, dtype=dtype
-            )
+            bench_suffix = f"; b = np.ones({n}, dtype=np.{dtype})"
             bench = "np.linalg.solve(A, b)"
         elif op == "linalg.lstsq":
-            bench_suffix = "; b = np.ones({n}, dtype=np.{dtype})".format(
-                n=n, dtype=dtype
-            )
+            bench_suffix = f"; b = np.ones({n}, dtype=np.{dtype})"
             bench = "np.linalg.lstsq(A, b, rcond=None)"
         else:
             bench_suffix = ""

--- a/benchmarks/_polynomial.py
+++ b/benchmarks/_polynomial.py
@@ -159,7 +159,6 @@ def benchmark_polynomial(
 
         if dist_values:
             results[op] = statistics.median(dist_values)
-            dist_values.index(statistics.median(dist_values))
             # Build explicit benchmark_size per op
             if op == "polyval":
                 bm_size = f"c: ({degree + 1},), x: ({n},)"

--- a/benchmarks/_sorting.py
+++ b/benchmarks/_sorting.py
@@ -246,8 +246,6 @@ def benchmark_sorting(
 
         if dist_values:
             results[op] = statistics.median(dist_values)
-            # Find the perf_instructions corresponding to the median alpha
-            dist_values.index(statistics.median(dist_values))
             # Build explicit benchmark_size per op
             if op in (
                 "sort",

--- a/benchmarks/_window.py
+++ b/benchmarks/_window.py
@@ -61,7 +61,7 @@ def benchmark_window(
         # Window functions are deterministic (no input distribution),
         # but we still take 3 measurements with different seeds for
         # consistency (they'll be nearly identical).
-        for seed in [42, 123, 999]:
+        for _seed in [42, 123, 999]:
             setup = "import numpy as np"
             if op == "kaiser":
                 bench = f"np.kaiser({n}, 14.0)"

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -145,7 +145,7 @@ def normalize_weights(
 def normalize_weights_v2(
     raw_alpha: dict[str, float],
     all_details: dict[str, dict],
-    baselines: "BaselineResult",
+    baselines: BaselineResult,
 ) -> dict[str, float]:
     """Subtract per-category ufunc overhead and clamp to minimum 1.0.
 

--- a/docker/lockdown/strip_stdlib.py
+++ b/docker/lockdown/strip_stdlib.py
@@ -56,7 +56,7 @@ def _discover_kept_files() -> set[str]:
 
     # Collect all file paths from loaded modules
     kept = set()
-    for name, mod in sys.modules.items():
+    for _name, mod in sys.modules.items():
         f = getattr(mod, "__file__", None)
         if f:
             kept.add(os.path.realpath(f))
@@ -77,7 +77,7 @@ def _discover_kept_files() -> set[str]:
                     kept.add(os.path.realpath(init))
 
     # Keep all .so files from loaded C extensions
-    for name, mod in sys.modules.items():
+    for _name, mod in sys.modules.items():
         f = getattr(mod, "__file__", None)
         if f and f.endswith(".so"):
             kept.add(os.path.realpath(f))
@@ -86,7 +86,7 @@ def _discover_kept_files() -> set[str]:
     stdlib = _stdlib_dir()
     enc_dir = os.path.join(stdlib, "encodings")
     if os.path.isdir(enc_dir):
-        for root, dirs, files in os.walk(enc_dir):
+        for root, _dirs, files in os.walk(enc_dir):
             for fname in files:
                 kept.add(os.path.realpath(os.path.join(root, fname)))
 
@@ -139,7 +139,7 @@ def strip(dry_run: bool = False) -> None:
         for d in [_stdlib_dir(), _platstdlib_dir()]:
             if not os.path.isdir(d):
                 continue
-            for root, dirnames, filenames in os.walk(d, topdown=False):
+            for root, dirnames, _filenames in os.walk(d, topdown=False):
                 for dirname in dirnames:
                     dirpath = os.path.join(root, dirname)
                     try:

--- a/docker/submissions/run.py
+++ b/docker/submissions/run.py
@@ -55,7 +55,7 @@ except (PermissionError, OSError):
 
 # Test 5: can read own submission files
 try:
-    open("/submission/run.py", "r").read()
+    open("/submission/run.py").read()
     check("can read /submission/", True)
 except Exception:
     check("can read /submission/", False)

--- a/docker/submissions/run_adversarial.py
+++ b/docker/submissions/run_adversarial.py
@@ -55,7 +55,7 @@ except (PermissionError, OSError):
 
 # Test 5: can read own submission files
 try:
-    open("/submission/run.py", "r").read()
+    open("/submission/run.py").read()
     check("can read /submission/", True)
 except Exception:
     check("can read /submission/", False)

--- a/examples/06_namespaces_and_display.py
+++ b/examples/06_namespaces_and_display.py
@@ -48,7 +48,7 @@ with we.BudgetContext(
     namespace="training",
     quiet=True,
 ) as train_ctx:
-    for step in range(5):  # 5 forward passes
+    for _step in range(5):  # 5 forward passes
         h = we.array(np.random.randn(batch_size, 64).astype(np.float32))
         for W_layer, b in layers:
             # Linear: h @ W.T  (batch_size x 64) @ (64 x 64) -> (batch_size x 64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
+extend-select = ["B", "C4", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 # Public re-exports: imports are intentionally "unused" from ruff's perspective

--- a/scripts/debug_phi.py
+++ b/scripts/debug_phi.py
@@ -24,7 +24,7 @@ print("Oracle inner symmetry:", sym.inner)
 all_indices = frozenset("ijklm")
 output_indices = frozenset("jklm")
 inner_indices = frozenset("i")
-size_dict = {c: n for c in "ijklm"}
+size_dict = dict.fromkeys("ijklm", n)
 
 # What unique_elements gives with oracle-detected symmetry
 combined_sym = list(sym.output or []) + list(sym.inner or [])

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -501,15 +501,15 @@ class OperationDocRecord:
     provenance_url: str = ""
     whest_source_url: str = ""
     upstream_source_url: str = ""
-    parameters: list["DocField"] | None = None
-    returns: list["DocField"] | None = None
-    see_also: list["DocLink"] | None = None
+    parameters: list[DocField] | None = None
+    returns: list[DocField] | None = None
+    see_also: list[DocLink] | None = None
     notes_sections: list[str] | None = None
-    example: "DocExample | None" = None
+    example: DocExample | None = None
     body_sections: list[dict] | None = None
     doc_coverage: dict[str, object] = field(default_factory=dict)
-    previous: "OperationNavLink | None" = None
-    next: "OperationNavLink | None" = None
+    previous: OperationNavLink | None = None
+    next: OperationNavLink | None = None
     api_docs_html: str = ""
     whest_examples_html: str = ""
 
@@ -1390,7 +1390,7 @@ def _convert_docutils_blocks(
             )
             continue
 
-        raw_text = getattr(node, "astext", lambda: str(node))()
+        raw_text = getattr(node, "astext", lambda node=node: str(node))()
         _record_coverage_event(
             coverage,
             "raw_blocks",
@@ -3415,7 +3415,7 @@ def update_counted_ops_page(registry: dict[str, dict]) -> None:
     content = page.read_text()
 
     additions = []
-    for module_directive, label in [
+    for module_directive, _label in [
         ("whest._polynomial", "polynomial"),
         ("whest._window", "window"),
         ("whest._unwrap", "unwrap"),

--- a/scripts/generate_empirical_weights_docs.py
+++ b/scripts/generate_empirical_weights_docs.py
@@ -288,7 +288,7 @@ def _empty_row(
     op_name: str, status: str, reason: str, category: str, notes: str
 ) -> dict:
     """Build a row with only status/reason fields populated."""
-    row = {col: "" for col in CSV_COLUMNS}
+    row = dict.fromkeys(CSV_COLUMNS, "")
     row["Operation"] = op_name
     row["Status"] = status
     row["Exclusion Reason"] = reason
@@ -512,7 +512,7 @@ def build_rows(data: dict) -> list[dict]:
         rows.append(row)
 
     # --- Excluded ops ---
-    for group_name, (op_set, reason) in _EXCLUSIONS.items():
+    for _group_name, (op_set, reason) in _EXCLUSIONS.items():
         for op_name in sorted(op_set):
             if op_name in weights:
                 continue

--- a/scripts/numpy_audit.py
+++ b/scripts/numpy_audit.py
@@ -18,7 +18,6 @@ import json
 import sys
 import types
 import warnings
-from typing import Dict, Tuple
 
 import numpy as np
 
@@ -279,7 +278,7 @@ def _should_skip(name: str, obj) -> bool:
     return False
 
 
-def introspect_numpy() -> Dict[str, dict]:
+def introspect_numpy() -> dict[str, dict]:
     """Walk numpy and its submodules to discover all public callables.
 
     Returns
@@ -288,7 +287,7 @@ def introspect_numpy() -> Dict[str, dict]:
         Maps qualified name (e.g. ``"exp"``, ``"linalg.svd"``) to a metadata
         dict with keys ``"module"`` (str) and ``"kind"`` (str).
     """
-    discovered: Dict[str, dict] = {}
+    discovered: dict[str, dict] = {}
 
     # Suppress numpy FutureWarning / DeprecationWarning for deprecated aliases
     # (e.g. np.bytes, np.int, np.float) that trigger on attribute access.
@@ -331,7 +330,7 @@ def introspect_numpy() -> Dict[str, dict]:
     return discovered
 
 
-def load_registry() -> Tuple[dict, dict]:
+def load_registry() -> tuple[dict, dict]:
     """Load the whest registry.
 
     Returns
@@ -349,9 +348,9 @@ def load_registry() -> Tuple[dict, dict]:
 
 
 def compare(
-    discovered: Dict[str, dict],
+    discovered: dict[str, dict],
     registry: dict,
-) -> Dict[str, list]:
+) -> dict[str, list]:
     """Compare discovered numpy callables against the whest registry.
 
     Parameters
@@ -384,7 +383,7 @@ def compare(
         except (AttributeError, TypeError):
             pass
 
-    result: Dict[str, list] = {
+    result: dict[str, list] = {
         "covered": [],
         "registered_not_implemented": [],
         "unclassified": [],
@@ -428,8 +427,8 @@ def _category_color(category: str) -> str:
 
 
 def print_rich_report(
-    discovered: Dict[str, dict],
-    comparison: Dict[str, list],
+    discovered: dict[str, dict],
+    comparison: dict[str, list],
     registry: dict,
     filter_category: str | None = None,
     filter_module: str | None = None,
@@ -505,8 +504,8 @@ def print_rich_report(
 
 
 def print_plain_report(
-    discovered: Dict[str, dict],
-    comparison: Dict[str, list],
+    discovered: dict[str, dict],
+    comparison: dict[str, list],
     registry: dict,
     filter_category: str | None = None,
     filter_module: str | None = None,

--- a/scripts/upload_to_sheets.py
+++ b/scripts/upload_to_sheets.py
@@ -88,7 +88,7 @@ def load_csv(path: Path) -> list[list[str]]:
     """Load CSV as a list of rows (each row is a list of strings)."""
     with open(path) as f:
         reader = csv.reader(f)
-        return [row for row in reader]
+        return list(reader)
 
 
 def create_spreadsheet() -> str:

--- a/scripts/verify_psi_match.py
+++ b/scripts/verify_psi_match.py
@@ -57,7 +57,7 @@ def build_einsum_args(n: int, s: int, t: int, v: int):
     output_labels = a_labels + b_labels
     inner_labels = c_labels
 
-    size_dict = {lbl: n for lbl in all_labels}
+    size_dict = dict.fromkeys(all_labels, n)
 
     # A is symmetric in all its indices (a_labels + c_labels)
     # B is symmetric in all its indices (b_labels + c_labels)

--- a/src/whest/_budget.py
+++ b/src/whest/_budget.py
@@ -64,11 +64,11 @@ class _OpTimer:
 
     __slots__ = ("_budget", "_start")
 
-    def __init__(self, budget: "BudgetContext"):
+    def __init__(self, budget: BudgetContext):
         self._budget = budget
         self._start: float | None = None
 
-    def __enter__(self) -> "_OpTimer":
+    def __enter__(self) -> _OpTimer:
         self._start = time.perf_counter()
         return self
 
@@ -96,7 +96,7 @@ class _OpTimer:
 
 
 _thread_local = threading.local()
-_all_budget_contexts: weakref.WeakSet["BudgetContext"] = weakref.WeakSet()
+_all_budget_contexts: weakref.WeakSet[BudgetContext] = weakref.WeakSet()
 
 
 def get_active_budget() -> BudgetContext | None:
@@ -107,11 +107,11 @@ def get_active_budget() -> BudgetContext | None:
 class _NamespaceScope:
     __slots__ = ("_budget", "_segment")
 
-    def __init__(self, budget: "BudgetContext", segment: str):
+    def __init__(self, budget: BudgetContext, segment: str):
         self._budget = budget
         self._segment = segment
 
-    def __enter__(self) -> "BudgetContext":
+    def __enter__(self) -> BudgetContext:
         self._budget._push_namespace(self._segment)
         return self._budget
 
@@ -383,7 +383,7 @@ class BudgetContext:
                 f"Namespace stack corrupted: expected {expected!r}, got {actual!r}"
             )
 
-    def _snapshot_record(self) -> "NamespaceRecord":
+    def _snapshot_record(self) -> NamespaceRecord:
         wall_time = self.wall_time_s
         if wall_time is None and self._start_time is not None:
             wall_time = self.elapsed_s

--- a/src/whest/_display.py
+++ b/src/whest/_display.py
@@ -400,7 +400,7 @@ def budget_summary(by_namespace: bool = False):
     """Print or return the session-wide budget summary."""
     result = render_budget_summary(by_namespace=by_namespace)
     try:
-        get_ipython  # noqa: F821
+        _ = get_ipython  # noqa: F821
         return result
     except NameError:
         if isinstance(result, str):

--- a/src/whest/_einsum.py
+++ b/src/whest/_einsum.py
@@ -39,7 +39,7 @@ def _symmetry_fingerprint(operands, input_parts):
     determines the symmetry structure without referencing tensor values.
     """
     parts = []
-    for op, chars in zip(operands, input_parts):
+    for op, _chars in zip(operands, input_parts, strict=False):
         if not isinstance(op, SymmetricTensor) or op.symmetry_info is None:
             parts.append(None)
             continue
@@ -91,7 +91,7 @@ def _make_path_cache(maxsize):
         output_str = subscripts.split("->")[1] if "->" in subscripts else ""
 
         perm_groups = []
-        for fp_entry, chars in zip(symmetry_fingerprint, input_parts):
+        for fp_entry, chars in zip(symmetry_fingerprint, input_parts, strict=False):
             if fp_entry is None:
                 perm_groups.append(None)
                 continue
@@ -171,7 +171,7 @@ def einsum_cache_info():
 def _execute_pairwise(path_info, operands: list):
     """Execute pairwise contractions according to the optimized path."""
     ops = list(operands)
-    for contract_inds, step in zip(path_info.path, path_info.steps):
+    for contract_inds, step in zip(path_info.path, path_info.steps, strict=False):
         # Pop operands in reverse sorted order (same as opt_einsum convention)
         inds = sorted(contract_inds, reverse=True)
         tensors = [ops.pop(i) for i in inds]

--- a/src/whest/_flops.py
+++ b/src/whest/_flops.py
@@ -43,7 +43,7 @@ def parse_einsum_subscripts(subscripts: str) -> tuple[list[list[str]], list[str]
 def einsum_cost(
     subscripts: str,
     shapes: list[tuple[int, ...]],
-    operand_symmetries: "list[SymmetryInfo | None] | None" = None,
+    operand_symmetries: list[SymmetryInfo | None] | None = None,
 ) -> int:
     """FLOP cost of an einsum operation.
 
@@ -76,7 +76,7 @@ def einsum_cost(
 
         perm_groups = [
             _symmetry_info_to_perm_groups(sym, chars)
-            for sym, chars in zip(operand_symmetries, input_parts)
+            for sym, chars in zip(operand_symmetries, input_parts, strict=False)
         ]
 
         from whest._opt_einsum._subgraph_symmetry import SubgraphSymmetryOracle
@@ -97,7 +97,7 @@ def einsum_cost(
 
 
 def pointwise_cost(
-    shape: tuple[int, ...], symmetry_info: "SymmetryInfo | None" = None
+    shape: tuple[int, ...], symmetry_info: SymmetryInfo | None = None
 ) -> int:
     """FLOP cost of a pointwise (element-wise) operation.
 
@@ -124,7 +124,7 @@ def pointwise_cost(
 def reduction_cost(
     input_shape: tuple[int, ...],
     axis: int | None = None,
-    symmetry_info: "SymmetryInfo | None" = None,
+    symmetry_info: SymmetryInfo | None = None,
 ) -> int:
     """FLOP cost of a reduction operation.
 

--- a/src/whest/_opt_einsum/_helpers.py
+++ b/src/whest/_opt_einsum/_helpers.py
@@ -9,7 +9,7 @@ __all__ = ["compute_size_by_dict", "find_contraction", "flop_count"]
 
 _valid_chars = "abcdefghijklmopqABC"
 _sizes = [2, 3, 4, 5, 4, 3, 2, 6, 5, 4, 3, 2, 5, 7, 4, 3, 2, 3, 4]
-_default_dim_dict = dict(zip(_valid_chars, _sizes))
+_default_dim_dict = dict(zip(_valid_chars, _sizes, strict=False))
 
 
 @overload

--- a/src/whest/_opt_einsum/_hsluv.py
+++ b/src/whest/_opt_einsum/_hsluv.py
@@ -11,7 +11,7 @@ See NOTICE in this package for attribution details.
 from __future__ import annotations
 
 import math
-from functools import lru_cache
+from functools import lru_cache, cache
 
 _M = (
     (3.240969941904521, -1.537383177570093, -0.498610760293),
@@ -139,7 +139,7 @@ def _max_chroma_for_lh(lightness: float, hue: float) -> float:
 def _dot_product(
     left: tuple[float, float, float], right: tuple[float, float, float]
 ) -> float:
-    return sum(left_value * right_value for left_value, right_value in zip(left, right))
+    return sum(left_value * right_value for left_value, right_value in zip(left, right, strict=False))
 
 
 def _from_linear(channel: float) -> float:
@@ -217,7 +217,7 @@ def rgb_distance_hex(left: str, right: str) -> float:
     return math.dist(left_rgb, right_rgb)
 
 
-@lru_cache(maxsize=None)
+@cache
 def rich_label_palette(slot_count: int) -> tuple[str, ...]:
     if slot_count <= 64:
         return PRECOMPUTED_QUALITATIVE_HSLUV_PALETTE_64

--- a/src/whest/_opt_einsum/_hsluv.py
+++ b/src/whest/_opt_einsum/_hsluv.py
@@ -139,7 +139,10 @@ def _max_chroma_for_lh(lightness: float, hue: float) -> float:
 def _dot_product(
     left: tuple[float, float, float], right: tuple[float, float, float]
 ) -> float:
-    return sum(left_value * right_value for left_value, right_value in zip(left, right, strict=False))
+    return sum(
+        left_value * right_value
+        for left_value, right_value in zip(left, right, strict=False)
+    )
 
 
 def _from_linear(channel: float) -> float:

--- a/src/whest/_opt_einsum/_hsluv.py
+++ b/src/whest/_opt_einsum/_hsluv.py
@@ -11,7 +11,7 @@ See NOTICE in this package for attribution details.
 from __future__ import annotations
 
 import math
-from functools import lru_cache, cache
+from functools import cache
 
 _M = (
     (3.240969941904521, -1.537383177570093, -0.498610760293),

--- a/src/whest/_opt_einsum/_parser.py
+++ b/src/whest/_opt_einsum/_parser.py
@@ -174,7 +174,7 @@ def find_output_shape(
     return tuple(
         max(
             shape[loc]
-            for shape, loc in zip(shapes, [x.find(c) for x in inputs])
+            for shape, loc in zip(shapes, [x.find(c) for x in inputs], strict=False)
             if loc >= 0
         )
         for c in output
@@ -233,10 +233,10 @@ def possibly_convert_to_numpy(x: Any) -> Any:
     if not hasattr(x, "shape"):
         try:
             import numpy as np  # type: ignore
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as err:
             raise ModuleNotFoundError(
                 "numpy is required to convert non-array objects to arrays. This function will be deprecated in the future."
-            )
+            ) from err
 
         return np.asanyarray(x)
     else:
@@ -288,10 +288,10 @@ def convert_interleaved_input(operands: Sequence[Any]) -> tuple[str, tuple[Any, 
             symbol: get_symbol(idx) for idx, symbol in enumerate(sorted(symbol_set))
         }
 
-    except TypeError:  # unhashable or uncomparable object
+    except TypeError as err:  # unhashable or uncomparable object
         raise TypeError(
             "For this input type lists must contain either Ellipsis or hashable and comparable object (e.g. int, str)."
-        )
+        ) from err
 
     subscripts = ",".join(convert_subscripts(sub, symbol_map) for sub in subscript_list)
     if output_list is not None:

--- a/src/whest/_opt_einsum/_paths.py
+++ b/src/whest/_opt_einsum/_paths.py
@@ -770,7 +770,7 @@ def ssa_greedy_optimize(
 
     # Find initial candidate contractions.
     queue: list[GreedyContractionType] = []
-    for dim, dim_keys in dim_to_keys.items():
+    for _dim, dim_keys in dim_to_keys.items():
         dim_keys_list = sorted(dim_keys, key=remaining.__getitem__)
         for i, k1 in enumerate(dim_keys_list[:-1]):
             k2s_guess = dim_keys_list[1 + i :]
@@ -1016,7 +1016,7 @@ def _bitmap_select(
         >>> list(_bitmap_select(0b11010, ['A', 'B', 'C', 'D', 'E']))
         ['B', 'D', 'E']
     """
-    return (x for x, b in zip(seq, bin(s)[:1:-1]) if b == "1")
+    return (x for x, b in zip(seq, bin(s)[:1:-1], strict=False) if b == "1")
 
 
 def _dp_calc_legs(g, all_tensors, s, inputs, i1_cut_i2_wo_output, i1_union_i2):

--- a/src/whest/_opt_einsum/_subgraph_symmetry.py
+++ b/src/whest/_opt_einsum/_subgraph_symmetry.py
@@ -72,8 +72,8 @@ def _derive_pi_canonical(
 
 
 def _collect_pi_permutations(
-    graph: "EinsumBipartite",
-    sub: "_Subgraph",
+    graph: EinsumBipartite,
+    sub: _Subgraph,
     row_order: tuple[int, ...],
     col_of: dict[str, tuple[int, ...]],
     fp_to_labels: dict[tuple[int, ...], set[str]],
@@ -122,7 +122,7 @@ def _collect_pi_permutations(
     row_perm_generators: list[tuple[int, ...]] = []
 
     # --- Source A: per-operand internal symmetry generators ---
-    for op_idx in sorted(set(graph.u_operand[u] for u in row_order)):
+    for op_idx in sorted({graph.u_operand[u] for u in row_order}):
         groups = graph.per_op_groups[op_idx]
         if groups is None:
             continue
@@ -196,7 +196,7 @@ def _collect_pi_permutations(
             if len(pos_a) != len(pos_b):
                 continue  # block sizes must match
             row_perm = list(identity_row)
-            for pa, pb in zip(pos_a, pos_b):
+            for pa, pb in zip(pos_a, pos_b, strict=False):
                 row_perm[pa] = identity_row[pb]
                 row_perm[pb] = identity_row[pa]
             row_perm_generators.append(tuple(row_perm))
@@ -361,7 +361,7 @@ def _build_bipartite(
 
         # Build one U vertex per axis, with incidence = label multiplicity.
         num_classes = len(sub)
-        class_incidence: list[dict[str, int]] = [dict() for _ in range(num_classes)]
+        class_incidence: list[dict[str, int]] = [{} for _ in range(num_classes)]
         class_labels: list[set[str]] = [set() for _ in range(num_classes)]
         for k, c in enumerate(sub):
             cls = class_of_position[k]

--- a/src/whest/_opt_einsum/_symmetry.py
+++ b/src/whest/_opt_einsum/_symmetry.py
@@ -9,8 +9,8 @@ Detection of symmetries is handled by ``_subgraph_symmetry.SubgraphSymmetryOracl
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from collections.abc import Collection
+from dataclasses import dataclass
 
 from whest._perm_group import PermutationGroup
 

--- a/src/whest/_opt_einsum/_symmetry.py
+++ b/src/whest/_opt_einsum/_symmetry.py
@@ -10,7 +10,7 @@ Detection of symmetries is handled by ``_subgraph_symmetry.SubgraphSymmetryOracl
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Collection
+from collections.abc import Collection
 
 from whest._perm_group import PermutationGroup
 

--- a/src/whest/_opt_einsum/_testing.py
+++ b/src/whest/_opt_einsum/_testing.py
@@ -39,7 +39,7 @@ _sizes = [
     2,
     6,
 ]
-_default_dim_dict = dict(zip(_valid_chars, _sizes))
+_default_dim_dict = dict(zip(_valid_chars, _sizes, strict=False))
 assert len(_valid_chars) == len(_sizes), (
     f"Valid characters and sizes must be the same length: {len(_valid_chars)} != {len(_sizes)}"
 )

--- a/tests/test_benchmark_random.py
+++ b/tests/test_benchmark_random.py
@@ -125,7 +125,7 @@ class TestBenchmarkRandom:
             result, details = benchmark_random(n=1_000, dtype="float64", repeats=1)
 
         assert set(details.keys()) == set(result.keys())
-        for op, d in details.items():
+        for _op, d in details.items():
             assert d["category"] == "counted_custom"
             assert d["analytical_formula"] == "numel(output)"
             assert d["analytical_flops"] == 1_000

--- a/tests/test_dp_symmetry.py
+++ b/tests/test_dp_symmetry.py
@@ -116,12 +116,12 @@ class TestDPMatchesOptimalUnderExactScoring:
         should agree on optimized_cost down to the last FLOP."""
         n = 6
         X = np.ones((n, n))
-        oracle_kwargs = dict(
-            operands=[X, X, X, X],
-            subscript_parts=["ij", "ik", "il", "im"],
-            per_op_groups=[None, None, None, None],
-            output_chars="jklm",
-        )
+        oracle_kwargs = {
+            "operands": [X, X, X, X],
+            "subscript_parts": ["ij", "ik", "il", "im"],
+            "per_op_groups": [None, None, None, None],
+            "output_chars": "jklm",
+        }
         _, info_dp = contract_path(
             "ij,ik,il,im->jklm",
             (n, n),
@@ -153,12 +153,12 @@ class TestDPMatchesOptimalUnderExactScoring:
         S3 gives ~1/6 savings, but // 2 would give only 1/2."""
         n = 10
         X = np.ones((n, n))
-        oracle_kwargs = dict(
-            operands=[X, X, X],
-            subscript_parts=["ai", "bi", "ci"],
-            per_op_groups=[None, None, None],
-            output_chars="abc",
-        )
+        oracle_kwargs = {
+            "operands": [X, X, X],
+            "subscript_parts": ["ai", "bi", "ci"],
+            "per_op_groups": [None, None, None],
+            "output_chars": "abc",
+        }
         _, info_dp = contract_path(
             "ai,bi,ci->abc",
             (n, n),
@@ -207,12 +207,12 @@ class TestDPSingleTermReductionWithOracle:
         n = 4
         v = np.ones(n)
         X = np.ones((n, n))
-        oracle_kwargs = dict(
-            operands=[v, X, X],
-            subscript_parts=["i", "ab", "cd"],
-            per_op_groups=[None, None, None],
-            output_chars="abcd",
-        )
+        oracle_kwargs = {
+            "operands": [v, X, X],
+            "subscript_parts": ["i", "ab", "cd"],
+            "per_op_groups": [None, None, None],
+            "output_chars": "abcd",
+        }
         # Sanity check: the oracle really does report block S2 at the
         # CORRECT subset {1, 2} and None at the WRONG subset {0, 1}.
         # If this invariant breaks (e.g., the oracle implementation

--- a/tests/test_einsum_integration.py
+++ b/tests/test_einsum_integration.py
@@ -256,7 +256,7 @@ class TestPathInfoDebugFields:
         B = numpy.ones((5, 5))
         C = numpy.ones((5, 5))
         path, info = einsum_path("ij,jk,kl->il", A, B, C)
-        for step, path_tuple in zip(info.steps, path):
+        for step, path_tuple in zip(info.steps, path, strict=False):
             assert step.path_indices == tuple(path_tuple)
 
     def test_step_merged_subset_grows_monotonically(self):

--- a/tests/test_getattr.py
+++ b/tests/test_getattr.py
@@ -42,7 +42,7 @@ def test_registered_not_implemented_gives_message():
 
 def test_unknown_name_still_errors():
     with pytest.raises(AttributeError, match="does not provide"):
-        getattr(we, "totally_fake_function_xyz")
+        _ = we.totally_fake_function_xyz
 
 
 def test_fft_submodule_exists():
@@ -67,4 +67,4 @@ def test_fft_getattr_gives_blacklist_error():
 def test_linalg_getattr_consults_registry():
     """Verify that accessing a non-existent linalg attr raises AttributeError."""
     with pytest.raises(AttributeError):
-        getattr(we.linalg, "nonexistent_function_xyz")
+        _ = we.linalg.nonexistent_function_xyz

--- a/tests/test_lazy_top_level_imports.py
+++ b/tests/test_lazy_top_level_imports.py
@@ -58,7 +58,7 @@ def test_registry_attribute_errors_are_unchanged_for_unknown_names():
     we = _fresh_whest()
 
     with pytest.raises(AttributeError, match="does not provide"):
-        getattr(we, "totally_fake_function_xyz")
+        _ = we.totally_fake_function_xyz
 
 
 def test_numpy_compat_rebind_imports_lazy_random_before_patching_numpy():

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -76,4 +76,4 @@ def test_linalg_unsupported():
         AttributeError,
         match="(does not provide|does not support|registered but not yet implemented)",
     ):
-        linalg.cross_decomposition
+        _ = linalg.cross_decomposition

--- a/tests/test_opt_einsum_paths.py
+++ b/tests/test_opt_einsum_paths.py
@@ -102,7 +102,7 @@ def assert_contract_order(
 
 def test_size_by_dict() -> None:
     sizes_dict = {}
-    for ind, val in zip("abcdez", [2, 5, 9, 11, 13, 0]):
+    for ind, val in zip("abcdez", [2, 5, 9, 11, 13, 0], strict=False):
         sizes_dict[ind] = val
 
     path_func = oe._helpers.compute_size_by_dict

--- a/tests/test_opt_einsum_symmetry.py
+++ b/tests/test_opt_einsum_symmetry.py
@@ -122,7 +122,7 @@ class TestSymmetryAwarePaths:
         from whest._opt_einsum._contract import contract_path
 
         args = ("ij,jk,ki->", (10, 10), (10, 10), (10, 10))
-        kwargs = dict(shapes=True, optimize="greedy")
+        kwargs = {"shapes": True, "optimize": "greedy"}
 
         _, info_dense = contract_path(*args, **kwargs)
 
@@ -412,10 +412,10 @@ class TestFixedSymmetricFlopCount:
 
         # Count FMA ops for unique (j,k) pairs (FMA=1 op)
         counted_ops = 0
-        for a in range(n):
+        for _a in range(n):
             for j in range(n):
-                for k in range(j, n):  # unique (j,k) only
-                    for i in range(n):
+                for _k in range(j, n):  # unique (j,k) only
+                    for _i in range(n):
                         counted_ops += 1  # one FMA (fused multiply-add)
 
         size_dict = {"i": n, "j": n, "k": n, "a": n}

--- a/tests/test_random_greedy_symmetry.py
+++ b/tests/test_random_greedy_symmetry.py
@@ -62,7 +62,7 @@ class TestSsaPathComputeCostUsesOracle:
         X = np.ones((n, n, n))
         inputs = [frozenset("ijk"), frozenset("ilm")]
         output = frozenset("jklm")
-        size_dict = {c: n for c in "ijklm"}
+        size_dict = dict.fromkeys("ijklm", n)
 
         oracle = SubgraphSymmetryOracle([X, X], ["ijk", "ilm"], [None, None], "jklm")
 

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -806,7 +806,7 @@ class TestRandomGetattr:
         from whest import random as merandom
 
         with pytest.raises(AttributeError, match="does not provide"):
-            merandom.totally_nonexistent_attr_xyz
+            _ = merandom.totally_nonexistent_attr_xyz
 
 
 class TestRandomOutputSize:

--- a/tests/test_subgraph_symmetry.py
+++ b/tests/test_subgraph_symmetry.py
@@ -171,7 +171,7 @@ class TestBuildBipartite:
         assert g.free_labels == frozenset("ab")
         assert g.summed_labels == frozenset("ij")
         # T's rows have incidence {i: 1} and {j: 1}
-        t_rows = [row for u, row in zip(g.u_operand, g.incidence) if u == 0]
+        t_rows = [row for u, row in zip(g.u_operand, g.incidence, strict=False) if u == 0]
         assert len(t_rows) == 2
         assert {"i": 1} in t_rows
         assert {"j": 1} in t_rows

--- a/tests/test_subgraph_symmetry.py
+++ b/tests/test_subgraph_symmetry.py
@@ -171,7 +171,9 @@ class TestBuildBipartite:
         assert g.free_labels == frozenset("ab")
         assert g.summed_labels == frozenset("ij")
         # T's rows have incidence {i: 1} and {j: 1}
-        t_rows = [row for u, row in zip(g.u_operand, g.incidence, strict=False) if u == 0]
+        t_rows = [
+            row for u, row in zip(g.u_operand, g.incidence, strict=False) if u == 0
+        ]
         assert len(t_rows) == 2
         assert {"i": 1} in t_rows
         assert {"j": 1} in t_rows

--- a/tests/test_symmetric_coverage.py
+++ b/tests/test_symmetric_coverage.py
@@ -40,7 +40,7 @@ def _assert_groups_equal(result, expected_axes_list):
     """Assert result is a list of PermutationGroups matching expected axes tuples."""
     assert result is not None
     assert len(result) == len(expected_axes_list)
-    for grp, axes in zip(result, expected_axes_list):
+    for grp, axes in zip(result, expected_axes_list, strict=False):
         assert isinstance(grp, PermutationGroup)
         assert grp.axes == tuple(axes), f"expected axes {tuple(axes)}, got {grp.axes}"
         import math

--- a/whest-client/src/whest/_connection.py
+++ b/whest-client/src/whest/_connection.py
@@ -74,10 +74,10 @@ class Connection:
         try:
             sock.send(raw_request)
             raw_response: bytes = sock.recv()
-        except zmq.Again:
+        except zmq.Again as err:
             # Socket is in a bad state after timeout — reset it
             self._reset_socket()
-            raise WhestServerError("server timeout: no response within timeout period")
+            raise WhestServerError("server timeout: no response within timeout period") from err
         t1 = time.monotonic_ns()
 
         response = decode_response(raw_response)

--- a/whest-client/src/whest/_connection.py
+++ b/whest-client/src/whest/_connection.py
@@ -77,7 +77,9 @@ class Connection:
         except zmq.Again as err:
             # Socket is in a bad state after timeout — reset it
             self._reset_socket()
-            raise WhestServerError("server timeout: no response within timeout period") from err
+            raise WhestServerError(
+                "server timeout: no response within timeout period"
+            ) from err
         t1 = time.monotonic_ns()
 
         response = decode_response(raw_response)

--- a/whest-client/src/whest/_display.py
+++ b/whest-client/src/whest/_display.py
@@ -271,7 +271,7 @@ def budget_summary():
     """Print or return the session-wide budget summary."""
     result = render_budget_summary()
     try:
-        get_ipython  # noqa: F821
+        _ = get_ipython  # noqa: F821
         return result
     except NameError:
         if isinstance(result, str):

--- a/whest-client/src/whest/_math_compat.py
+++ b/whest-client/src/whest/_math_compat.py
@@ -13,7 +13,7 @@ a fallback ``_constants.py`` is checked in with the same values.
 from __future__ import annotations
 
 from functools import reduce
-from typing import Iterable
+from collections.abc import Iterable
 
 from whest._constants import e, inf, nan, pi
 

--- a/whest-client/src/whest/_math_compat.py
+++ b/whest-client/src/whest/_math_compat.py
@@ -12,8 +12,8 @@ a fallback ``_constants.py`` is checked in with the same values.
 
 from __future__ import annotations
 
-from functools import reduce
 from collections.abc import Iterable
+from functools import reduce
 
 from whest._constants import e, inf, nan, pi
 

--- a/whest-client/src/whest/_remote_array.py
+++ b/whest-client/src/whest/_remote_array.py
@@ -8,7 +8,7 @@ operations are dispatched to the server transparently.
 from __future__ import annotations
 
 import struct
-from typing import Any, Dict, Tuple, Union
+from typing import Any
 
 from whest._math_compat import prod as _prod
 
@@ -19,7 +19,7 @@ from whest._math_compat import prod as _prod
 #: Maps dtype string to (struct format char, byte width).
 #: Complex types use their float-component format char; _bytes_to_list
 #: handles pairing them into Python complex numbers.
-_DTYPE_INFO: Dict[str, Tuple[str, int]] = {
+_DTYPE_INFO: dict[str, tuple[str, int]] = {
     "float64": ("d", 8),
     "float32": ("f", 4),
     "float16": ("e", 2),
@@ -40,7 +40,7 @@ _DTYPE_INFO: Dict[str, Tuple[str, int]] = {
 _COMPLEX_DTYPES = frozenset({"complex64", "complex128"})
 
 
-def _bytes_to_list(data: bytes, shape: Tuple[int, ...], dtype: str) -> Any:
+def _bytes_to_list(data: bytes, shape: tuple[int, ...], dtype: str) -> Any:
     """Convert raw *data* bytes into a (possibly nested) Python list.
 
     Uses :mod:`struct` for unpacking -- no numpy dependency.
@@ -87,7 +87,7 @@ def _bytes_to_list(data: bytes, shape: Tuple[int, ...], dtype: str) -> Any:
     return _reshape(flat, shape)
 
 
-def _reshape(flat: list, shape: Tuple[int, ...]) -> Any:
+def _reshape(flat: list, shape: tuple[int, ...]) -> Any:
     """Reshape a flat list into nested lists matching *shape*."""
     if len(shape) == 1:
         return flat
@@ -121,7 +121,7 @@ class RemoteScalar:
 
     __slots__ = ("_value", "_dtype")
 
-    def __init__(self, value: Union[int, float], dtype: str) -> None:
+    def __init__(self, value: int | float, dtype: str) -> None:
         self._value = value
         self._dtype = dtype
 
@@ -149,7 +149,7 @@ class RemoteScalar:
 
     # -- conversions --------------------------------------------------------
 
-    def tolist(self) -> Union[int, float]:
+    def tolist(self) -> int | float:
         return self._value
 
     def __float__(self) -> float:
@@ -365,7 +365,7 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
 
     # -- data access (auto-fetch from server) -------------------------------
 
-    def _fetch_data(self) -> Tuple[bytes, tuple, str]:
+    def _fetch_data(self) -> tuple[bytes, tuple, str]:
         """Fetch the raw data from the server.
 
         Returns ``(raw_bytes, shape, dtype)``.
@@ -602,7 +602,7 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
 # ---------------------------------------------------------------------------
 
 
-def _result_from_response(resp: dict) -> Union[RemoteArray, RemoteScalar, tuple, dict]:
+def _result_from_response(resp: dict) -> RemoteArray | RemoteScalar | tuple | dict:
     """Convert a server response dict into the appropriate proxy object.
 
     Examines the ``"result"`` key:

--- a/whest-client/src/whest/flops.py
+++ b/whest-client/src/whest/flops.py
@@ -6,7 +6,7 @@ proxy to the server for more complex estimations.
 
 from __future__ import annotations
 
-from typing import Sequence, Tuple, Union
+from collections.abc import Sequence
 
 from whest._math_compat import prod as _prod
 
@@ -15,7 +15,7 @@ from whest._math_compat import prod as _prod
 # ---------------------------------------------------------------------------
 
 
-def pointwise_cost(shape: Tuple[int, ...]) -> int:
+def pointwise_cost(shape: tuple[int, ...]) -> int:
     """Return the FLOP cost of a pointwise (element-wise) operation.
 
     Parameters
@@ -32,7 +32,7 @@ def pointwise_cost(shape: Tuple[int, ...]) -> int:
     return max(_prod(shape), 1)
 
 
-def reduction_cost(input_shape: Tuple[int, ...], axis: Union[int, None] = None) -> int:
+def reduction_cost(input_shape: tuple[int, ...], axis: int | None = None) -> int:
     """Return the FLOP cost of a reduction operation.
 
     Parameters
@@ -61,7 +61,7 @@ def reduction_cost(input_shape: Tuple[int, ...], axis: Union[int, None] = None) 
 # ---------------------------------------------------------------------------
 
 
-def einsum_cost(subscripts: str, shapes: Sequence[Tuple[int, ...]]) -> int:
+def einsum_cost(subscripts: str, shapes: Sequence[tuple[int, ...]]) -> int:
     """Query the server for the FLOP cost of an einsum operation.
 
     Parameters

--- a/whest-client/tests/test_adversarial.py
+++ b/whest-client/tests/test_adversarial.py
@@ -562,7 +562,7 @@ class TestIterationAndDataAccess:
 
         with we.BudgetContext(flop_budget=1_000_000):
             x = we.array([10.0, 20.0, 30.0])
-            values = [v for v in x]
+            values = list(x)
             assert len(values) == 3
 
     def test_iterate_2d_rows(self):
@@ -646,13 +646,13 @@ class TestErrorCases:
         import whest as we
 
         with pytest.raises(AttributeError, match="blacklisted"):
-            we.save
+            _ = we.save
 
     def test_unknown_function_raises_attribute_error(self):
         import whest as we
 
         with pytest.raises(AttributeError):
-            we.nonexistent_function_xyz_12345
+            _ = we.nonexistent_function_xyz_12345
 
     def test_setitem_raises_type_error(self):
         import whest as we

--- a/whest-client/tests/test_api_surface.py
+++ b/whest-client/tests/test_api_surface.py
@@ -253,29 +253,29 @@ class TestGetattr:
 
     def test_blacklisted_top_level(self):
         with pytest.raises(AttributeError, match="intentionally not supported"):
-            we.save
+            _ = we.save
 
     def test_blacklisted_top_level_load(self):
         with pytest.raises(AttributeError, match="intentionally not supported"):
-            we.load
+            _ = we.load
 
     def test_unknown_top_level(self):
         with pytest.raises(AttributeError, match="has no attribute"):
-            we.completely_nonexistent_function_xyz
+            _ = we.completely_nonexistent_function_xyz
 
     def test_fft_registered_not_blacklisted(self):
         # fft.fft is now counted_custom, not blacklisted
         with pytest.raises(AttributeError, match="registered but not yet implemented"):
-            we.fft.fft
+            _ = we.fft.fft
 
     def test_fft_rfft_registered_not_blacklisted(self):
         # fft.rfft is now counted_custom, not blacklisted
         with pytest.raises(AttributeError, match="registered but not yet implemented"):
-            we.fft.rfft
+            _ = we.fft.rfft
 
     def test_unknown_fft(self):
         with pytest.raises(AttributeError, match="has no attribute"):
-            we.fft.nonexistent_xyz
+            _ = we.fft.nonexistent_xyz
 
     def test_linalg_eig_is_proxy(self):
         # linalg.eig is now a counted_custom proxy, not blacklisted
@@ -283,11 +283,11 @@ class TestGetattr:
 
     def test_unknown_linalg(self):
         with pytest.raises(AttributeError, match="has no attribute"):
-            we.linalg.nonexistent_xyz
+            _ = we.linalg.nonexistent_xyz
 
     def test_unknown_random(self):
         with pytest.raises(AttributeError, match="has no attribute"):
-            we.random.nonexistent_xyz
+            _ = we.random.nonexistent_xyz
 
 
 # ===================================================================

--- a/whest-client/tests/test_integration.py
+++ b/whest-client/tests/test_integration.py
@@ -215,7 +215,7 @@ class TestTransparency:
 
         with we.BudgetContext(flop_budget=1_000_000):
             x = we.array([10.0, 20.0, 30.0])
-            values = [v for v in x]
+            values = list(x)
             assert values == [10.0, 20.0, 30.0]
 
     def test_indexing(self):
@@ -282,13 +282,13 @@ class TestErrors:
         import whest as we
 
         with pytest.raises(AttributeError, match="blacklisted"):
-            we.save
+            _ = we.save
 
     def test_unknown_function(self):
         import whest as we
 
         with pytest.raises(AttributeError):
-            we.nonexistent_function_xyz
+            _ = we.nonexistent_function_xyz
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Enable Ruff lint extensions B, C4, and UP in repository config.
- Apply and fix all new violations from these rule sets.
- Touch related code paths in core, client, tests, and benchmark areas (including #21 target).
- Keep behavior unchanged while removing dead code/useless expressions and tightening exception practices.

Closes #21