### PR TITLE
Fix explorer appendix and home routing

### DIFF
--- a/website/components/symmetry-aware-einsum-contractions/SymmetryAwareEinsumContractionsApp.jsx
+++ b/website/components/symmetry-aware-einsum-contractions/SymmetryAwareEinsumContractionsApp.jsx
@@ -47,6 +47,23 @@ const CUSTOM_IDX = -1;
 const DEFAULT_EXAMPLE_ID = 'triple-outer';
 const DEFAULT_EXAMPLE_IDX = Math.max(0, EXAMPLES.findIndex((example) => example.id === DEFAULT_EXAMPLE_ID));
 const DEFAULT_DIMENSION_N = 5;
+const APPENDIX_ROOT_HASH = '#appendix';
+const APPENDIX_SECTION_HASH_PREFIX = '#appendix-section-';
+const APPENDIX_RETURN_HASH = '#cost-savings';
+
+function isAppendixHash(hash = '') {
+  return hash === APPENDIX_ROOT_HASH || hash.startsWith(APPENDIX_SECTION_HASH_PREFIX);
+}
+
+function scrollToHashTarget(hash) {
+  if (typeof document === 'undefined') return;
+  if (hash === APPENDIX_ROOT_HASH) {
+    document.getElementById('expr-modal-heading')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return;
+  }
+  if (!hash?.startsWith('#')) return;
+  document.getElementById(hash.slice(1))?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
 
 function presetDefaultSize(example) {
   const sizes = Object.values(example?.labelSizes ?? {}).filter(
@@ -108,6 +125,7 @@ export default function SymmetryAwareEinsumContractionsApp() {
   const [graphHover, setGraphHover] = useState(null);
   const [exprModalOpen, setExprModalOpen] = useState(false);
   const [isThemeDockVisible, setIsThemeDockVisible] = useState(false);
+  const appendixReturnHashRef = useRef(APPENDIX_RETURN_HASH);
   const explorerThemeId = useSyncExternalStore(
     subscribeActiveExplorerTheme,
     getActiveExplorerThemeId,
@@ -225,6 +243,57 @@ export default function SymmetryAwareEinsumContractionsApp() {
   useEffect(() => {
     resetActiveExplorerTheme();
     return () => resetActiveExplorerTheme();
+  }, []);
+
+  const openAppendix = useCallback((hash = APPENDIX_ROOT_HASH) => {
+    if (typeof window !== 'undefined') {
+      const currentHash = window.location.hash;
+      if (currentHash && !isAppendixHash(currentHash)) {
+        appendixReturnHashRef.current = currentHash;
+      }
+      window.history.replaceState(null, '', hash);
+    }
+    setExprModalOpen(true);
+    if (typeof window !== 'undefined') {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          scrollToHashTarget(hash);
+        });
+      });
+    }
+  }, []);
+
+  const closeAppendix = useCallback(() => {
+    setExprModalOpen(false);
+    if (typeof window === 'undefined') return;
+    if (!isAppendixHash(window.location.hash)) return;
+    const fallbackHash = appendixReturnHashRef.current || APPENDIX_RETURN_HASH;
+    window.history.replaceState(null, '', fallbackHash);
+    if (fallbackHash.startsWith('#')) {
+      document.getElementById(fallbackHash.slice(1))?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const syncAppendixFromHash = () => {
+      const hash = window.location.hash;
+      if (isAppendixHash(hash)) {
+        setExprModalOpen(true);
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => {
+            scrollToHashTarget(hash);
+          });
+        });
+        return;
+      }
+      if (hash) appendixReturnHashRef.current = hash;
+      setExprModalOpen(false);
+    };
+
+    syncAppendixFromHash();
+    window.addEventListener('hashchange', syncAppendixFromHash);
+    return () => window.removeEventListener('hashchange', syncAppendixFromHash);
   }, []);
 
   useEffect(() => {
@@ -556,7 +625,7 @@ export default function SymmetryAwareEinsumContractionsApp() {
 
                     <button
                       type="button"
-                      onClick={() => setExprModalOpen(true)}
+                      onClick={() => openAppendix()}
                       className="-mx-4 -mb-4 mt-8 block w-auto cursor-pointer border-t border-stone-200/70 bg-gray-50 px-4 py-4 text-left transition-colors hover:bg-stone-100/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-coral"
                     >
                       <span className="block font-sans text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-400">
@@ -588,7 +657,7 @@ export default function SymmetryAwareEinsumContractionsApp() {
 
       <ExpressionLevelModal
         isOpen={exprModalOpen}
-        onClose={() => setExprModalOpen(false)}
+        onClose={closeAppendix}
         analysis={analysis}
         group={group}
         example={example}

--- a/website/components/symmetry-aware-einsum-contractions/components/StickyBar.jsx
+++ b/website/components/symmetry-aware-einsum-contractions/components/StickyBar.jsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { withBasePath } from '@/lib/base-path';
 import { formatGeneratorNotation } from '../lib/symmetryLabel.js';
 import { EXPLORER_ACTS } from './explorerNarrative.js';
 import SymmetryBadge from './SymmetryBadge.jsx';
@@ -255,7 +254,7 @@ export default function StickyBar({ example, group, activeActId, hoveredLabels =
             `.whest-wordmark` utility (Newsreader 700 opsz32, coral dot);
             do not reimplement. */}
         <Link
-          href={withBasePath('/')}
+          href="/"
           aria-label="Whest."
           className="whest-wordmark mr-4 shrink-0 text-[20px] no-underline"
         >

--- a/website/symmetry-explorer.route.test.mjs
+++ b/website/symmetry-explorer.route.test.mjs
@@ -110,3 +110,14 @@ test('route wrapper uses a branded centered loading shell instead of plain text'
   assert.doesNotMatch(routeSource, /radial-gradient/);
   assert.doesNotMatch(routeSource, /Loading Symmetry Aware Einsum Contractions/);
 });
+
+test('sticky bar wordmark relies on Next Link basePath handling instead of pre-prefixing the home href', () => {
+  const stickyBarSource = fs.readFileSync(
+    new URL('./components/symmetry-aware-einsum-contractions/components/StickyBar.jsx', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(stickyBarSource, /import Link from 'next\/link';/);
+  assert.match(stickyBarSource, /href="\/"/);
+  assert.doesNotMatch(stickyBarSource, /href=\{withBasePath\('\/'\)\}/);
+});

--- a/website/symmetry-explorer.route.test.mjs
+++ b/website/symmetry-explorer.route.test.mjs
@@ -69,6 +69,17 @@ test('article route still wires the appendix modal while the main page stays app
   assert.match(appSource, /<ExpressionLevelModal/);
   assert.match(appSource, /<ExpressionLevelModal[\s\S]*example=\{example\}/);
   assert.match(appSource, /<ExpressionLevelModal[\s\S]*onSelectPreset=\{handleSelect\}/);
+  assert.match(appSource, /const APPENDIX_ROOT_HASH = '#appendix';/);
+  assert.match(appSource, /const APPENDIX_SECTION_HASH_PREFIX = '#appendix-section-';/);
+  assert.match(appSource, /function isAppendixHash\(hash = ''\)/);
+  assert.match(appSource, /function scrollToHashTarget\(hash\)/);
+  assert.match(appSource, /const openAppendix = useCallback\(\(hash = APPENDIX_ROOT_HASH\) =>/);
+  assert.match(appSource, /const closeAppendix = useCallback\(\(\) =>/);
+  assert.match(appSource, /window\.addEventListener\('hashchange', syncAppendixFromHash\)/);
+  assert.match(appSource, /window\.history\.replaceState\(null, '', hash\)/);
+  assert.match(appSource, /window\.history\.replaceState\(null, '', fallbackHash\)/);
+  assert.match(appSource, /onClick=\{\(\) => openAppendix\(\)\}/);
+  assert.match(appSource, /<ExpressionLevelModal[\s\S]*onClose=\{closeAppendix\}/);
   assert.match(appSource, /Is this the full symmetry of the final expression\?/);
   assert.match(appSource, /The cost above uses .*notationLatex\('g_pointwise'\).* for accumulation/);
   assert.match(appSource, /The fully summed expression can have a larger label-renaming formal symmetry/);


### PR DESCRIPTION
## Summary
Adds shareable appendix hash links and fixes the deployed explorer wordmark home link.

## Includes
- open the appendix modal from `#appendix` and `#appendix-section-N` links
- preserve deep-link routing for appendix sections inside the modal
- fix the sticky-bar `Whest.` wordmark so GitHub Pages does not resolve it to `/whest/whest`
- add route/base-path regression coverage for both behaviors

## Validation
- `node --test website/docs-tree.test.mjs website/symmetry-explorer.route.test.mjs website/next.config.test.mjs`
