### PR TITLE
xfail upstream numpy 2.3 longdouble FFT flake

### DIFF
--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -141,6 +141,27 @@ REMOVED_IN_NUMPY = (
 
 XFAIL_PATTERNS: dict[str, str] = {
     # ------------------------------------------------------------------ #
+    # test_pocketfft.py — upstream numpy flake (not whest's fault)        #
+    # ------------------------------------------------------------------ #
+    # test_identity_long_short_reversed[longdouble] has atol = 5 * spacing
+    # on the dtype, which on Linux x86 (80-bit extended longdouble,
+    # ε ≈ 1.08e-19) leaves about 5.4e-19 of headroom. The test uses
+    # unseeded random input and hits ~5.96e-19 mismatches "fairly often"
+    # (numpy's words). Upstream patched this on numpy main in commit
+    # 0c514d9 by bumping atol from 5×spacing to 6×spacing; shipped in
+    # numpy 2.4 but NOT backported to 2.3. So this pattern fires only
+    # on numpy 2.3 × longdouble × Linux; on 2.2 the native path returned
+    # double anyway, and on 2.4+ the upstream fix means the test passes.
+    # strict=False (the default for our conftest) handles the 2.2/2.4
+    # xpass cases cleanly.
+    "*TestFFT1D::test_identity_long_short_reversed*longdouble*": (
+        "UPSTREAM_NUMPY_FLAKE: numpy 2.3 longdouble FFT tolerance is too "
+        "tight (5×spacing on ε≈1.08e-19 leaves no headroom); unseeded "
+        "random input hits this occasionally. Fixed upstream in numpy "
+        "commit 0c514d9 (atol: 5→6×spacing), shipped in 2.4, not "
+        "backported to 2.3. xpass on 2.2/2.4 is expected."
+    ),
+    # ------------------------------------------------------------------ #
     # test_random.py                                                      #
     # ------------------------------------------------------------------ #
     # test_shuffle iterates the shuffle over 11 array variants and does


### PR DESCRIPTION
## Summary

Follow-up to [#17](https://github.com/AIcrowd/whest/pull/17). Marks an upstream numpy flake as xfail so CI on numpy 2.3 × Linux × `longdouble` isn't red on an unlucky random draw.

## The flake

`numpy.fft.tests.test_pocketfft.py::TestFFT1D::test_identity_long_short_reversed[longdouble]` uses `atol = 5 * np.spacing(longdouble(1.0))`. On Linux x86 where `longdouble` is 80-bit extended precision (ε ≈ 1.08e-19), that gives only ~5.4e-19 of headroom. The test feeds **unseeded** random data, so ~1 in 10 runs hits a mismatch of roughly 5.5–6 × ε and trips the assertion.

Observed on PR #17 run [24572375511 job 71848669583](https://github.com/AIcrowd/whest/actions/runs/24572375511/job/71848669583):

```
FAILED test_pocketfft.py::TestFFT1D::test_identity_long_short_reversed[longdouble]
Mismatched elements: 1 / 16 (6.25%)
Max absolute difference among violations: 5.96311195e-19
```

A re-run of the same commit (no code change, just re-rolled random input) went green.

## Upstream acknowledgement

numpy itself has patched this. Commit [`0c514d9`](https://github.com/numpy/numpy/commit/0c514d9) on `main`, Oct 2025:

> *"MAINT, TST: Increase tolerance in fft test. `test_identity_long_short_reversed` fails fairly often, so increase the test tolerance by a bit."*

The fix bumps `atol` from `5 × spacing` → `6 × spacing`. It shipped in **numpy 2.4** but was **not backported** to `maintenance/2.3.x` (verified via `git compare`).

## Fix in this PR

One new entry in `tests/numpy_compat/xfails.py` scoped tightly to the flaky parametrize:

```python
"*TestFFT1D::test_identity_long_short_reversed*longdouble*": (
    "UPSTREAM_NUMPY_FLAKE: numpy 2.3 longdouble FFT tolerance is too "
    "tight (5×spacing on ε≈1.08e-19 leaves no headroom); unseeded "
    "random input hits this occasionally. Fixed upstream in numpy "
    "commit 0c514d9 (atol: 5→6×spacing), shipped in 2.4, not "
    "backported to 2.3. xpass on 2.2/2.4 is expected."
),
```

- `strict=False` (default in our conftest) means the `xpass` on 2.2 / 2.4 / macOS-ARM is non-fatal.
- Pattern uses `*longdouble*` wildcards because `fnmatch` treats literal `[longdouble]` as a character class; the `single` / `double` parametrizes continue to run normally.
- The single-line pattern auto-retires if we ever drop numpy 2.3 from the CI matrix.

## Test plan

- [x] Locally verified on numpy 2.2 / 2.3 / 2.4: the pattern marks only the `longdouble` parametrize xfail; `single` and `double` pass normally.
- [x] Verified `fnmatch` + substring fallback match the real pytest node ID.
- [x] No other xfail counts change across the three versions.

## Out of scope (tracked separately)

A backport of [`0c514d9`](https://github.com/numpy/numpy/commit/0c514d9) to numpy's own `maintenance/2.3.x` would be a cleaner upstream fix (would likely land in 2.3.6). Willing to send that upstream PR if wanted — just didn't want to couple it with this whest-side mitigation.