### PR TITLE
Make error docs links configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  WHEST_DOCS_ROOT: https://aicrowd.github.io/whest/docs
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/src/whest/errors.py
+++ b/src/whest/errors.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-_DOCS_BASE = "https://aicrowd.github.io/whest/troubleshooting/common-errors"
+import os
+
+_DEFAULT_DOCS_ROOT = "https://aicrowd.github.io/whest/docs"
+_BUDGET_DOCS_PATH = "/guides/budget-planning"
+_COMPETITION_DOCS_PATH = "/getting-started/competition"
+_SYMMETRY_DOCS_PATH = "/guides/symmetry"
+
+
+def _docs_url(path: str) -> str:
+    root = os.environ.get("WHEST_DOCS_ROOT", "").strip() or _DEFAULT_DOCS_ROOT
+    return f"{root.rstrip('/')}{path}"
 
 
 class WhestError(Exception):
@@ -19,7 +29,7 @@ class BudgetExhaustedError(WhestError):
         super().__init__(
             f"{op_name} would cost {flop_cost:,} FLOPs but only "
             f"{flops_remaining:,} remain. "
-            f"See: {_DOCS_BASE}/#budgetexhaustederror"
+            f"See: {_docs_url(_BUDGET_DOCS_PATH)}"
         )
 
 
@@ -33,7 +43,7 @@ class TimeExhaustedError(WhestError):
         super().__init__(
             f"{op_name}: wall-clock time {elapsed_s:.3f}s exceeds "
             f"limit {limit_s:.3f}s. "
-            f"See: {_DOCS_BASE}/#timeexhaustederror"
+            f"See: {_docs_url(_BUDGET_DOCS_PATH)}"
         )
 
 
@@ -44,7 +54,7 @@ class NoBudgetContextError(WhestError):
         super().__init__(
             "No active BudgetContext. "
             "Wrap your code in `with whest.BudgetContext(...):`  "
-            f"See: {_DOCS_BASE}/#nobudgetcontexterror"
+            f"See: {_docs_url(_COMPETITION_DOCS_PATH)}"
         )
 
 
@@ -66,7 +76,7 @@ class SymmetryError(WhestError):
             f"Tensor not symmetric along axes ({', '.join(str(d) for d in axes)}): "
             f"max deviation = {max_deviation} "
             f"(tolerance: atol={atol}, rtol={rtol}). "
