### PR TITLE
Fix API docs dark mode and billing presentation

### DIFF
--- a/website/app/global.css
+++ b/website/app/global.css
@@ -151,13 +151,15 @@ article > div.prose :not(pre) > code {
   font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.92em;
   padding: 0.08em 0.4em;
+  border: 1px solid var(--gray-200);
   border-radius: 4px;
   background: var(--gray-100);
   color: var(--gray-900);
 }
 
 .dark article > div.prose :not(pre) > code {
-  background: color-mix(in oklab, var(--gray-900) 70%, white 0%);
+  background: #232628;
+  border-color: rgba(232, 234, 235, 0.26);
   color: #E8EAEB;
 }
 

--- a/website/components/api-reference/ApiReference.tsx
+++ b/website/components/api-reference/ApiReference.tsx
@@ -57,8 +57,7 @@ export default function ApiReference({operations}: ApiReferenceProps): React.Rea
               <th>Operation</th>
               <th>Area</th>
               <th>Type</th>
-              <th>Weight</th>
-              <th>Cost Formula</th>
+              <th>Cost</th>
             </tr>
           </thead>
           <tbody>
@@ -67,7 +66,7 @@ export default function ApiReference({operations}: ApiReferenceProps): React.Rea
             ))}
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={5} className={styles.noResults}>
+                <td colSpan={4} className={styles.noResults}>
                   No operations match your filters.
                 </td>
               </tr>

--- a/website/components/api-reference/BilledCost.tsx
+++ b/website/components/api-reference/BilledCost.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import Latex, {stripMathDelimiters} from '../shared/Latex';
+import styles from './styles.module.css';
+
+export interface CostDisplayOperation {
+  weight: number;
+  cost_formula: string;
+  cost_formula_latex: string;
+  display_type: string;
+  free?: boolean;
+  blocked?: boolean;
+}
+
+function weightBucket(weight: number) {
+  if (weight >= 16) return 'weight--16';
+  if (weight >= 4) return 'weight--4';
+  if (weight >= 2) return 'weight--2';
+  return 'weight--1';
+}
+
+function formatWeight(weight: number) {
+  return Number.isInteger(weight) ? `${weight}×` : `${weight.toFixed(1)}×`;
+}
+
+function renderFormulaContent(op: CostDisplayOperation) {
+  const latex = op.cost_formula_latex.trim();
+  if (latex.startsWith('$') && latex.endsWith('$')) {
+    return <Latex math={stripMathDelimiters(latex)} />;
+  }
+
+  const plain = op.cost_formula.trim();
+  if (plain) {
+    return <span>{plain}</span>;
+  }
+
+  if (latex) {
+    return <span>{latex}</span>;
+  }
+
+  return <span>&mdash;</span>;
+}
+
+export default function BilledCost({
+  op,
+  className,
+}: {
+  op: CostDisplayOperation;
+  className?: string;
+}): React.ReactElement {
+  if (op.blocked || op.display_type === 'blocked') {
+    return <span className={`${styles.billedCost} ${styles.billedCostBlocked}`.trim()}>&mdash;</span>;
+  }
+
+  if (op.free || op.display_type === 'free') {
+    return (
+      <span className={`${styles.billedCost} ${className ?? ''}`.trim()}>
+        <span className={styles.billedCostExpression}>0</span>
+      </span>
+    );
+  }
+
+  const showWeight = op.weight !== 1;
+  const weightLabel = formatWeight(op.weight);
+
+  return (
+    <span className={`${styles.billedCost} ${className ?? ''}`.trim()}>
+      {showWeight ? (
+        <span
+          className={`${styles.weightChip} ${styles[weightBucket(op.weight)]} ${styles.costWeightFactor}`}
+          title={`Weight multiplier ${weightLabel}`}
+        >
+          {weightLabel}
+        </span>
+      ) : null}
+      <span className={styles.billedCostExpression}>{renderFormulaContent(op)}</span>
+    </span>
+  );
+}

--- a/website/components/api-reference/OperationDocBody.tsx
+++ b/website/components/api-reference/OperationDocBody.tsx
@@ -1,11 +1,11 @@
-import {highlight} from 'fumadocs-core/highlight';
-import {CodeBlock, Pre} from 'fumadocs-ui/components/codeblock';
-import {Children, Fragment, isValidElement, type CSSProperties, type ReactElement, type ReactNode} from 'react';
+import {ServerCodeBlock} from 'fumadocs-ui/components/codeblock.rsc';
+import {Fragment, type ReactNode} from 'react';
 import Latex from '../shared/Latex';
 import OperationDocFieldList from './OperationDocFieldList';
 import OperationDocLink from './OperationDocLink';
 import OperationDocSectionHeading from './OperationDocSectionHeading';
 import OperationDocSignature from './OperationDocSignature';
+import {apiCodeThemes} from './runtime-shiki-themes';
 import styles from './styles.module.css';
 import type {
   DocBlock,
@@ -22,18 +22,6 @@ import type {
   DocRawBlock,
   DocSection,
 } from './op-doc-types';
-
-const editorTheme = {
-  light: 'github-light',
-  dark: 'github-dark',
-} as const;
-
-type HighlightedPre = ReactElement<{
-  children?: ReactNode;
-  className?: string;
-  style?: CSSProperties;
-  tabIndex?: number;
-}>;
 
 function renderInline(nodes: DocInlineNode[]): ReactNode[] {
   return nodes.flatMap((node, index) => [
@@ -276,19 +264,18 @@ async function renderDoctest(block: DocBlock & {lines: DocLine[]}): Promise<Reac
 }
 
 async function renderHighlightedCode(code: string, lang: string): Promise<ReactNode> {
-  const highlighted = await highlight(code, {lang, themes: editorTheme});
-  const preNode = Children.toArray(highlighted).find(
-    (child): child is HighlightedPre => isValidElement(child) && child.type === 'pre',
-  );
-
-  if (!preNode) {
-    return <CodeBlock allowCopy={false}>{highlighted}</CodeBlock>;
-  }
-
   return (
-    <CodeBlock allowCopy={false} className={preNode.props.className} style={preNode.props.style}>
-      <Pre tabIndex={preNode.props.tabIndex}>{preNode.props.children}</Pre>
-    </CodeBlock>
+    <ServerCodeBlock
+      code={code}
+      lang={lang}
+      themes={apiCodeThemes}
+      codeblock={{
+        allowCopy: false,
+        keepBackground: true,
+        className: styles.apiCodeFigure,
+        viewportProps: {className: styles.apiCodeViewport},
+      }}
+    />
   );
 }
 

--- a/website/components/api-reference/OperationDocExample.tsx
+++ b/website/components/api-reference/OperationDocExample.tsx
@@ -1,67 +1,42 @@
-import {highlight} from 'fumadocs-core/highlight';
-import {CodeBlock, Pre} from 'fumadocs-ui/components/codeblock';
+import {ServerCodeBlock} from 'fumadocs-ui/components/codeblock.rsc';
 import {Terminal} from 'lucide-react';
-import {
-  Children,
-  isValidElement,
-  type ComponentProps,
-  type CSSProperties,
-  type ReactElement,
-  type ReactNode,
-} from 'react';
+import {apiCodeThemes} from './runtime-shiki-themes';
 import styles from './styles.module.css';
 import type {DocExample} from './op-doc-types';
-
-const editorTheme = {
-  light: 'github-light',
-  dark: 'github-dark',
-} as const;
-
-type HighlightedPre = ReactElement<{
-  children?: ReactNode;
-  className?: string;
-  style?: CSSProperties;
-  tabIndex?: number;
-}>;
-
-function renderHighlightedBlock(highlighted: ReactNode, props?: ComponentProps<typeof CodeBlock>) {
-  const preNode = Children.toArray(highlighted).find(
-    (child): child is HighlightedPre => isValidElement(child) && child.type === 'pre',
-  );
-
-  if (!preNode) {
-    return <CodeBlock {...props}>{highlighted}</CodeBlock>;
-  }
-
-  return (
-    <CodeBlock {...props} className={preNode.props.className} style={preNode.props.style}>
-      <Pre tabIndex={preNode.props.tabIndex}>{preNode.props.children}</Pre>
-    </CodeBlock>
-  );
-}
 
 export default async function OperationDocExample({example}: {example?: DocExample | null}) {
   if (!example) {
     return null;
   }
 
-  const [highlightedCode, highlightedOutput] = await Promise.all([
-    highlight(example.code, {lang: 'python', themes: editorTheme}),
-    example.output
-      ? highlight(example.output, {lang: 'python', themes: editorTheme})
-      : Promise.resolve(null),
-  ]);
-
   return (
     <section className={styles.docSection}>
       <h2>Examples</h2>
-      {renderHighlightedBlock(highlightedCode, {allowCopy: false})}
-      {highlightedOutput ? (
-        renderHighlightedBlock(highlightedOutput, {
-          title: 'output',
-          icon: <Terminal className="size-3.5" />,
-          className: styles.docOutputSpacing,
-        })
+      <ServerCodeBlock
+        code={example.code}
+        lang="python"
+        themes={apiCodeThemes}
+        codeblock={{
+          allowCopy: false,
+          keepBackground: true,
+          className: styles.apiCodeFigure,
+          viewportProps: {className: styles.apiCodeViewport},
+        }}
+      />
+      {example.output ? (
+        <ServerCodeBlock
+          code={example.output}
+          lang="python"
+          themes={apiCodeThemes}
+          codeblock={{
+            allowCopy: false,
+            keepBackground: true,
+            title: 'output',
+            icon: <Terminal className="size-3.5" />,
+            className: `${styles.apiCodeFigure} ${styles.docOutputSpacing}`,
+            viewportProps: {className: styles.apiCodeViewport},
+          }}
+        />
       ) : null}
     </section>
   );

--- a/website/components/api-reference/OperationDocNav.tsx
+++ b/website/components/api-reference/OperationDocNav.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import {ChevronLeft, ChevronRight} from 'lucide-react';
 import type {OperationNavLink} from './op-doc-types';
+import styles from './styles.module.css';
 
 function NavCard({link, index}: {link: OperationNavLink; index: 0 | 1}) {
   const Icon = index === 0 ? ChevronLeft : ChevronRight;
@@ -9,6 +10,7 @@ function NavCard({link, index}: {link: OperationNavLink; index: 0 | 1}) {
     <Link
       href={link.href}
       className={[
+        styles.docNavCard,
         'flex flex-col gap-2 rounded-lg border p-4 text-sm transition-colors hover:bg-fd-accent/80 hover:text-fd-accent-foreground @max-lg:col-span-full',
         index === 1 ? 'text-end' : '',
       ]
@@ -47,6 +49,7 @@ export default function OperationDocNav({
   return (
     <nav
       className={[
+        styles.docNav,
         '@container grid gap-4',
         previous && next ? 'grid-cols-2' : 'grid-cols-1',
       ].join(' ')}

--- a/website/components/api-reference/OperationDocOverlay.tsx
+++ b/website/components/api-reference/OperationDocOverlay.tsx
@@ -1,19 +1,6 @@
-import Latex, {stripMathDelimiters} from '../shared/Latex';
+import BilledCost from './BilledCost';
 import styles from './styles.module.css';
 import type {OperationDocRecord} from './op-doc-types';
-
-function renderFormula(value: string) {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return <span>&mdash;</span>;
-  }
-
-  if (trimmed.startsWith('$') && trimmed.endsWith('$')) {
-    return <Latex math={stripMathDelimiters(trimmed)} display />;
-  }
-
-  return <span>{trimmed}</span>;
-}
 
 // Paper-register metadata panel: no card chrome, no "Quick Info" heading.
 // Kickers + chips/values flow as part of the page directly under the
@@ -21,7 +8,6 @@ function renderFormula(value: string) {
 // data sits in the prose flow without widget framing.
 export default function OperationDocOverlay({op}: {op: OperationDocRecord}) {
   const aliases = op.aliases.length ? op.aliases.map((alias) => `we.${alias}`).join(', ') : null;
-  const formattedWeight = Number.isInteger(op.weight) ? op.weight.toString() : op.weight.toFixed(1);
 
   return (
     <section className={styles.docOverlay} aria-label="Operation summary">
@@ -37,12 +23,16 @@ export default function OperationDocOverlay({op}: {op: OperationDocRecord}) {
           </span>
         </div>
         <div className={styles.docMetaPair}>
-          <span className={styles.docMetaLabel}>Weight</span>
-          <span className={styles.docMetaValue}>{formattedWeight}&times;</span>
-        </div>
-        <div className={styles.docMetaPair}>
           <span className={styles.docMetaLabel}>NumPy Ref</span>
-          <span className={styles.docMetaValue}>{op.numpy_ref}</span>
+          <span className={styles.docMetaValue}>
+            {op.provenance_url ? (
+              <a href={op.provenance_url} target="_blank" rel="noreferrer">
+                {op.numpy_ref}
+              </a>
+            ) : (
+              op.numpy_ref
+            )}
+          </span>
         </div>
       </div>
 
@@ -54,8 +44,10 @@ export default function OperationDocOverlay({op}: {op: OperationDocRecord}) {
       ) : null}
 
       <div className={styles.docMetaRow}>
-        <span className={styles.docMetaLabel}>Cost Formula</span>
-        <div className={styles.docFormula}>{renderFormula(op.cost_formula_latex)}</div>
+        <span className={styles.docMetaLabel}>Cost</span>
+        <div className={styles.docFormula}>
+          <BilledCost op={op} />
+        </div>
       </div>
 
       {op.notes ? (

--- a/website/components/api-reference/OperationRow.tsx
+++ b/website/components/api-reference/OperationRow.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
-import Latex, {stripMathDelimiters} from '../shared/Latex';
+import BilledCost from './BilledCost';
 import styles from './styles.module.css';
 
 export interface Operation {
@@ -23,26 +23,6 @@ export interface Operation {
   href?: string;
 }
 
-function renderFormula(op: Operation) {
-  const latex = op.cost_formula_latex.trim();
-  if (latex.startsWith('$') && latex.endsWith('$')) {
-    return <Latex math={stripMathDelimiters(latex)} />;
-  }
-
-  return <span>{op.cost_formula || '\u2014'}</span>;
-}
-
-function weightBucket(weight: number) {
-  if (weight >= 16) return 'weight--16';
-  if (weight >= 4) return 'weight--4';
-  if (weight >= 2) return 'weight--2';
-  return 'weight--1';
-}
-
-function formatWeight(weight: number) {
-  return Number.isInteger(weight) ? `${weight}×` : `${weight.toFixed(1)}×`;
-}
-
 export default function OperationRow({op}: {op: Operation}): React.ReactElement {
   const opLabel = <span className={styles.opLink}>{op.whest_ref}</span>;
 
@@ -59,15 +39,9 @@ export default function OperationRow({op}: {op: Operation}): React.ReactElement 
           {op.display_type}
         </span>
       </td>
-      <td className={styles.opWeight}>
-        <span
-          className={`${styles.weightChip} ${styles[weightBucket(op.weight)]}`}
-          title={`Empirical weight ${op.weight.toFixed(1)}×`}
-        >
-          {formatWeight(op.weight)}
-        </span>
+      <td className={styles.opCost}>
+        <BilledCost op={op} className={styles.opBilledCost} />
       </td>
-      <td className={styles.opFormula}>{renderFormula(op)}</td>
     </tr>
   );
 }

--- a/website/components/api-reference/runtime-shiki-themes.ts
+++ b/website/components/api-reference/runtime-shiki-themes.ts
@@ -1,0 +1,19 @@
+import { whestDark, whestLight } from '@/lib/shiki-themes';
+
+const whestApiDark = {
+  ...whestDark,
+  name: 'whest-api-ink',
+  colors: {
+    ...whestDark.colors,
+    'editor.background': '#232628',
+    'editor.selectionBackground': '#34393B',
+    'editorLineNumber.foreground': '#7B8284',
+  },
+};
+
+export const apiCodeThemes = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  light: whestLight as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dark: whestApiDark as any,
+} as const;

--- a/website/components/api-reference/styles.module.css
+++ b/website/components/api-reference/styles.module.css
@@ -1,3 +1,85 @@
+.apiReference,
+.docHeader,
+.docOverlay,
+.docSection,
+.docSignatureBlock,
+.docNav {
+  --api-surface-border: var(--gray-200, #D9DCDC);
+  --api-surface-border-strong: rgba(217, 220, 220, 0.95);
+  --api-link-color: #c83c38;
+  --api-link-hover-color: #b73a36;
+  --api-source-link-color: #0b8ea5;
+  --api-source-link-hover-color: #087f94;
+  --api-chip-core-bg: var(--gray-100, #F1F3F5);
+  --api-chip-core-fg: var(--gray-900, #292C2D);
+  --api-chip-linalg-bg: rgba(74, 124, 255, 0.12);
+  --api-chip-linalg-fg: #1E4ACC;
+  --api-chip-fft-bg: rgba(250, 158, 51, 0.15);
+  --api-chip-fft-fg: #A8650B;
+  --api-chip-random-bg: rgba(35, 183, 97, 0.13);
+  --api-chip-random-fg: #126E39;
+  --api-chip-stats-bg: var(--coral-light, #FEF2F1);
+  --api-chip-stats-fg: var(--coral-hover, #D23934);
+  --api-chip-counted-bg: rgba(74, 124, 255, 0.12);
+  --api-chip-counted-fg: #1E4ACC;
+  --api-chip-custom-bg: rgba(250, 158, 51, 0.18);
+  --api-chip-custom-fg: #A8650B;
+  --api-chip-free-bg: rgba(35, 183, 97, 0.13);
+  --api-chip-free-fg: #126E39;
+  --api-chip-blocked-bg: var(--coral-light, #FEF2F1);
+  --api-chip-blocked-fg: var(--coral-hover, #D23934);
+  --api-code-block-border: rgba(217, 220, 220, 0.95);
+  --api-code-surface: #ffffff;
+  --api-summary-fg: var(--gray-600, #5D5F60);
+  --api-signature-ink: var(--gray-900, #292C2D);
+  --api-signature-muted: var(--gray-600, #5D5F60);
+  --api-nav-separator: rgba(217, 220, 220, 0.95);
+  --api-nav-card-border: rgba(217, 220, 220, 0.95);
+  --api-nav-card-bg: transparent;
+  --api-nav-card-hover-bg: rgba(240, 82, 77, 0.08);
+}
+
+:global(.dark) .apiReference,
+:global(.dark) .docHeader,
+:global(.dark) .docOverlay,
+:global(.dark) .docSection,
+:global(.dark) .docSignatureBlock,
+:global(.dark) .docNav {
+  --api-surface-border: rgba(232, 234, 235, 0.24);
+  --api-surface-border-strong: rgba(232, 234, 235, 0.32);
+  --api-link-color: #ffb0a4;
+  --api-link-hover-color: #ffd0c8;
+  --api-source-link-color: #8ce7df;
+  --api-source-link-hover-color: #b2f4ee;
+  --api-chip-core-bg: #313537;
+  --api-chip-core-fg: #F1F3F5;
+  --api-chip-linalg-bg: #1F2C44;
+  --api-chip-linalg-fg: #BFD1FF;
+  --api-chip-fft-bg: #3B2C18;
+  --api-chip-fft-fg: #FFD28F;
+  --api-chip-random-bg: #163126;
+  --api-chip-random-fg: #8DE0AA;
+  --api-chip-stats-bg: #452525;
+  --api-chip-stats-fg: #FFC2B6;
+  --api-chip-counted-bg: #2B3442;
+  --api-chip-counted-fg: #D6E0F5;
+  --api-chip-custom-bg: #3A3122;
+  --api-chip-custom-fg: #F2D1A0;
+  --api-chip-free-bg: #22352C;
+  --api-chip-free-fg: #B7E0C1;
+  --api-chip-blocked-bg: #44302F;
+  --api-chip-blocked-fg: #F1C1BA;
+  --api-code-block-border: rgba(232, 234, 235, 0.24);
+  --api-code-surface: #232628;
+  --api-summary-fg: #B1B6B8;
+  --api-signature-ink: #E8EAEB;
+  --api-signature-muted: #BEC3C5;
+  --api-nav-separator: rgba(232, 234, 235, 0.26);
+  --api-nav-card-border: rgba(232, 234, 235, 0.26);
+  --api-nav-card-bg: rgba(255, 255, 255, 0.02);
+  --api-nav-card-hover-bg: rgba(240, 82, 77, 0.14);
+}
+
 /* ── ApiReference wrapper ──────────────────────────────── */
 .apiReference {
   width: 100%;
@@ -105,7 +187,7 @@
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   max-width: calc(100vw - 2rem);
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--api-surface-border);
   border-radius: 8px;
 }
 
@@ -124,13 +206,13 @@
   font-weight: 600;
   text-align: left;
   padding: 10px 16px;
-  border-bottom: 2px solid hsl(var(--border));
+  border-bottom: 2px solid var(--api-surface-border-strong);
   white-space: nowrap;
 }
 
 .opsTable td {
   padding: 10px 16px;
-  border-bottom: 1px solid hsl(var(--secondary));
+  border-bottom: 1px solid var(--api-surface-border);
   vertical-align: middle;
 }
 
@@ -159,7 +241,7 @@
 }
 
 .opLink {
-  color: #c83c38;
+  color: var(--api-link-color);
   font-weight: 550;
   text-decoration: none;
 }
@@ -168,7 +250,7 @@
   color: hsl(var(--muted-foreground));
 }
 
-.opWeight {
+.opCost {
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
@@ -184,9 +266,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 3.6rem;
+  min-width: 3.2rem;
   padding: 0.18rem 0.55rem;
-  border-radius: 999px;
+  border-radius: 0.55rem;
+  border: 1px solid transparent;
   font-family: var(--font-app-sans, ui-sans-serif, system-ui, sans-serif);
   font-size: 0.74rem;
   font-weight: 700;
@@ -194,13 +277,9 @@
   white-space: nowrap;
 }
 
-.weight--1 {
-  background: var(--gray-100, #F1F3F5);
-  color: var(--gray-600, #5D5F60);
-}
-
+.weight--1,
 .weight--2 {
-  background: color-mix(in oklab, var(--coral) 10%, transparent);
+  background: color-mix(in oklab, var(--coral) 18%, transparent);
   color: var(--coral-hover, #D23934);
 }
 
@@ -210,13 +289,57 @@
 }
 
 .weight--16 {
-  background: var(--coral, #F0524D);
-  color: #ffffff;
+  background: color-mix(in oklab, var(--coral) 18%, transparent);
+  color: var(--coral-hover, #D23934);
+  border-color: color-mix(in oklab, var(--coral) 42%, transparent);
 }
 
-.opFormula {
+.billedCost.opBilledCost {
+  display: inline-grid;
+  grid-template-columns: 3.5rem auto;
+  align-items: center;
+  column-gap: 0.55rem;
   white-space: nowrap;
+}
+
+.billedCost.opBilledCost .billedCostExpression {
+  grid-column: 2;
+}
+
+.billedCost.opBilledCost .costWeightFactor {
+  grid-column: 1;
+  justify-self: start;
+}
+
+.billedCost {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.billedCostBlocked {
   color: hsl(var(--muted-foreground));
+}
+
+.billedCostExpression {
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+}
+
+.billedCostExpression :global(.katex) {
+  font-size: 1em;
+}
+
+.billedCostExpression :global(.katex-display) {
+  margin: 0;
+}
+
+.costWeightFactor {
+  min-width: auto;
+  padding-inline: 0.5rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .areaChip,
@@ -235,49 +358,49 @@
 
 /* Areas — neutral "default" for `core`, then the four semantics */
 .area--core {
-  background: var(--gray-100, #F1F3F5);
-  color: var(--gray-900, #292C2D);
+  background: var(--api-chip-core-bg);
+  color: var(--api-chip-core-fg);
 }
 
 .area--linalg {
-  background: rgba(74, 124, 255, 0.12);
-  color: #1E4ACC;
+  background: var(--api-chip-linalg-bg);
+  color: var(--api-chip-linalg-fg);
 }
 
 .area--fft {
-  background: rgba(250, 158, 51, 0.15);
-  color: #A8650B;
+  background: var(--api-chip-fft-bg);
+  color: var(--api-chip-fft-fg);
 }
 
 .area--random {
-  background: rgba(35, 183, 97, 0.13);
-  color: #126E39;
+  background: var(--api-chip-random-bg);
+  color: var(--api-chip-random-fg);
 }
 
 .area--stats {
-  background: var(--coral-light, #FEF2F1);
-  color: var(--coral-hover, #D23934);
+  background: var(--api-chip-stats-bg);
+  color: var(--api-chip-stats-fg);
 }
 
 /* Types — same palette, distinct meaning */
 .type--counted {
-  background: rgba(74, 124, 255, 0.12);
-  color: #1E4ACC;
+  background: var(--api-chip-counted-bg);
+  color: var(--api-chip-counted-fg);
 }
 
 .type--custom {
-  background: rgba(250, 158, 51, 0.18);
-  color: #A8650B;
+  background: var(--api-chip-custom-bg);
+  color: var(--api-chip-custom-fg);
 }
 
 .type--free {
-  background: rgba(35, 183, 97, 0.13);
-  color: #126E39;
+  background: var(--api-chip-free-bg);
+  color: var(--api-chip-free-fg);
 }
 
 .type--blocked {
-  background: var(--coral-light, #FEF2F1);
-  color: var(--coral-hover, #D23934);
+  background: var(--api-chip-blocked-bg);
+  color: var(--api-chip-blocked-fg);
 }
 
 .docHeader {
@@ -303,7 +426,7 @@
   font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Consolas, monospace !important;
   font-size: 1.0625rem;
   line-height: 1.45;
-  color: var(--gray-900);
+  color: var(--api-signature-ink);
 }
 .docSignature span {
   font-family: inherit;
@@ -317,7 +440,7 @@
 
 .docSignatureNamespace {
   font-weight: 500;
-  color: var(--gray-600);
+  color: var(--api-signature-muted);
 }
 
 .docSignatureFunction {
@@ -327,7 +450,7 @@
 
 .docSignatureParams {
   font-weight: 400;
-  color: var(--gray-900);
+  color: var(--api-signature-ink);
 }
 
 .docSummary {
@@ -335,7 +458,7 @@
   margin: 0.4rem 0 0;
   font-size: 1rem;
   line-height: 1.65;
-  color: var(--gray-900);
+  color: var(--api-summary-fg);
 }
 
 .docMetaLine {
@@ -371,7 +494,7 @@
 }
 
 .docSourceLink {
-  color: #0b8ea5;
+  color: var(--api-source-link-color);
   font-size: 0.86rem;
   font-weight: 700;
   text-decoration: underline;
@@ -380,7 +503,7 @@
 }
 
 .docSourceLink:hover {
-  color: #087f94;
+  color: var(--api-source-link-hover-color);
 }
 
 @media (max-width: 860px) {
@@ -401,7 +524,7 @@
   box-shadow: none;
 }
 
-/* Top strip — Area / Type / Weight / NumPy Ref as inline kicker+value pairs */
+/* Top strip — Area / Type / NumPy Ref as inline kicker+value pairs */
 .docMetaStrip {
   display: flex;
   flex-wrap: wrap;
@@ -409,8 +532,8 @@
   gap: 0.6rem 1.75rem;
   margin: 0 0 1.25rem;
   padding: 0.75rem 0;
-  border-top: 1px solid var(--gray-200, #D9DCDC);
-  border-bottom: 1px solid var(--gray-200, #D9DCDC);
+  border-top: 1px solid var(--api-surface-border-strong);
+  border-bottom: 1px solid var(--api-surface-border-strong);
 }
 
 .docMetaPair {
@@ -491,6 +614,9 @@
 
 .docFormula {
   font-size: 0.92rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
 }
 
 .docPlaceholder {
@@ -640,11 +766,12 @@
 }
 
 .docLinkList a {
-  color: #c83c38;
+  color: var(--api-link-color);
   text-decoration: none;
 }
 
 .docLinkList a:hover {
+  color: var(--api-link-hover-color);
   text-decoration: underline;
 }
 
@@ -700,6 +827,62 @@
 
 .docOutputSpacing {
   margin-top: 1rem;
+}
+
+.apiCodeFigure {
+  margin: 0 0 1rem;
+  border-color: var(--api-code-block-border);
+  border-radius: 0.5rem;
+  background: var(--api-code-surface);
+  box-shadow: none;
+}
+
+.apiCodeViewport {
+  padding-top: 0;
+  padding-bottom: 0;
+  max-height: none;
+}
+
+.apiCodeFigure :global(pre) {
+  min-width: 100%;
+  margin: 0;
+  padding: 0.95rem 1.15rem;
+  background: transparent !important;
+  color: var(--shiki-light, #292C2D) !important;
+  border: none;
+  border-radius: 0;
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+
+.apiCodeFigure :global(.line) {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+:global(.dark) .apiCodeFigure :global(pre) {
+  background: transparent !important;
+  color: var(--shiki-dark, #E8EAEB) !important;
+}
+
+:global(.dark) .apiCodeFigure :global(code span) {
+  color: var(--shiki-dark) !important;
+  font-style: var(--shiki-dark-font-style);
+}
+
+.docNav {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--api-nav-separator);
+}
+
+.docNavCard {
+  border-color: var(--api-nav-card-border);
+  background: var(--api-nav-card-bg);
+}
+
+.docNavCard:hover {
+  background: var(--api-nav-card-hover-bg);
 }
 
 .status--partial {

--- a/website/op-pages.test.mjs
+++ b/website/op-pages.test.mjs
@@ -34,3 +34,72 @@ test('op pages use the dedicated numpy-style renderer stack', async () => {
   assert.match(pageSource, /OperationDocBody/);
   assert.match(pageSource, /OperationDocSignature/);
 });
+
+test('api runtime code blocks use shared whest themes and preserve shiki backgrounds', async () => {
+  const bodySource = await readSource('components/api-reference/OperationDocBody.tsx');
+  const exampleSource = await readSource('components/api-reference/OperationDocExample.tsx');
+  const themeSource = await readSource('components/api-reference/runtime-shiki-themes.ts');
+
+  assert.match(bodySource, /from '\.\/runtime-shiki-themes'/);
+  assert.match(exampleSource, /from '\.\/runtime-shiki-themes'/);
+  assert.match(bodySource, /ServerCodeBlock/);
+  assert.match(exampleSource, /ServerCodeBlock/);
+  assert.doesNotMatch(bodySource, /github-light|github-dark/);
+  assert.doesNotMatch(exampleSource, /github-light|github-dark/);
+  assert.match(bodySource, /keepBackground/);
+  assert.match(exampleSource, /keepBackground/);
+  assert.match(themeSource, /whestLight/);
+  assert.match(themeSource, /whestDark/);
+  assert.match(themeSource, /editor\.background': '#232628'/);
+});
+
+test('api dark-mode styling is explicitly defined for shared chrome', async () => {
+  const cssSource = await readSource('components/api-reference/styles.module.css');
+  const navSource = await readSource('components/api-reference/OperationDocNav.tsx');
+  const globalSource = await readSource('app/global.css');
+
+  assert.match(cssSource, /:global\(\.dark\)\s+\.apiReference/);
+  assert.match(cssSource, /--api-link-color/);
+  assert.match(cssSource, /--api-nav-card-border/);
+  assert.match(cssSource, /--api-chip-counted-bg/);
+  assert.match(cssSource, /--api-summary-fg/);
+  assert.match(cssSource, /--api-signature-ink/);
+  assert.match(cssSource, /:global\(\.dark\)\s+\.docHeader/);
+  assert.match(cssSource, /\.apiCodeFigure/);
+  assert.match(cssSource, /\.apiCodeViewport/);
+  assert.match(cssSource, /\.apiCodeFigure\s+:global\(pre\)/);
+  assert.match(cssSource, /\.apiCodeFigure\s+:global\(\.line\)/);
+  assert.match(cssSource, /color:\s*var\(--shiki-dark/);
+  assert.match(navSource, /styles\.docNav/);
+  assert.match(navSource, /styles\.docNavCard/);
+  assert.match(globalSource, /\.dark article > div\.prose :not\(pre\) > code/);
+  assert.match(globalSource, /border-color:\s*rgba\(232,\s*234,\s*235,\s*0\.26\)/);
+});
+
+test('api billing presentation is unified around a single cost field', async () => {
+  const tableSource = await readSource('components/api-reference/ApiReference.tsx');
+  const rowSource = await readSource('components/api-reference/OperationRow.tsx');
+  const overlaySource = await readSource('components/api-reference/OperationDocOverlay.tsx');
+  const billedCostSource = await readSource('components/api-reference/BilledCost.tsx');
+
+  assert.match(tableSource, /<th>Cost<\/th>/);
+  assert.doesNotMatch(tableSource, /<th>Weight<\/th>/);
+  assert.doesNotMatch(tableSource, /<th>Cost Formula<\/th>/);
+  assert.match(tableSource, /colSpan=\{4\}/);
+
+  assert.match(overlaySource, /Cost/);
+  assert.doesNotMatch(overlaySource, /Weight/);
+  assert.doesNotMatch(overlaySource, /Cost Formula/);
+
+  assert.match(rowSource, /BilledCost/);
+  assert.match(overlaySource, /BilledCost/);
+  assert.match(billedCostSource, /weight !== 1/);
+  assert.match(billedCostSource, /display_type === 'free'/);
+  assert.match(billedCostSource, /display_type === 'blocked'/);
+  assert.match(billedCostSource, /Weight multiplier/);
+  assert.match(billedCostSource, /formatWeight/);
+  assert.match(billedCostSource, /stripMathDelimiters/);
+  assert.match(billedCostSource, /op\.cost_formula/);
+  assert.match(billedCostSource, />0</);
+  assert.match(billedCostSource, /&mdash;|\\u2014/);
+});


### PR DESCRIPTION
## Summary

Fix the API reference dark-mode regressions and clean up the billing presentation on the op docs pages.

Closes #45

## What changed

- switched runtime-highlighted API code blocks to shared Whest-based Shiki themes
- preserved Shiki backgrounds and fixed dark-mode code block rendering
- improved dark-mode API chrome: chips, links, inline code, separators, nav chrome, and typography contrast
- unified `Weight` + `Cost Formula` into a single `Cost` presentation
- added a shared billed-cost renderer for the API table and op detail pages
- aligned table cost expressions with a fixed weight gutter
- linked `NumPy Ref` values on op pages to the upstream NumPy docs
- normalized weight tokens to a subdued rectangular style
- added source-level regressions for theme usage, billing presentation, and shared dark-mode styling

## Why

The docs had two related problems:

1. dark mode was leaking light-only styles into API docs surfaces, including code blocks and metadata chrome
2. the billing UI exposed internal factors (`Weight` and `Cost Formula`) separately instead of the billable expression users actually care about

## Validation

Passed:

- `node --test website/op-pages.test.mjs`
- `python3 -m uv sync --all-extras --quiet`
- `make ci UV='python3 -m uv run'` through lint, repo tests, NumPy-compat, sync checks, and parity tests
- manual Playwright verification against local docs pages for the API table and `/docs/api/ops/sin/`

Blocked locally by environment:

- website production build/check could not complete in this shell because Next/Turbopack and `lightningcss` native binaries are unavailable here
- attempted fallback `next build --webpack`, but it still failed on missing native `lightningcss` bindings in local `node_modules`

## Impact

- API docs are readable in dark mode again
- billing information is simpler and more consistent across the API table and operation detail pages
- op pages now link directly to the matching NumPy reference entry