-            f"See: {_DOCS_BASE}/#symmetryerror"
+            f"See: {_docs_url(_SYMMETRY_DOCS_PATH)}"
         )
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ from whest.errors import (
     BudgetExhaustedError,
     NoBudgetContextError,
     SymmetryError,
+    TimeExhaustedError,
     UnsupportedFunctionError,
     WhestError,
     WhestWarning,
@@ -44,6 +45,59 @@ def test_symmetry_error_attributes():
     assert err.axes == (0, 1)
     assert err.max_deviation == 0.5
     assert "0, 1" in str(err)
+
+
+def test_error_docs_links_use_hosted_fallback(monkeypatch):
+    monkeypatch.delenv("WHEST_DOCS_ROOT", raising=False)
+
+    assert "https://aicrowd.github.io/whest/docs/guides/budget-planning" in str(
+        BudgetExhaustedError("einsum", flop_cost=100, flops_remaining=50)
+    )
+    assert "https://aicrowd.github.io/whest/docs/guides/budget-planning" in str(
+        TimeExhaustedError("matmul", elapsed_s=1.5, limit_s=1.0)
+    )
+    assert "https://aicrowd.github.io/whest/docs/getting-started/competition" in str(
+        NoBudgetContextError()
+    )
+    assert "https://aicrowd.github.io/whest/docs/guides/symmetry" in str(
+        SymmetryError(axes=(0, 1), max_deviation=0.5)
+    )
+
+
+def test_error_docs_links_use_env_override(monkeypatch):
+    monkeypatch.setenv("WHEST_DOCS_ROOT", "http://localhost:3000/docs")
+
+    assert "http://localhost:3000/docs/guides/budget-planning" in str(
+        BudgetExhaustedError("einsum", flop_cost=100, flops_remaining=50)
+    )
+    assert "http://localhost:3000/docs/guides/budget-planning" in str(
+        TimeExhaustedError("matmul", elapsed_s=1.5, limit_s=1.0)
+    )
+    assert "http://localhost:3000/docs/getting-started/competition" in str(
+        NoBudgetContextError()
+    )
+    assert "http://localhost:3000/docs/guides/symmetry" in str(
+        SymmetryError(axes=(0, 1), max_deviation=0.5)
+    )
+
+
+def test_error_docs_links_normalize_trailing_slash(monkeypatch):
+    monkeypatch.setenv("WHEST_DOCS_ROOT", "http://localhost:3000/docs/")
+
+    assert "http://localhost:3000/docs/guides/budget-planning" in str(
+        TimeExhaustedError("matmul", elapsed_s=1.5, limit_s=1.0)
+    )
+    assert "http://localhost:3000/docs//guides/budget-planning" not in str(
+        TimeExhaustedError("matmul", elapsed_s=1.5, limit_s=1.0)
+    )
+
+
+def test_error_docs_links_blank_env_uses_hosted_fallback(monkeypatch):
+    monkeypatch.setenv("WHEST_DOCS_ROOT", "   ")
+
+    assert "https://aicrowd.github.io/whest/docs/guides/budget-planning" in str(
+        BudgetExhaustedError("einsum", flop_cost=100, flops_remaining=50)
+    )
 
 
 def test_whest_warning_is_warning():

--- a/website/content/docs/development/contributing.mdx
+++ b/website/content/docs/development/contributing.mdx
@@ -72,6 +72,16 @@ uv run pytest
 uv run mkdocs serve
 ```
 
+When running the local docs site and you want whest error messages to link to
+your local copy instead of the hosted site, set:
+
+```bash
+export WHEST_DOCS_ROOT=http://localhost:3000/docs
+```
+
+If `WHEST_DOCS_ROOT` is unset, whest falls back to the hosted docs at
+`https://aicrowd.github.io/whest/docs`.
+
 ### Client package
 
 The client package is independently installable, so its test suite can run via


### PR DESCRIPTION
## Summary

Fixes the stale docs links emitted by core whest exceptions.

Issue `#30` reported that `src/whest/errors.py` still pointed at the old `troubleshooting/common-errors` page, which now 404s. This change replaces that hardcoded URL setup with an env-configurable docs root while keeping a hosted fallback for normal installs.

## What changed

- added `WHEST_DOCS_ROOT` as the single configuration point for exception docs links
- kept `https://aicrowd.github.io/whest/docs` as the fallback when the env var is unset or blank
- resolved the docs root at exception construction time, so tests and local runs can override it without reloading the module
- normalized trailing slashes on `WHEST_DOCS_ROOT`
- kept explicit per-error page targets:
  - `BudgetExhaustedError` -> `/guides/budget-planning`
  - `TimeExhaustedError` -> `/guides/budget-planning`
  - `NoBudgetContextError` -> `/getting-started/competition`
  - `SymmetryError` -> `/guides/symmetry`
- set `WHEST_DOCS_ROOT: https://aicrowd.github.io/whest/docs` at workflow scope in CI
- documented the local override for development docs runs

## Why this approach

This keeps runtime behavior useful for end users while making local development and CI explicit and configurable. It also avoids baking deployment-specific full URLs into every exception message.

## Tests

Added coverage for:
- hosted fallback when `WHEST_DOCS_ROOT` is unset
- local override via `WHEST_DOCS_ROOT`
- trailing slash normalization
- blank env fallback
- correct per-exception page mapping

Verification:
- Not run locally in this session.
