### PR TITLE
Track method calls and NumPy protocols on WhestArray (closes #58, #38, #62)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lint-commits:  ## Conventional-commit check on PR commits (origin/main..HEAD)
 	@if ! git rev-parse --verify origin/main >/dev/null 2>&1; then \
 		echo "lint-commits: origin/main not found; run 'git fetch origin main' first"; exit 1; \
 	fi
-	$(UV) gitlint --commits origin/main..HEAD
+	$(UV) gitlint --ignore-stdin --commits origin/main..HEAD
 
 .PHONY: fmt
 fmt:  ## Auto-fix lint and format issues

--- a/scripts/sync_client.py
+++ b/scripts/sync_client.py
@@ -126,6 +126,18 @@ def _generate_errors() -> str:
             "WhestWarning",
             "Warning issued when an operation causes loss of symmetry metadata.",
         ),
+        (
+            "CostFallbackWarning",
+            "WhestWarning",
+            (
+                "Warning issued when whest skips its symmetry-aware cost "
+                "adjustment (e.g. ``ufunc.outer`` / ``tensordot`` on a "
+                "symmetry group whose degree exceeds the per-call "
+                "Burnside-enumeration threshold). The op runs correctly "
+                "with the dense cost charged instead. Suppress with "
+                "``we.configure(symmetry_warnings=False)``."
+            ),
+        ),
         # client-only
         (
             "WhestServerError",

--- a/src/whest/_counting_ops.py
+++ b/src/whest/_counting_ops.py
@@ -25,11 +25,17 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     budget = require_budget()
     a = _np.asarray(a)
     cost = _builtins.max(_builtins.min(a.shape[axis1], a.shape[axis2]), 1)
+    out_stripped = _to_base_ndarray(out) if out is not None else None
     with budget.deduct("trace", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
         result = _np.trace(
-            a, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out
+            _to_base_ndarray(a),
+            offset=offset,
+            axis1=axis1,
+            axis2=axis2,
+            dtype=dtype,
+            out=out_stripped,
         )
-    return result
+    return out if out is not None else result
 
 
 attach_docstring(

--- a/src/whest/_counting_ops.py
+++ b/src/whest/_counting_ops.py
@@ -13,6 +13,7 @@ import numpy as _np
 
 from whest._docstrings import attach_docstring
 from whest._flops import _ceil_log2
+from whest._ndarray import _to_base_ndarray, _to_base_ndarray_tree
 from whest._validation import require_budget
 
 # ---------------------------------------------------------------------------
@@ -302,7 +303,9 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     budget = require_budget()
     if not isinstance(arr, _np.ndarray):
         arr = _np.asarray(arr)
-    result = _np.apply_along_axis(func1d, axis, arr, *args, **kwargs)
+    result = _np.apply_along_axis(
+        func1d, axis, _to_base_ndarray(arr), *args, **kwargs
+    )
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct(
         "apply_along_axis", flop_cost=cost, subscripts=None, shapes=(arr.shape,)
@@ -324,7 +327,7 @@ def apply_over_axes(func, a, axes):
     budget = require_budget()
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
-    result = _np.apply_over_axes(func, a, axes)
+    result = _np.apply_over_axes(func, _to_base_ndarray(a), axes)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct(
         "apply_over_axes", flop_cost=cost, subscripts=None, shapes=(a.shape,)
@@ -346,7 +349,9 @@ def piecewise(x, condlist, funclist, *args, **kw):
     budget = require_budget()
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
-    result = _np.piecewise(x, condlist, funclist, *args, **kw)
+    result = _np.piecewise(
+        _to_base_ndarray(x), _to_base_ndarray_tree(condlist), funclist, *args, **kw
+    )
     cost = x.size
     with budget.deduct("piecewise", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
         pass

--- a/src/whest/_counting_ops.py
+++ b/src/whest/_counting_ops.py
@@ -303,9 +303,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     budget = require_budget()
     if not isinstance(arr, _np.ndarray):
         arr = _np.asarray(arr)
-    result = _np.apply_along_axis(
-        func1d, axis, _to_base_ndarray(arr), *args, **kwargs
-    )
+    result = _np.apply_along_axis(func1d, axis, _to_base_ndarray(arr), *args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct(
         "apply_along_axis", flop_cost=cost, subscripts=None, shapes=(arr.shape,)

--- a/src/whest/_einsum.py
+++ b/src/whest/_einsum.py
@@ -156,9 +156,7 @@ def _execute_pairwise(path_info, operands: list):
         # Pop operands in reverse sorted order (same as opt_einsum convention)
         inds = sorted(contract_inds, reverse=True)
         tensors = [ops.pop(i) for i in inds]
-        result = _np.einsum(
-            step.subscript, *[_to_base_ndarray(t) for t in tensors]
-        )
+        result = _np.einsum(step.subscript, *[_to_base_ndarray(t) for t in tensors])
         ops.append(result)
     return ops[0]
 

--- a/src/whest/_einsum.py
+++ b/src/whest/_einsum.py
@@ -7,6 +7,7 @@ import functools
 import numpy as _np
 
 from whest._config import get_setting
+from whest._ndarray import _to_base_ndarray
 from whest._perm_group import SymmetryGroup
 from whest._pointwise import _prepare_symmetric_out, _validate_result_symmetry
 from whest._symmetric import SymmetricTensor
@@ -155,7 +156,9 @@ def _execute_pairwise(path_info, operands: list):
         # Pop operands in reverse sorted order (same as opt_einsum convention)
         inds = sorted(contract_inds, reverse=True)
         tensors = [ops.pop(i) for i in inds]
-        result = _np.einsum(step.subscript, *tensors)
+        result = _np.einsum(
+            step.subscript, *[_to_base_ndarray(t) for t in tensors]
+        )
         ops.append(result)
     return ops[0]
 
@@ -362,7 +365,9 @@ def einsum(
         if path_info.steps:
             result = _execute_pairwise(path_info, list(operands))
         else:
-            result = _np.einsum(canonical_subscripts, *operands)
+            result = _np.einsum(
+                canonical_subscripts, *[_to_base_ndarray(o) for o in operands]
+            )
 
     if out is not None:
         _validate_result_symmetry(result, target_symmetry)

--- a/src/whest/_free_ops.py
+++ b/src/whest/_free_ops.py
@@ -1553,8 +1553,12 @@ attach_docstring(ravel_multi_index, _np.ravel_multi_index, "free", "0 FLOPs")
 
 def require(*args, **kwargs):
     """Return array satisfying requirements. Wraps ``numpy.require``. Cost: 0 FLOPs."""
-    stripped_args = _to_base_ndarray_tree(args)
-    return _np.require(*stripped_args, **kwargs)
+    # Pass args through unstripped: ``_np.require`` is a thin Python
+    # helper around ``np.asanyarray`` and does not enter the
+    # ``__array_function__`` dispatch path, so passing a WhestArray
+    # cannot recurse. Stripping would break ``np.require(x).is(x)``
+    # identity for already-conforming inputs.
+    return _np.require(*args, **kwargs)
 
 
 attach_docstring(require, _np.require, "free", "0 FLOPs")

--- a/src/whest/_free_ops.py
+++ b/src/whest/_free_ops.py
@@ -1368,7 +1368,8 @@ attach_docstring(matrix_transpose, _np.matrix_transpose, "free", "0 FLOPs")
 
 def may_share_memory(*args, **kwargs):
     """Determine if two arrays might share memory. Wraps ``numpy.may_share_memory``. Cost: 0 FLOPs."""
-    return _np.may_share_memory(*args, **kwargs)
+    stripped_args = tuple(_to_base_ndarray(a) for a in args)
+    return _np.may_share_memory(*stripped_args, **kwargs)
 
 
 attach_docstring(may_share_memory, _np.may_share_memory, "free", "0 FLOPs")

--- a/src/whest/_free_ops.py
+++ b/src/whest/_free_ops.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 import numpy as _np
 
 from whest._docstrings import attach_docstring
-from whest._ndarray import _to_base_ndarray
+from whest._ndarray import _to_base_ndarray, _to_base_ndarray_tree
 from whest._perm_group import SymmetryGroup
 from whest._symmetric import SymmetricTensor
 from whest._symmetry_utils import (
@@ -202,7 +202,7 @@ attach_docstring(linspace, _np.linspace, "counted_custom", "numel(output) FLOPs"
 
 def zeros_like(a, dtype=None, **kwargs):
     """Return array of zeros with same shape. Wraps ``numpy.zeros_like``. Cost: 0 FLOPs."""
-    result = _np.zeros_like(a, dtype=dtype, **kwargs)
+    result = _np.zeros_like(_to_base_ndarray(a), dtype=dtype, **kwargs)
     symmetry = None
     if isinstance(a, SymmetricTensor):
         symmetry = _compatible_symmetry_for_shape(a.symmetry, result.shape)
@@ -220,7 +220,7 @@ attach_docstring(zeros_like, _np.zeros_like, "free", "0 FLOPs")
 
 def ones_like(a, dtype=None, **kwargs):
     """Return array of ones with same shape. Wraps ``numpy.ones_like``. Cost: 0 FLOPs."""
-    result = _np.ones_like(a, dtype=dtype, **kwargs)
+    result = _np.ones_like(_to_base_ndarray(a), dtype=dtype, **kwargs)
     symmetry = None
     if isinstance(a, SymmetricTensor):
         symmetry = _compatible_symmetry_for_shape(a.symmetry, result.shape)
@@ -242,7 +242,7 @@ def full_like(a, fill_value, dtype=None, **kwargs):
     a_arr = _np.asarray(a)
     cost = max(a_arr.size, 1)
     with budget.deduct("full_like", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.full_like(a, fill_value, dtype=dtype, **kwargs)
+        result = _np.full_like(_to_base_ndarray(a), fill_value, dtype=dtype, **kwargs)
     symmetry = None
     if isinstance(a, SymmetricTensor):
         symmetry = _compatible_symmetry_for_shape(a.symmetry, result.shape)
@@ -268,7 +268,7 @@ attach_docstring(empty, _np.empty, "free", "0 FLOPs")
 
 def empty_like(a, dtype=None, **kwargs):
     """Return uninitialized array with same shape. Wraps ``numpy.empty_like``. Cost: 0 FLOPs."""
-    return _np.empty_like(a, dtype=dtype, **kwargs)
+    return _np.empty_like(_to_base_ndarray(a), dtype=dtype, **kwargs)
 
 
 attach_docstring(empty_like, _np.empty_like, "free", "0 FLOPs")
@@ -301,7 +301,7 @@ attach_docstring(reshape, _np.reshape, "free", "0 FLOPs")
 def transpose(a, axes=None):
     """Permute array dimensions. Wraps ``numpy.transpose``. Cost: 0 FLOPs."""
     if not isinstance(a, SymmetricTensor):
-        return _np.transpose(a, axes=axes)
+        return _np.transpose(_to_base_ndarray(a), axes=axes)
     result = _np.transpose(_np.asarray(a), axes=axes)
     if axes is None:
         order = tuple(reversed(range(a.ndim)))
@@ -317,7 +317,7 @@ attach_docstring(transpose, _np.transpose, "free", "0 FLOPs")
 def swapaxes(a, axis1, axis2):
     """Swap two axes. Wraps ``numpy.swapaxes``. Cost: 0 FLOPs."""
     if not isinstance(a, SymmetricTensor):
-        return _np.swapaxes(a, axis1, axis2)
+        return _np.swapaxes(_to_base_ndarray(a), axis1, axis2)
     result = _np.swapaxes(_np.asarray(a), axis1, axis2)
     order = list(range(a.ndim))
     axis1 %= a.ndim
@@ -333,7 +333,7 @@ attach_docstring(swapaxes, _np.swapaxes, "free", "0 FLOPs")
 def moveaxis(a, source, destination):
     """Move axes to new positions. Wraps ``numpy.moveaxis``. Cost: 0 FLOPs."""
     if not isinstance(a, SymmetricTensor):
-        return _np.moveaxis(a, source, destination)
+        return _np.moveaxis(_to_base_ndarray(a), source, destination)
     result = _np.moveaxis(_np.asarray(a), source, destination)
     if _np.ndim(source) == 0:
         source_axes = (int(source),)
@@ -360,7 +360,7 @@ def concatenate(arrays, axis=0, **kwargs):
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in arrays), 1)
     with budget.deduct("concatenate", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.concatenate(arrays, axis=axis, **kwargs)
+        result = _np.concatenate(_to_base_ndarray_tree(arrays), axis=axis, **kwargs)
     return result
 
 
@@ -372,7 +372,7 @@ def stack(arrays, axis=0, **kwargs):
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in arrays), 1)
     with budget.deduct("stack", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.stack(arrays, axis=axis, **kwargs)
+        result = _np.stack(_to_base_ndarray_tree(arrays), axis=axis, **kwargs)
     return result
 
 
@@ -384,7 +384,7 @@ def vstack(tup):
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in tup), 1)
     with budget.deduct("vstack", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.vstack(tup)
+        result = _np.vstack(_to_base_ndarray_tree(tup))
     return result
 
 
@@ -393,7 +393,7 @@ attach_docstring(vstack, _np.vstack, "free", "0 FLOPs")
 
 def hstack(tup):
     """Stack arrays horizontally. Wraps ``numpy.hstack``. Cost: 0 FLOPs."""
-    return _np.hstack(tup)
+    return _np.hstack(_to_base_ndarray_tree(tup))
 
 
 attach_docstring(hstack, _np.hstack, "free", "0 FLOPs")
@@ -407,7 +407,7 @@ def split(ary, indices_or_sections, axis=0):
     with budget.deduct(
         "split", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.split(ary, indices_or_sections, axis=axis)
+        result = _np.split(_to_base_ndarray(ary), indices_or_sections, axis=axis)
     return result
 
 
@@ -416,7 +416,7 @@ attach_docstring(split, _np.split, "free", "0 FLOPs")
 
 def hsplit(ary, indices_or_sections):
     """Split array horizontally. Wraps ``numpy.hsplit``. Cost: 0 FLOPs."""
-    return _np.hsplit(ary, indices_or_sections)
+    return _np.hsplit(_to_base_ndarray(ary), indices_or_sections)
 
 
 attach_docstring(hsplit, _np.hsplit, "free", "0 FLOPs")
@@ -430,7 +430,7 @@ def vsplit(ary, indices_or_sections):
     with budget.deduct(
         "vsplit", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.vsplit(ary, indices_or_sections)
+        result = _np.vsplit(_to_base_ndarray(ary), indices_or_sections)
     return result
 
 
@@ -439,7 +439,7 @@ attach_docstring(vsplit, _np.vsplit, "free", "0 FLOPs")
 
 def squeeze(a, axis=None):
     """Remove length-1 axes. Wraps ``numpy.squeeze``. Cost: 0 FLOPs."""
-    return _np.squeeze(a, axis=axis)
+    return _np.squeeze(_to_base_ndarray(a), axis=axis)
 
 
 attach_docstring(squeeze, _np.squeeze, "free", "0 FLOPs")
@@ -493,9 +493,13 @@ def where(condition, x=None, y=None):
         "where", flop_cost=cost, subscripts=None, shapes=(cond_arr.shape,)
     ):
         if x is None and y is None:
-            result = _np.where(condition)
+            result = _np.where(_to_base_ndarray(condition))
         else:
-            result = _np.where(condition, x, y)
+            result = _np.where(
+                _to_base_ndarray(condition),
+                _to_base_ndarray(x),
+                _to_base_ndarray(y),
+            )
     return result
 
 
@@ -510,7 +514,7 @@ def tile(A, reps):
     # Output size = input size * product of reps
     cost = max(a_arr.size * int(_np.prod(reps_tup)), 1)
     with budget.deduct("tile", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.tile(A, reps)
+        result = _np.tile(_to_base_ndarray(A), reps)
     return result
 
 
@@ -528,7 +532,7 @@ def repeat(a, repeats, axis=None):
     else:
         cost = max(int(reps.sum()), 1)
     with budget.deduct("repeat", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.repeat(a, repeats, axis=axis)
+        result = _np.repeat(_to_base_ndarray(a), _to_base_ndarray(repeats), axis=axis)
     return result
 
 
@@ -537,7 +541,7 @@ attach_docstring(repeat, _np.repeat, "free", "0 FLOPs")
 
 def flip(m, axis=None):
     """Reverse order of elements. Wraps ``numpy.flip``. Cost: 0 FLOPs."""
-    return _np.flip(m, axis=axis)
+    return _np.flip(_to_base_ndarray(m), axis=axis)
 
 
 attach_docstring(flip, _np.flip, "free", "0 FLOPs")
@@ -549,7 +553,7 @@ def roll(a, shift, axis=None):
     a_arr = _np.asarray(a)
     cost = max(a_arr.size, 1)
     with budget.deduct("roll", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.roll(a, shift, axis=axis)
+        result = _np.roll(_to_base_ndarray(a), shift, axis=axis)
     return result
 
 
@@ -561,7 +565,7 @@ def pad(array, pad_width, **kwargs):
     budget = require_budget()
     # cost depends on result; duration is post-hoc
     # pad_width parsing is complex (scalar, per-axis, per-side) — not worth replicating
-    result = _np.pad(array, pad_width, **kwargs)
+    result = _np.pad(_to_base_ndarray(array), pad_width, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("pad", flop_cost=cost, subscripts=None, shapes=()):
         pass
@@ -573,7 +577,7 @@ attach_docstring(pad, _np.pad, "free", "0 FLOPs")
 
 def triu(m, k=0):
     """Upper triangle. Wraps ``numpy.triu``. Cost: 0 FLOPs."""
-    return _np.triu(m, k=k)
+    return _np.triu(_to_base_ndarray(m), k=k)
 
 
 attach_docstring(triu, _np.triu, "free", "0 FLOPs")
@@ -581,7 +585,7 @@ attach_docstring(triu, _np.triu, "free", "0 FLOPs")
 
 def tril(m, k=0):
     """Lower triangle. Wraps ``numpy.tril``. Cost: 0 FLOPs."""
-    return _np.tril(m, k=k)
+    return _np.tril(_to_base_ndarray(m), k=k)
 
 
 attach_docstring(tril, _np.tril, "free", "0 FLOPs")
@@ -601,7 +605,9 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     with budget.deduct(
         "diagonal", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.diagonal(a, offset=offset, axis1=axis1, axis2=axis2)
+        result = _np.diagonal(
+            _to_base_ndarray(a), offset=offset, axis1=axis1, axis2=axis2
+        )
     return result
 
 
@@ -635,7 +641,7 @@ def meshgrid(*xi, **kwargs):
     grid_size = int(_np.prod(sizes)) if sizes else 0
     cost = max(grid_size * len(sizes), 1)
     with budget.deduct("meshgrid", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.meshgrid(*xi, **kwargs)
+        result = _np.meshgrid(*[_to_base_ndarray(x) for x in xi], **kwargs)
     return result
 
 
@@ -648,7 +654,7 @@ attach_docstring(meshgrid, _np.meshgrid, "free", "0 FLOPs")
 
 def astype(x, dtype, /, *, copy=True, device=None):
     """Cast array to *dtype*. Wraps ``np.astype(x, dtype)``. Cost: 0 FLOPs."""
-    return _np.astype(x, dtype, copy=copy, device=device)
+    return _np.astype(_to_base_ndarray(x), dtype, copy=copy, device=device)
 
 
 def asarray(a, dtype=None, **kwargs):
@@ -720,7 +726,9 @@ def append(arr, values, axis=None, **kwargs):
     values_arr = _np.asarray(values)
     cost = values_arr.size  # num appended
     with budget.deduct("append", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.append(arr, values, axis=axis, **kwargs)
+        result = _np.append(
+            _to_base_ndarray(arr), _to_base_ndarray(values), axis=axis, **kwargs
+        )
     return result
 
 
@@ -735,7 +743,7 @@ def argwhere(a, *args, **kwargs):
     with budget.deduct(
         "argwhere", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.argwhere(a, *args, **kwargs)
+        result = _np.argwhere(_to_base_ndarray(a), *args, **kwargs)
     return result
 
 
@@ -750,7 +758,7 @@ def array_split(ary, *args, **kwargs):
     with budget.deduct(
         "array_split", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.array_split(ary, *args, **kwargs)
+        result = _np.array_split(_to_base_ndarray(ary), *args, **kwargs)
     return result
 
 
@@ -760,7 +768,7 @@ attach_docstring(array_split, _np.array_split, "free", "0 FLOPs")
 def asarray_chkfinite(a, *args, **kwargs):
     """Convert to array checking for NaN/Inf. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.asarray_chkfinite(a, *args, **kwargs)
+    result = _np.asarray_chkfinite(_to_base_ndarray(a), *args, **kwargs)
     cost = (
         result.size
         if hasattr(result, "size")
@@ -780,7 +788,7 @@ attach_docstring(asarray_chkfinite, _np.asarray_chkfinite, "free", "0 FLOPs")
 
 def atleast_1d(*args, **kwargs):
     """Convert to 1-D or higher. Wraps ``numpy.atleast_1d``. Cost: 0 FLOPs."""
-    return _np.atleast_1d(*args, **kwargs)
+    return _np.atleast_1d(*[_to_base_ndarray(a) for a in args], **kwargs)
 
 
 attach_docstring(atleast_1d, _np.atleast_1d, "free", "0 FLOPs")
@@ -788,7 +796,7 @@ attach_docstring(atleast_1d, _np.atleast_1d, "free", "0 FLOPs")
 
 def atleast_2d(*args, **kwargs):
     """Convert to 2-D or higher. Wraps ``numpy.atleast_2d``. Cost: 0 FLOPs."""
-    return _np.atleast_2d(*args, **kwargs)
+    return _np.atleast_2d(*[_to_base_ndarray(a) for a in args], **kwargs)
 
 
 attach_docstring(atleast_2d, _np.atleast_2d, "free", "0 FLOPs")
@@ -796,7 +804,7 @@ attach_docstring(atleast_2d, _np.atleast_2d, "free", "0 FLOPs")
 
 def atleast_3d(*args, **kwargs):
     """Convert to 3-D or higher. Wraps ``numpy.atleast_3d``. Cost: 0 FLOPs."""
-    return _np.atleast_3d(*args, **kwargs)
+    return _np.atleast_3d(*[_to_base_ndarray(a) for a in args], **kwargs)
 
 
 attach_docstring(atleast_3d, _np.atleast_3d, "free", "0 FLOPs")
@@ -831,7 +839,7 @@ attach_docstring(binary_repr, _np.binary_repr, "free", "0 FLOPs")
 def block(*args, **kwargs):
     """Assemble array from nested lists. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.block(*args, **kwargs)
+    result = _np.block(*[_to_base_ndarray_tree(a) for a in args], **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("block", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -844,7 +852,14 @@ attach_docstring(block, _np.block, "free", "0 FLOPs")
 def bmat(*args, **kwargs):
     """Build matrix from string/nested sequence. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.bmat(*args, **kwargs)
+    # First arg may be a string OR a nested sequence of arrays
+    stripped_args = []
+    for arg in args:
+        if isinstance(arg, (tuple, list)):
+            stripped_args.append(_to_base_ndarray_tree(arg))
+        else:
+            stripped_args.append(arg)
+    result = _np.bmat(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("bmat", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -898,7 +913,16 @@ attach_docstring(can_cast, _np.can_cast, "free", "0 FLOPs")
 def choose(*args, **kwargs):
     """Construct array from index array. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.choose(*args, **kwargs)
+    # Args: (a, choices, ...) or just (a, choices) — strip arrays.
+    stripped_args = []
+    for arg in args:
+        if isinstance(arg, _np.ndarray):
+            stripped_args.append(_to_base_ndarray(arg))
+        elif isinstance(arg, (tuple, list)):
+            stripped_args.append(_to_base_ndarray_tree(arg))
+        else:
+            stripped_args.append(arg)
+    result = _np.choose(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("choose", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -910,7 +934,12 @@ attach_docstring(choose, _np.choose, "free", "0 FLOPs")
 
 def column_stack(*args, **kwargs):
     """Stack 1-D arrays as columns. Wraps ``numpy.column_stack``. Cost: 0 FLOPs."""
-    return _np.column_stack(*args, **kwargs)
+    # First positional arg is sequence of arrays
+    if args and isinstance(args[0], (tuple, list)):
+        stripped_args = (_to_base_ndarray_tree(args[0]), *args[1:])
+    else:
+        stripped_args = tuple(_to_base_ndarray(a) for a in args)
+    return _np.column_stack(*stripped_args, **kwargs)
 
 
 attach_docstring(column_stack, _np.column_stack, "free", "0 FLOPs")
@@ -918,7 +947,7 @@ attach_docstring(column_stack, _np.column_stack, "free", "0 FLOPs")
 
 def common_type(*args, **kwargs):
     """Return scalar type common to input arrays. Wraps ``numpy.common_type``. Cost: 0 FLOPs."""
-    return _np.common_type(*args, **kwargs)
+    return _np.common_type(*[_to_base_ndarray(a) for a in args], **kwargs)
 
 
 attach_docstring(common_type, _np.common_type, "free", "0 FLOPs")
@@ -927,7 +956,9 @@ attach_docstring(common_type, _np.common_type, "free", "0 FLOPs")
 def compress(condition, a, *args, **kwargs):
     """Return selected slices along an axis. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.compress(condition, a, *args, **kwargs)
+    result = _np.compress(
+        _to_base_ndarray(condition), _to_base_ndarray(a), *args, **kwargs
+    )
     cost = (
         result.size
         if hasattr(result, "size")
@@ -948,7 +979,12 @@ attach_docstring(compress, _np.compress, "free", "0 FLOPs")
 def concat(*args, **kwargs):
     """Join arrays along an axis. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.concat(*args, **kwargs)
+    # First arg is sequence of arrays
+    if args and isinstance(args[0], (tuple, list)):
+        stripped_args = (_to_base_ndarray_tree(args[0]), *args[1:])
+    else:
+        stripped_args = tuple(_to_base_ndarray(a) for a in args)
+    result = _np.concat(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("concat", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -968,7 +1004,12 @@ def copyto(dst, src, casting="same_kind", where=True):
     else:
         cost = src_arr.size
     with budget.deduct("copyto", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.copyto(dst, src, casting=casting, where=where)
+        result = _np.copyto(
+            _to_base_ndarray(dst),
+            _to_base_ndarray(src),
+            casting=casting,
+            where=_to_base_ndarray(where) if where is not True else where,
+        )
     return result
 
 
@@ -979,7 +1020,7 @@ def delete(arr, obj, axis=None, **kwargs):
     """Return new array with sub-arrays deleted. Cost: num elements removed."""
     budget = require_budget()
     arr_np = _np.asarray(arr)
-    result = _np.delete(arr, obj, axis=axis, **kwargs)
+    result = _np.delete(_to_base_ndarray(arr), obj, axis=axis, **kwargs)
     cost = max(arr_np.size - result.size, 0)  # num deleted
     with budget.deduct("delete", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -1009,7 +1050,7 @@ def diagflat(v, k=0):
     """Create diagonal array from flattened input. Cost: numel(output)."""
     budget = require_budget()
     v_arr = _np.asarray(v)
-    result = _np.diagflat(v, k=k)
+    result = _np.diagflat(_to_base_ndarray(v), k=k)
     cost = result.size  # output is (n+|k|)×(n+|k|) matrix
     with budget.deduct(
         "diagflat", flop_cost=cost, subscripts=None, shapes=(v_arr.shape,)
@@ -1034,7 +1075,7 @@ def dsplit(ary, *args, **kwargs):
     with budget.deduct(
         "dsplit", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.dsplit(ary, *args, **kwargs)
+        result = _np.dsplit(_to_base_ndarray(ary), *args, **kwargs)
     return result
 
 
@@ -1044,7 +1085,8 @@ attach_docstring(dsplit, _np.dsplit, "free", "0 FLOPs")
 def dstack(*args, **kwargs):
     """Stack arrays along third axis. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.dstack(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    result = _np.dstack(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("dstack", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -1062,7 +1104,9 @@ def extract(condition, arr, *args, **kwargs):
     with budget.deduct(
         "extract", flop_cost=cost, subscripts=None, shapes=(arr_np.shape,)
     ):
-        result = _np.extract(condition, arr, *args, **kwargs)
+        result = _np.extract(
+            _to_base_ndarray(condition), _to_base_ndarray(arr), *args, **kwargs
+        )
     return result
 
 
@@ -1077,7 +1121,9 @@ def fill_diagonal(a, val, wrap=False, **kwargs):
     with budget.deduct(
         "fill_diagonal", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.fill_diagonal(a, val, wrap=wrap, **kwargs)
+        # ``np.fill_diagonal`` mutates ``a`` in-place; ``_to_base_ndarray``
+        # is zero-copy so the mutation propagates to the user's array.
+        result = _np.fill_diagonal(_to_base_ndarray(a), val, wrap=wrap, **kwargs)
     return result
 
 
@@ -1092,7 +1138,7 @@ def flatnonzero(a, *args, **kwargs):
     with budget.deduct(
         "flatnonzero", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.flatnonzero(a, *args, **kwargs)
+        result = _np.flatnonzero(_to_base_ndarray(a), *args, **kwargs)
     return result
 
 
@@ -1101,7 +1147,8 @@ attach_docstring(flatnonzero, _np.flatnonzero, "free", "0 FLOPs")
 
 def fliplr(*args, **kwargs):
     """Reverse elements along axis 1. Wraps ``numpy.fliplr``. Cost: 0 FLOPs."""
-    return _np.fliplr(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.fliplr(*stripped_args, **kwargs)
 
 
 attach_docstring(fliplr, _np.fliplr, "free", "0 FLOPs")
@@ -1109,7 +1156,8 @@ attach_docstring(fliplr, _np.fliplr, "free", "0 FLOPs")
 
 def flipud(*args, **kwargs):
     """Reverse elements along axis 0. Wraps ``numpy.flipud``. Cost: 0 FLOPs."""
-    return _np.flipud(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.flipud(*stripped_args, **kwargs)
 
 
 attach_docstring(flipud, _np.flipud, "free", "0 FLOPs")
@@ -1225,7 +1273,9 @@ def insert(arr, obj, values, axis=None, **kwargs):
     values_arr = _np.asarray(values)
     cost = values_arr.size  # num inserted
     with budget.deduct("insert", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.insert(arr, obj, values, axis=axis, **kwargs)
+        result = _np.insert(
+            _to_base_ndarray(arr), obj, _to_base_ndarray(values), axis=axis, **kwargs
+        )
     return result
 
 
@@ -1250,7 +1300,7 @@ attach_docstring(isfortran, _np.isfortran, "free", "0 FLOPs")
 
 def isin(*args, **kwargs):
     """Test element-wise membership in a set. Wraps ``numpy.isin``. Cost: 0 FLOPs."""
-    return _np.isin(*args, **kwargs)
+    return _np.isin(*[_to_base_ndarray(a) for a in args], **kwargs)
 
 
 attach_docstring(isin, _np.isin, "free", "0 FLOPs")
@@ -1283,7 +1333,8 @@ attach_docstring(iterable, _np.iterable, "free", "0 FLOPs")
 def ix_(*args, **kwargs):
     """Construct open mesh from multiple sequences. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.ix_(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    result = _np.ix_(*stripped_args, **kwargs)
     cost = sum(a.size for a in result)
     with budget.deduct("ix_", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -1308,7 +1359,8 @@ attach_docstring(mask_indices, _np.mask_indices, "free", "0 FLOPs")
 
 def matrix_transpose(*args, **kwargs):
     """Transpose a matrix or stack of matrices. Wraps ``numpy.matrix_transpose``. Cost: 0 FLOPs."""
-    return _np.matrix_transpose(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.matrix_transpose(*stripped_args, **kwargs)
 
 
 attach_docstring(matrix_transpose, _np.matrix_transpose, "free", "0 FLOPs")
@@ -1354,7 +1406,7 @@ def nonzero(a, *args, **kwargs):
     with budget.deduct(
         "nonzero", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.nonzero(a, *args, **kwargs)
+        result = _np.nonzero(_to_base_ndarray(a), *args, **kwargs)
     return result
 
 
@@ -1364,7 +1416,7 @@ attach_docstring(nonzero, _np.nonzero, "free", "0 FLOPs")
 def packbits(a, *args, **kwargs):
     """Pack binary-valued array into bits. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.packbits(a, *args, **kwargs)
+    result = _np.packbits(_to_base_ndarray(a), *args, **kwargs)
     cost = (
         result.size
         if hasattr(result, "size")
@@ -1384,7 +1436,8 @@ attach_docstring(packbits, _np.packbits, "free", "0 FLOPs")
 
 def permute_dims(*args, **kwargs):
     """Permute dimensions of array. Wraps ``numpy.permute_dims``. Cost: 0 FLOPs."""
-    return _np.permute_dims(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.permute_dims(*stripped_args, **kwargs)
 
 
 attach_docstring(permute_dims, _np.permute_dims, "free", "0 FLOPs")
@@ -1398,7 +1451,15 @@ def place(arr, mask, vals, *args, **kwargs):
     with budget.deduct(
         "place", flop_cost=cost, subscripts=None, shapes=(arr_np.shape,)
     ):
-        result = _np.place(arr, mask, vals, *args, **kwargs)
+        # ``np.place`` mutates ``arr`` in-place; ``_to_base_ndarray`` is
+        # zero-copy so the mutation propagates to the user's array.
+        result = _np.place(
+            _to_base_ndarray(arr),
+            _to_base_ndarray(mask),
+            _to_base_ndarray(vals),
+            *args,
+            **kwargs,
+        )
     return result
 
 
@@ -1419,7 +1480,16 @@ def put(a, ind, v, *args, **kwargs):
     a_arr = _np.asarray(a)
     cost = a_arr.size
     with budget.deduct("put", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)):
-        result = _np.put(a, ind, v, *args, **kwargs)
+        # ``np.put`` mutates ``a`` in-place. ``_to_base_ndarray`` is a
+        # zero-copy view, so the mutation propagates to the user's
+        # original WhestArray buffer.
+        result = _np.put(
+            _to_base_ndarray(a),
+            _to_base_ndarray(ind),
+            _to_base_ndarray(v),
+            *args,
+            **kwargs,
+        )
     return result
 
 
@@ -1434,7 +1504,16 @@ def put_along_axis(arr, indices, values, axis, *args, **kwargs):
     with budget.deduct(
         "put_along_axis", flop_cost=cost, subscripts=None, shapes=(arr_np.shape,)
     ):
-        result = _np.put_along_axis(arr, indices, values, axis, *args, **kwargs)
+        # ``np.put_along_axis`` mutates ``arr`` in-place; ``_to_base_ndarray``
+        # is zero-copy so the mutation propagates to the user's array.
+        result = _np.put_along_axis(
+            _to_base_ndarray(arr),
+            _to_base_ndarray(indices),
+            _to_base_ndarray(values),
+            axis,
+            *args,
+            **kwargs,
+        )
     return result
 
 
@@ -1449,7 +1528,13 @@ def putmask(a, mask, values, *args, **kwargs):
     with budget.deduct(
         "putmask", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.putmask(a, mask, values, *args, **kwargs)
+        result = _np.putmask(
+            _to_base_ndarray(a),
+            _to_base_ndarray(mask),
+            _to_base_ndarray(values),
+            *args,
+            **kwargs,
+        )
     return result
 
 
@@ -1458,7 +1543,8 @@ attach_docstring(putmask, _np.putmask, "free", "0 FLOPs")
 
 def ravel_multi_index(*args, **kwargs):
     """Convert multi-index to flat index. Wraps ``numpy.ravel_multi_index``. Cost: 0 FLOPs."""
-    return _np.ravel_multi_index(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.ravel_multi_index(*stripped_args, **kwargs)
 
 
 attach_docstring(ravel_multi_index, _np.ravel_multi_index, "free", "0 FLOPs")
@@ -1466,7 +1552,8 @@ attach_docstring(ravel_multi_index, _np.ravel_multi_index, "free", "0 FLOPs")
 
 def require(*args, **kwargs):
     """Return array satisfying requirements. Wraps ``numpy.require``. Cost: 0 FLOPs."""
-    return _np.require(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.require(*stripped_args, **kwargs)
 
 
 attach_docstring(require, _np.require, "free", "0 FLOPs")
@@ -1475,7 +1562,8 @@ attach_docstring(require, _np.require, "free", "0 FLOPs")
 def resize(*args, **kwargs):
     """Return new array with given shape. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.resize(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    result = _np.resize(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("resize", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -1496,7 +1584,8 @@ attach_docstring(result_type, _np.result_type, "free", "0 FLOPs")
 def rollaxis(*args, **kwargs):
     """Roll specified axis backwards. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.rollaxis(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    result = _np.rollaxis(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("rollaxis", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -1508,7 +1597,8 @@ attach_docstring(rollaxis, _np.rollaxis, "free", "0 FLOPs")
 
 def rot90(*args, **kwargs):
     """Rotate array 90 degrees. Wraps ``numpy.rot90``. Cost: 0 FLOPs."""
-    return _np.rot90(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.rot90(*stripped_args, **kwargs)
 
 
 attach_docstring(rot90, _np.rot90, "free", "0 FLOPs")
@@ -1516,7 +1606,8 @@ attach_docstring(rot90, _np.rot90, "free", "0 FLOPs")
 
 def row_stack(*args, **kwargs):
     """Stack arrays vertically (alias for vstack). Wraps ``numpy.row_stack``. Cost: 0 FLOPs."""
-    return _np.row_stack(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    return _np.row_stack(*stripped_args, **kwargs)
 
 
 attach_docstring(row_stack, _np.row_stack, "free", "0 FLOPs")
@@ -1528,7 +1619,11 @@ def select(condlist, choicelist, default=0):
     # Cost based on the size of the choice arrays
     cost = max((_np.asarray(c).size for c in choicelist), default=1)
     with budget.deduct("select", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.select(condlist, choicelist, default=default)
+        result = _np.select(
+            _to_base_ndarray_tree(condlist),
+            _to_base_ndarray_tree(choicelist),
+            default=default,
+        )
     return result
 
 
@@ -1545,7 +1640,7 @@ attach_docstring(shape, _np.shape, "free", "0 FLOPs")
 
 def shares_memory(*args, **kwargs):
     """Determine if two arrays share memory. Wraps ``numpy.shares_memory``. Cost: 0 FLOPs."""
-    return _np.shares_memory(*args, **kwargs)
+    return _np.shares_memory(*[_to_base_ndarray(a) for a in args], **kwargs)
 
 
 attach_docstring(shares_memory, _np.shares_memory, "free", "0 FLOPs")
@@ -1562,7 +1657,8 @@ attach_docstring(size, _np.size, "free", "0 FLOPs")
 def take(*args, **kwargs):
     """Take elements from array along axis. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.take(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    result = _np.take(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("take", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -1575,7 +1671,8 @@ attach_docstring(take, _np.take, "free", "0 FLOPs")
 def take_along_axis(*args, **kwargs):
     """Take values from input array along axis using indices. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.take_along_axis(*args, **kwargs)
+    stripped_args = _to_base_ndarray_tree(args)
+    result = _np.take_along_axis(*stripped_args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("take_along_axis", flop_cost=cost, subscripts=None, shapes=()):
         pass  # numpy call already executed above
@@ -1613,7 +1710,7 @@ def trim_zeros(filt, trim="fb", **kwargs):
     """Trim leading and/or trailing zeros from 1-D array. Cost: num elements trimmed."""
     budget = require_budget()
     filt_arr = _np.asarray(filt)
-    result = _np.trim_zeros(filt, trim=trim, **kwargs)
+    result = _np.trim_zeros(_to_base_ndarray(filt), trim=trim, **kwargs)
     result_arr = _np.asarray(result)
     cost = max(filt_arr.size - result_arr.size, 0)  # num trimmed
     with budget.deduct("trim_zeros", flop_cost=cost, subscripts=None, shapes=()):
@@ -1651,7 +1748,7 @@ attach_docstring(typename, _np.typename, "free", "0 FLOPs")
 def unpackbits(a, *args, **kwargs):
     """Unpack elements of uint8 array into binary-valued bit array. Cost: numel(output)."""
     budget = require_budget()
-    result = _np.unpackbits(a, *args, **kwargs)
+    result = _np.unpackbits(_to_base_ndarray(a), *args, **kwargs)
     cost = (
         result.size
         if hasattr(result, "size")
@@ -1687,7 +1784,7 @@ if hasattr(_np, "unstack"):
         with budget.deduct(
             "unstack", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
         ):
-            result = _np.unstack(x, *args, **kwargs)
+            result = _np.unstack(_to_base_ndarray(x), *args, **kwargs)
         return result
 
     attach_docstring(unstack, _np.unstack, "free", "0 FLOPs")

--- a/src/whest/_free_ops.py
+++ b/src/whest/_free_ops.py
@@ -13,6 +13,7 @@ from functools import lru_cache
 import numpy as _np
 
 from whest._docstrings import attach_docstring
+from whest._ndarray import _to_base_ndarray
 from whest._perm_group import SymmetryGroup
 from whest._symmetric import SymmetricTensor
 from whest._symmetry_utils import (
@@ -672,7 +673,9 @@ def isnan(x, **kwargs):
     x_arr = _np.asarray(x)
     cost = x_arr.size
     with budget.deduct("isnan", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)):
-        result = _np.isnan(x, **kwargs)
+        # Strip whest subclasses so the raw NumPy ufunc does not
+        # re-dispatch through __array_ufunc__ and recurse.
+        result = _np.isnan(_to_base_ndarray(x), **kwargs)
     return result
 
 
@@ -687,7 +690,7 @@ def isfinite(x, **kwargs):
     with budget.deduct(
         "isfinite", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
     ):
-        result = _np.isfinite(x, **kwargs)
+        result = _np.isfinite(_to_base_ndarray(x), **kwargs)
     return result
 
 
@@ -700,7 +703,7 @@ def isinf(x, **kwargs):
     x_arr = _np.asarray(x)
     cost = x_arr.size
     with budget.deduct("isinf", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)):
-        result = _np.isinf(x, **kwargs)
+        result = _np.isinf(_to_base_ndarray(x), **kwargs)
     return result
 
 

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -340,6 +340,155 @@ class WhestArray(_np.ndarray):
             return NotImplemented
         return we_func(*args, **kwargs)
 
+    # ----- ndarray method overrides (route through me.* for budget parity) -----
+    # We forward *args, **kwargs to be forward-compatible with NumPy's
+    # evolving method signatures (dtype, out, where, casting, keepdims, axis
+    # as positional or keyword).
+
+    def sum(self, *args, **kwargs):
+        return _me().sum(self, *args, **kwargs)
+
+    def mean(self, *args, **kwargs):
+        return _me().mean(self, *args, **kwargs)
+
+    def prod(self, *args, **kwargs):
+        return _me().prod(self, *args, **kwargs)
+
+    def min(self, *args, **kwargs):
+        return _me().min(self, *args, **kwargs)
+
+    def max(self, *args, **kwargs):
+        return _me().max(self, *args, **kwargs)
+
+    def std(self, *args, **kwargs):
+        return _me().std(self, *args, **kwargs)
+
+    def var(self, *args, **kwargs):
+        return _me().var(self, *args, **kwargs)
+
+    def all(self, *args, **kwargs):
+        return _me().all(self, *args, **kwargs)
+
+    def any(self, *args, **kwargs):
+        return _me().any(self, *args, **kwargs)
+
+    def cumsum(self, *args, **kwargs):
+        return _me().cumsum(self, *args, **kwargs)
+
+    def cumprod(self, *args, **kwargs):
+        return _me().cumprod(self, *args, **kwargs)
+
+    def argmin(self, *args, **kwargs):
+        return _me().argmin(self, *args, **kwargs)
+
+    def argmax(self, *args, **kwargs):
+        return _me().argmax(self, *args, **kwargs)
+
+    def ptp(self, *args, **kwargs):
+        return _me().ptp(self, *args, **kwargs)
+
+    def trace(self, *args, **kwargs):
+        return _me().trace(self, *args, **kwargs)
+
+    def round(self, *args, **kwargs):
+        return _me().round(self, *args, **kwargs)
+
+    def clip(self, *args, **kwargs):
+        return _me().clip(self, *args, **kwargs)
+
+    # ----- Other ndarray methods -----
+
+    def dot(self, *args, **kwargs):
+        return _me().dot(self, *args, **kwargs)
+
+    def conj(self):
+        return _me().conjugate(self)
+
+    def conjugate(self):
+        return _me().conjugate(self)
+
+    def argsort(self, *args, **kwargs):
+        return _me().argsort(self, *args, **kwargs)
+
+    def argpartition(self, kth, *args, **kwargs):
+        return _me().argpartition(self, kth, *args, **kwargs)
+
+    def take(self, indices, *args, **kwargs):
+        return _me().take(self, indices, *args, **kwargs)
+
+    def repeat(self, repeats, *args, **kwargs):
+        return _me().repeat(self, repeats, *args, **kwargs)
+
+    def searchsorted(self, v, *args, **kwargs):
+        return _me().searchsorted(self, v, *args, **kwargs)
+
+    def compress(self, condition, *args, **kwargs):
+        # ndarray.compress(condition) -> np.compress(condition, arr)
+        return _me().compress(condition, self, *args, **kwargs)
+
+    # In-place sort/partition: NumPy mutates self and returns None.
+    # Charge FLOPs through me.sort/partition, then copy result into self.
+    # Guard against in-place mutation that would silently break symmetry.
+
+    def _check_inplace_breaks_symmetry(self, op_name):
+        """Refuse in-place ops that would invalidate SymmetricTensor metadata.
+
+        ``self._symmetry`` is set by SymmetricTensor; plain WhestArrays
+        do not have it (or it's None). Guarding via getattr keeps this
+        method valid on both subclasses without a forward reference.
+        """
+        sym = getattr(self, "_symmetry", None)
+        if sym is not None:
+            raise ValueError(
+                f"in-place {op_name} on a SymmetricTensor would break "
+                f"symmetry on axes {sym.axes}; call we.{op_name}(arr) for "
+                f"an unsymmetric copy instead."
+            )
+
+    def sort(self, *args, **kwargs):
+        self._check_inplace_breaks_symmetry("sort")
+        result = _me().sort(self, *args, **kwargs)
+        # Strip both self and result before np.copyto: keeps the
+        # invariant ("never pass a whest subclass to a raw NumPy call")
+        # explicit even though np.copyto is currently NOT in the
+        # __array_function__ allowlist.
+        _np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))
+
+    def partition(self, kth, *args, **kwargs):
+        self._check_inplace_breaks_symmetry("partition")
+        result = _me().partition(self, kth, *args, **kwargs)
+        _np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))
+
+    def _inplace_from_result(self, result, op_name):
+        """Apply ``result`` into ``self`` in place; refuse if the
+        operation would destroy or weaken symmetry metadata.
+
+        Compare ``self.symmetry`` and ``result.symmetry`` directly via
+        ``SymmetryGroup.__eq__`` (PR #51 made these value-equal with an
+        identity short-circuit and per-instance canonical-action cache).
+        Scalar in-place ops (``a += 1.0``) keep every group identically,
+        so the comparison passes via the identity short-circuit and the
+        copy proceeds cleanly.
+
+        ``_to_base_ndarray(self)`` is required around ``np.copyto``
+        because ``np.copyto`` could otherwise dispatch via
+        ``__array_function__`` if it ever lands in the allowlist --
+        without the strip, the call would recurse back through whest.
+        """
+        self_sym = getattr(self, "_symmetry", None)
+        result_sym = getattr(result, "_symmetry", None)
+        if self_sym is not None:
+            if self_sym != result_sym:
+                raise ValueError(
+                    f"in-place {op_name} would destroy or weaken symmetry "
+                    f"metadata on axes {self_sym.axes} (result symmetry: "
+                    f"{result_sym.axes if result_sym is not None else None}); "
+                    f"use ``self = we.{op_name}(self, other)`` to accept the "
+                    f"new result explicitly."
+                )
+        _np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))
+        return self
+
     # ----- Binary arithmetic -----
 
     def __add__(self, other):
@@ -349,7 +498,8 @@ class WhestArray(_np.ndarray):
         return _me().add(other, self)
 
     def __iadd__(self, other):
-        return _me().add(self, other)
+        result = _me().add(self, other)
+        return self._inplace_from_result(result, "add")
 
     def __sub__(self, other):
         return _me().subtract(self, other)
@@ -358,7 +508,8 @@ class WhestArray(_np.ndarray):
         return _me().subtract(other, self)
 
     def __isub__(self, other):
-        return _me().subtract(self, other)
+        result = _me().subtract(self, other)
+        return self._inplace_from_result(result, "subtract")
 
     def __mul__(self, other):
         return _me().multiply(self, other)
@@ -367,7 +518,8 @@ class WhestArray(_np.ndarray):
         return _me().multiply(other, self)
 
     def __imul__(self, other):
-        return _me().multiply(self, other)
+        result = _me().multiply(self, other)
+        return self._inplace_from_result(result, "multiply")
 
     def __truediv__(self, other):
         return _me().true_divide(self, other)
@@ -376,7 +528,8 @@ class WhestArray(_np.ndarray):
         return _me().true_divide(other, self)
 
     def __itruediv__(self, other):
-        return _me().true_divide(self, other)
+        result = _me().true_divide(self, other)
+        return self._inplace_from_result(result, "true_divide")
 
     def __floordiv__(self, other):
         return _me().floor_divide(self, other)
@@ -385,7 +538,8 @@ class WhestArray(_np.ndarray):
         return _me().floor_divide(other, self)
 
     def __ifloordiv__(self, other):
-        return _me().floor_divide(self, other)
+        result = _me().floor_divide(self, other)
+        return self._inplace_from_result(result, "floor_divide")
 
     def __mod__(self, other):
         return _me().mod(self, other)
@@ -394,7 +548,8 @@ class WhestArray(_np.ndarray):
         return _me().mod(other, self)
 
     def __imod__(self, other):
-        return _me().mod(self, other)
+        result = _me().mod(self, other)
+        return self._inplace_from_result(result, "mod")
 
     def __pow__(self, other):
         return _me().power(self, other)
@@ -403,7 +558,8 @@ class WhestArray(_np.ndarray):
         return _me().power(other, self)
 
     def __ipow__(self, other):
-        return _me().power(self, other)
+        result = _me().power(self, other)
+        return self._inplace_from_result(result, "power")
 
     def __matmul__(self, other):
         return _me().matmul(self, other)
@@ -412,7 +568,17 @@ class WhestArray(_np.ndarray):
         return _me().matmul(other, self)
 
     def __imatmul__(self, other):
-        return _me().matmul(self, other)
+        # __imatmul__ is special: matmul output shape may differ from
+        # self.shape, in which case in-place mutation is impossible.
+        # CPython's documented in-place fallback rebinds the name to the
+        # new (out-of-place) result. NumPy raises ValueError on shape
+        # mismatch; we follow the CPython fallback so typical pipelines
+        # using ``A @= B`` to grow state work cleanly.
+        result = _me().matmul(self, other)
+        result_arr = _np.asarray(result)
+        if result_arr.shape != self.shape:
+            return result
+        return self._inplace_from_result(result, "matmul")
 
     # ----- Unary arithmetic -----
 
@@ -461,7 +627,8 @@ class WhestArray(_np.ndarray):
         return _me().bitwise_and(other, self)
 
     def __iand__(self, other):
-        return _me().bitwise_and(self, other)
+        result = _me().bitwise_and(self, other)
+        return self._inplace_from_result(result, "bitwise_and")
 
     def __or__(self, other):
         return _me().bitwise_or(self, other)
@@ -470,7 +637,8 @@ class WhestArray(_np.ndarray):
         return _me().bitwise_or(other, self)
 
     def __ior__(self, other):
-        return _me().bitwise_or(self, other)
+        result = _me().bitwise_or(self, other)
+        return self._inplace_from_result(result, "bitwise_or")
 
     def __xor__(self, other):
         return _me().bitwise_xor(self, other)
@@ -479,7 +647,8 @@ class WhestArray(_np.ndarray):
         return _me().bitwise_xor(other, self)
 
     def __ixor__(self, other):
-        return _me().bitwise_xor(self, other)
+        result = _me().bitwise_xor(self, other)
+        return self._inplace_from_result(result, "bitwise_xor")
 
     def __lshift__(self, other):
         return _me().left_shift(self, other)
@@ -488,7 +657,8 @@ class WhestArray(_np.ndarray):
         return _me().left_shift(other, self)
 
     def __ilshift__(self, other):
-        return _me().left_shift(self, other)
+        result = _me().left_shift(self, other)
+        return self._inplace_from_result(result, "left_shift")
 
     def __rshift__(self, other):
         return _me().right_shift(self, other)
@@ -497,7 +667,8 @@ class WhestArray(_np.ndarray):
         return _me().right_shift(other, self)
 
     def __irshift__(self, other):
-        return _me().right_shift(self, other)
+        result = _me().right_shift(self, other)
+        return self._inplace_from_result(result, "right_shift")
 
 
 def wrap_module_returns(module, skip_names=None, check_module=True):

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -11,6 +11,9 @@ numpy.ndarray) returns True. All me.* functions return WhestArray.
 
 from __future__ import annotations
 
+import functools as _functools
+import inspect as _inspect
+
 import numpy as _np
 
 
@@ -325,3 +328,117 @@ def _asplainwhest(x):
     """
     arr = _np.asarray(x)
     return arr.view(WhestArray)
+
+
+def _to_base_ndarray(x):
+    """View a whest array as a plain ``np.ndarray`` (zero-copy).
+
+    Distinct from :func:`_asplainwhest` (which returns a ``WhestArray`` —
+    still a numpy subclass that triggers ``__array_function__``).
+    Required before calling ``_np.<func>(x)`` from inside our own
+    ``__array_ufunc__`` / ``__array_function__`` handlers, so that
+    NumPy's protocol dispatch (which would route WhestArray inputs back
+    through ``me.<func>``) does not recurse infinitely.
+
+    Non-array inputs (Python scalars, lists) pass through unchanged so
+    that NEP 50 weak-typing rules continue to apply when whest wrappers
+    forward these to NumPy.
+
+    Examples
+    --------
+    >>> a = WhestArray((4,), dtype=float)
+    >>> type(_to_base_ndarray(a)) is _np.ndarray
+    True
+    >>> _to_base_ndarray(2.0) == 2.0
+    True
+    """
+    if isinstance(x, _np.ndarray):
+        return x.view(_np.ndarray)
+    return x
+
+
+def _to_base_ndarray_tree(x):
+    """Recursively strip whest subclasses from arrays inside tuples/lists.
+
+    Use for arguments that accept *containers* of arrays passed through
+    ``__array_function__``:
+    - ``np.lexsort(keys)`` — keys is a sequence of arrays.
+    - ``np.meshgrid(*xi)`` — xi is a tuple of arrays.
+    - ``np.concatenate(arrays)`` / ``np.stack(arrays)`` — arrays is a sequence.
+    - ``out=(out1, out2)`` — multi-output ufunc out tuples.
+
+    Plain ``_to_base_ndarray`` only handles a single array; using it on
+    a list of WhestArrays leaves the inner WhestArrays intact and
+    recursion can still happen through them.
+
+    Preserves namedtuples (e.g. ``UniqueAllResult``) by re-constructing
+    the type with stripped fields.
+
+    Intentional scope: tuples, lists, namedtuples, and bare arrays only.
+    Dicts and other generic mappings are NOT recursed into.
+    """
+    if isinstance(x, _np.ndarray):
+        return x.view(_np.ndarray)
+    if isinstance(x, tuple):
+        stripped = tuple(_to_base_ndarray_tree(e) for e in x)
+        # Preserve namedtuple type if present.
+        if type(x) is not tuple and hasattr(type(x), "_fields"):
+            return type(x)(*stripped)
+        return stripped
+    if isinstance(x, list):
+        return [_to_base_ndarray_tree(e) for e in x]
+    return x
+
+
+@_functools.cache
+def _signature_kwargs_accepted(np_func):
+    """Return frozenset of kwarg names accepted by ``np_func``.
+
+    Returns:
+    - ``None`` if ``np_func`` is ``None`` or signature inspection fails.
+    - Empty frozenset if ``np_func`` accepts ``**kwargs`` (sentinel meaning
+      "accepts every kwarg name; do not filter").
+    - Otherwise a frozenset of accepted parameter names.
+
+    Cached: NumPy callable identities are stable for the process
+    lifetime, so ``@functools.cache`` is safe and necessary on this hot
+    path. PR #51 memoized similar per-call introspection
+    (``unique_elements_for_shape``, ``_canonical_axis_action``); this
+    follows the same pattern. See PR #51 perf comment for why per-call
+    ``inspect.signature`` is unacceptable.
+    """
+    if np_func is None:
+        return None
+    try:
+        sig = _inspect.signature(np_func)
+    except (ValueError, TypeError):
+        return None
+    for p in sig.parameters.values():
+        if p.kind == _inspect.Parameter.VAR_KEYWORD:
+            return frozenset()  # sentinel: accepts everything
+    return frozenset(
+        n for n, p in sig.parameters.items()
+        if p.kind != _inspect.Parameter.VAR_POSITIONAL
+    )
+
+
+def _filter_to_np_signature(np_func, kwargs):
+    """Drop kwargs that ``np_func`` does not accept.
+
+    NumPy's ``ufunc.reduce`` always supplies ``dtype=`` / ``keepdims=`` /
+    ``out=``, but the equivalent function-form wrapper (``np.all``,
+    ``np.any``, etc.) accepts only a subset. Forwarding the full
+    ufunc-reduce kwarg set to those function-form wrappers raises
+    ``TypeError``.
+
+    Falls back to the original kwargs when ``inspect.signature`` cannot
+    introspect (e.g. C-implemented functions). Per-function signature
+    lookup is cached via :func:`_signature_kwargs_accepted` — this is on
+    the per-ufunc-call hot path; uncached lookup would be a perf cliff.
+    """
+    accepted = _signature_kwargs_accepted(np_func)
+    if accepted is None:
+        return kwargs
+    if not accepted:  # empty frozenset = sentinel for **kwargs accepted
+        return kwargs
+    return {k: v for k, v in kwargs.items() if k in accepted}

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -74,6 +74,95 @@ class WhestArray(_np.ndarray):
             return out_arr[()]
         return super().__array_wrap__(out_arr, context, return_scalar)
 
+    # ----- numpy ufunc protocol (NEP 13) -----
+
+    _REDUCE_TO_WHEST = {
+        "add": "sum",
+        "multiply": "prod",
+        "maximum": "max",
+        "minimum": "min",
+        "logical_and": "all",
+        "logical_or": "any",
+    }
+    _ACCUMULATE_TO_WHEST = {
+        "add": "cumsum",
+        "multiply": "cumprod",
+    }
+
+    def __array_ufunc__(self, ufunc, method, *inputs, out=None, **kwargs):
+        """Route ufunc calls through whest's counted functions.
+
+        Triggered for:
+        - ``np.add(whest, x)``         → method='__call__'
+        - ``np.add.reduce(whest)``     → method='reduce'
+        - ``np.add.accumulate(whest)`` → method='accumulate'
+
+        ``out`` is passed by NumPy as a tuple (e.g. ``(out_arr,)`` for a
+        single-output ufunc). Whest functions expect ``out=arr``, so we
+        unwrap the single-element tuple before forwarding.
+
+        Unsupported ufunc methods (``outer``, ``reduceat``, ``at``) and
+        multi-output ufuncs (``modf``, ``frexp`` — anything with
+        ``ufunc.nout != 1``) raise ``NotImplementedError`` so callers
+        cannot silently bypass tracking.
+        """
+        me = _me()
+
+        # Reject multi-output ufuncs explicitly — whest wrappers do not
+        # currently honor multi-output ``out=(out1, out2)``.
+        if ufunc.nout != 1:
+            raise NotImplementedError(
+                f"ufuncs with nout != 1 are not yet supported on WhestArray "
+                f"(operation: {ufunc.__name__}, nout={ufunc.nout}); use the "
+                f"equivalent whest function (e.g. ``we.modf(a)``) instead."
+            )
+
+        np_target_name = None  # used to drive _filter_to_np_signature below
+        if method == "__call__":
+            whest_fn = getattr(me, ufunc.__name__, None)
+            np_target_name = ufunc.__name__
+        elif method == "reduce":
+            target = self._REDUCE_TO_WHEST.get(ufunc.__name__)
+            whest_fn = getattr(me, target, None) if target else None
+            np_target_name = target
+            # NumPy's ufunc.reduce defaults to axis=0; whest's me.sum etc.
+            # default to axis=None (full reduction). Force NumPy default.
+            kwargs.setdefault("axis", 0)
+        elif method == "accumulate":
+            target = self._ACCUMULATE_TO_WHEST.get(ufunc.__name__)
+            whest_fn = getattr(me, target, None) if target else None
+            np_target_name = target
+            kwargs.setdefault("axis", 0)
+        elif method in ("outer", "reduceat", "at"):
+            raise NotImplementedError(
+                f"ufunc.{method} is not yet supported on WhestArray "
+                f"(operation: {ufunc.__name__}); use the equivalent "
+                f"whest function instead, or open an issue if you need this."
+            )
+        else:
+            whest_fn = None
+
+        if whest_fn is None:
+            return NotImplemented
+
+        # Unwrap single-output ``out`` tuple.
+        if out is not None:
+            if isinstance(out, tuple) and len(out) == 1:
+                kwargs["out"] = out[0]
+            else:
+                kwargs["out"] = out
+
+        # Filter kwargs against the target NumPy callable's signature so
+        # ufunc-internal kwargs (e.g. ``dtype=`` from np.all → np.add.reduce)
+        # don't reach a function-form whest wrapper that doesn't accept
+        # them.
+        if np_target_name is not None:
+            kwargs = _filter_to_np_signature(
+                getattr(_np, np_target_name, None), kwargs
+            )
+
+        return whest_fn(*inputs, **kwargs)
+
     # ----- Binary arithmetic -----
 
     def __add__(self, other):

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -35,10 +35,16 @@ def _me():
 # *original* numpy callables.
 _PASSTHROUGH_NAMES = (
     # Zero-FLOP type/shape queries:
-    "ndim", "shape", "size",
+    "ndim",
+    "shape",
+    "size",
     # Zero-FLOP type-system queries (added by Task 4 for #62/#58 followup):
-    "result_type", "can_cast", "min_scalar_type", "promote_types",
-    "find_common_type", "mintypecode",
+    "result_type",
+    "can_cast",
+    "min_scalar_type",
+    "promote_types",
+    "find_common_type",
+    "mintypecode",
     # Test-harness assertion that should not count FLOPs:
     "array_equal",
 )
@@ -185,9 +191,7 @@ class WhestArray(_np.ndarray):
         # don't reach a function-form whest wrapper that doesn't accept
         # them.
         if np_target_name is not None:
-            kwargs = _filter_to_np_signature(
-                getattr(_np, np_target_name, None), kwargs
-            )
+            kwargs = _filter_to_np_signature(getattr(_np, np_target_name, None), kwargs)
 
         return whest_fn(*inputs, **kwargs)
 
@@ -228,32 +232,75 @@ class WhestArray(_np.ndarray):
 
         # ----- Reductions -----
         for name in (
-            "sum", "prod", "mean", "min", "max", "std", "var", "all", "any",
-            "cumsum", "cumprod", "argmin", "argmax", "ptp", "median",
-            "average", "percentile", "quantile",
+            "sum",
+            "prod",
+            "mean",
+            "min",
+            "max",
+            "std",
+            "var",
+            "all",
+            "any",
+            "cumsum",
+            "cumprod",
+            "argmin",
+            "argmax",
+            "ptp",
+            "median",
+            "average",
+            "percentile",
+            "quantile",
         ):
             _bind(name, name)
 
         # ----- Sorting / selection -----
         for name in (
-            "sort", "argsort", "lexsort", "partition", "argpartition",
-            "searchsorted", "digitize",
+            "sort",
+            "argsort",
+            "lexsort",
+            "partition",
+            "argpartition",
+            "searchsorted",
+            "digitize",
         ):
             _bind(name, name)
 
         # ----- Set / unique -----
         for name in (
-            "unique", "unique_all", "unique_counts", "unique_inverse",
-            "unique_values", "in1d", "isin", "intersect1d", "union1d",
-            "setdiff1d", "setxor1d",
+            "unique",
+            "unique_all",
+            "unique_counts",
+            "unique_inverse",
+            "unique_values",
+            "in1d",
+            "isin",
+            "intersect1d",
+            "union1d",
+            "setdiff1d",
+            "setxor1d",
         ):
             _bind(name, name)
 
         # ----- Free / structural (asarray excluded) -----
         for name in (
-            "where", "tile", "repeat", "flip", "roll", "pad", "triu", "tril",
-            "diagonal", "broadcast_to", "meshgrid", "copy",
-            "astype", "trace", "diff", "gradient", "clip", "round",
+            "where",
+            "tile",
+            "repeat",
+            "flip",
+            "roll",
+            "pad",
+            "triu",
+            "tril",
+            "diagonal",
+            "broadcast_to",
+            "meshgrid",
+            "copy",
+            "astype",
+            "trace",
+            "diff",
+            "gradient",
+            "clip",
+            "round",
         ):
             _bind(name, name)
 
@@ -265,11 +312,25 @@ class WhestArray(_np.ndarray):
         # symmetry; PASSTHROUGH would silently strip it via
         # ``_to_base_ndarray_tree`` before the raw NumPy call.
         for name in (
-            "transpose", "swapaxes", "moveaxis", "reshape", "ravel",
-            "expand_dims", "squeeze",
-            "concatenate", "stack", "vstack", "hstack", "column_stack",
-            "split", "hsplit", "vsplit", "dsplit",
-            "atleast_1d", "atleast_2d", "atleast_3d",
+            "transpose",
+            "swapaxes",
+            "moveaxis",
+            "reshape",
+            "ravel",
+            "expand_dims",
+            "squeeze",
+            "concatenate",
+            "stack",
+            "vstack",
+            "hstack",
+            "column_stack",
+            "split",
+            "hsplit",
+            "vsplit",
+            "dsplit",
+            "atleast_1d",
+            "atleast_2d",
+            "atleast_3d",
             "broadcast_to",
             "matrix_transpose",  # numpy 2.x ufunc-like
         ):
@@ -277,29 +338,57 @@ class WhestArray(_np.ndarray):
 
         # ----- Linear algebra -----
         for name in (
-            "dot", "matmul", "einsum", "tensordot", "inner", "outer", "cross",
+            "dot",
+            "matmul",
+            "einsum",
+            "tensordot",
+            "inner",
+            "outer",
+            "cross",
         ):
             _bind(name, name)
 
         # ----- Comparisons -----
         for name in (
-            "allclose", "isclose", "array_equiv",
+            "allclose",
+            "isclose",
+            "array_equiv",
             # NOTE: array_equal is in _PASSTHROUGH instead.
         ):
             _bind(name, name)
 
         # ----- Histograms / counts -----
         for name in (
-            "histogram", "histogram2d", "histogramdd", "histogram_bin_edges",
-            "bincount", "vander", "apply_over_axes", "piecewise",
+            "histogram",
+            "histogram2d",
+            "histogramdd",
+            "histogram_bin_edges",
+            "bincount",
+            "vander",
+            "apply_over_axes",
+            "piecewise",
         ):
             _bind(name, name)
 
         # ----- linalg submodule -----
         for name in (
-            "norm", "solve", "det", "inv", "pinv", "eig", "eigh", "eigvals",
-            "eigvalsh", "svd", "qr", "cholesky", "matrix_rank", "lstsq",
-            "multi_dot", "matrix_power", "slogdet",
+            "norm",
+            "solve",
+            "det",
+            "inv",
+            "pinv",
+            "eig",
+            "eigh",
+            "eigvals",
+            "eigvalsh",
+            "svd",
+            "qr",
+            "cholesky",
+            "matrix_rank",
+            "lstsq",
+            "multi_dot",
+            "matrix_power",
+            "slogdet",
         ):
             _bind(f"linalg.{name}", f"linalg.{name}")
 
@@ -329,9 +418,7 @@ class WhestArray(_np.ndarray):
         # PASSTHROUGH check first: zero-FLOP queries bypass dispatch.
         if func in self._get_passthrough():
             stripped_args = _to_base_ndarray_tree(args)
-            stripped_kwargs = {
-                k: _to_base_ndarray_tree(v) for k, v in kwargs.items()
-            }
+            stripped_kwargs = {k: _to_base_ndarray_tree(v) for k, v in kwargs.items()}
             return func(*stripped_args, **stripped_kwargs)
 
         dispatch = self._get_array_function_dispatch()
@@ -866,7 +953,8 @@ def _signature_kwargs_accepted(np_func):
         if p.kind == _inspect.Parameter.VAR_KEYWORD:
             return frozenset()  # sentinel: accepts everything
     return frozenset(
-        n for n, p in sig.parameters.items()
+        n
+        for n, p in sig.parameters.items()
         if p.kind != _inspect.Parameter.VAR_POSITIONAL
     )
 

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -1,12 +1,41 @@
-"""Subclass of numpy.ndarray whose operators track FLOP usage.
+"""Subclass of ``numpy.ndarray`` that routes every operation through
+whest's FLOP-counted ``me.*`` functions.
 
-This module defines WhestArray, a thin numpy.ndarray subclass
-that overrides arithmetic, matmul, unary, comparison, bitwise, and
-shift operators to route through whest's FLOP-counted me.*
-functions.
+``WhestArray`` overrides:
 
-Because WhestArray inherits from numpy.ndarray, isinstance(x,
-numpy.ndarray) returns True. All me.* functions return WhestArray.
+- **Arithmetic / comparison / bitwise / shift dunders** so ``a + b``,
+  ``a @ b``, ``a == b``, ``a & b``, ``a << b`` etc. route through
+  ``me.add``, ``me.matmul``, etc.
+- **In-place dunders** (``__iadd__``, …, ``__imatmul__``) with a
+  symmetry-corruption guard that refuses ``A_sym += B`` when the
+  result would weaken or destroy ``A_sym``'s tagged symmetry. ``A @= B``
+  on shape-changing matmul falls back to CPython's documented
+  rebind-the-name semantics.
+- **25 ndarray methods** (``sum``, ``mean``, ``dot``, ``argsort``,
+  ``compress``, ``trace``, ``round``, ``clip``, ``ptp``, …) so
+  ``a.sum()`` and ``we.sum(a)`` produce the same FLOP count.
+- **In-place ``sort`` / ``partition``** which refuse on a
+  ``SymmetricTensor`` (the reorder would break symmetry).
+
+It also implements two NumPy protocols:
+
+- ``__array_ufunc__`` (NEP 13) — ``np.add(a, b)``, ``np.add.reduce(a)``,
+  ``np.add.outer(a, b)``, ``np.add.at(a, idx, val)``, multi-output
+  ufuncs (``np.divmod`` / ``np.frexp`` / ``np.modf``), etc.
+- ``__array_function__`` (NEP 18) — explicit allowlist routing
+  ``np.<func>(whest, …)`` for ~108 callables (reductions, sorting,
+  shape ops, linear algebra, comparisons, histograms, …) plus a
+  ``_PASSTHROUGH`` set of zero-FLOP type/shape queries.
+
+Recursion-prevention helpers (``_to_base_ndarray``,
+``_to_base_ndarray_tree``) view-cast ``WhestArray`` to plain
+``np.ndarray`` for the inner NumPy call, breaking the cycle that
+would otherwise re-dispatch through these protocols.
+
+Because ``WhestArray`` inherits from ``numpy.ndarray``,
+``isinstance(x, numpy.ndarray)`` returns ``True``. All ``me.*``
+functions return ``WhestArray`` (or ``SymmetricTensor`` when symmetry
+survives the operation). See PR #67 for the complete protocol design.
 """
 
 from __future__ import annotations
@@ -705,8 +734,7 @@ class WhestArray(_np.ndarray):
         # mismatch; we follow the CPython fallback so typical pipelines
         # using ``A @= B`` to grow state work cleanly.
         result = _me().matmul(self, other)
-        result_arr = _np.asarray(result)
-        if result_arr.shape != self.shape:
+        if result.shape != self.shape:
             return result
         return self._inplace_from_result(result, "matmul")
 

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -250,6 +250,11 @@ class WhestArray(_np.ndarray):
             "average",
             "percentile",
             "quantile",
+            # NumPy 2.x retained ``amax``/``amin`` as exported aliases
+            # for ``max``/``min``. Bind them so ``np.amax(WhestArray)``
+            # routes through whest instead of raising TypeError.
+            "amax",
+            "amin",
         ):
             _bind(name, name)
 

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -127,9 +127,12 @@ class WhestArray(_np.ndarray):
         """Route ufunc calls through whest's counted functions.
 
         Triggered for:
-        - ``np.add(whest, x)``         → method='__call__'
-        - ``np.add.reduce(whest)``     → method='reduce'
-        - ``np.add.accumulate(whest)`` → method='accumulate'
+        - ``np.add(whest, x)``           → method='__call__'
+        - ``np.add.reduce(whest)``       → method='reduce'
+        - ``np.add.accumulate(whest)``   → method='accumulate'
+        - ``np.add.outer(whest, w2)``    → method='outer'
+        - ``np.add.reduceat(whest, ix)`` → method='reduceat'
+        - ``np.add.at(whest, ix, val)``  → method='at'
 
         ``out`` is passed by NumPy as a tuple of length ``ufunc.nout``.
         For single-output ufuncs we unwrap the 1-tuple to ``out=arr``;
@@ -137,55 +140,98 @@ class WhestArray(_np.ndarray):
         forward the tuple as-is to the corresponding ``we.*`` wrapper,
         which knows how to handle per-slot stripping and identity.
 
-        Unsupported ufunc methods (``outer``, ``reduceat``, ``at``)
-        raise ``NotImplementedError`` so callers cannot silently bypass
-        tracking.
+        ``reduce`` / ``accumulate`` first try the optimized routing in
+        :attr:`_REDUCE_TO_WHEST` / :attr:`_ACCUMULATE_TO_WHEST`; on a
+        miss (e.g. ``np.subtract.reduce``) they fall back to a generic
+        path in :mod:`whest._pointwise` that strips, charges
+        :func:`reduction_cost`, and routes back through the raw
+        ``ufunc.<method>``. ``outer`` / ``reduceat`` / ``at`` always
+        use the generic path. ``ufunc.at`` refuses on SymmetricTensor
+        operands (the in-place fancy-index write would break symmetry).
         """
         me = _me()
 
         np_target_name = None  # used to drive _filter_to_np_signature below
+        whest_fn = None
         if method == "__call__":
             whest_fn = getattr(me, ufunc.__name__, None)
             np_target_name = ufunc.__name__
         elif method == "reduce":
             target = self._REDUCE_TO_WHEST.get(ufunc.__name__)
-            whest_fn = getattr(me, target, None) if target else None
-            np_target_name = target
-            # NumPy's ufunc.reduce defaults to axis=0; whest's me.sum etc.
-            # default to axis=None (full reduction). Force NumPy default.
-            kwargs.setdefault("axis", 0)
+            if target is not None:
+                whest_fn = getattr(me, target, None)
+                np_target_name = target
+                # NumPy's ufunc.reduce defaults to axis=0; whest's me.sum etc.
+                # default to axis=None (full reduction). Force NumPy default.
+                kwargs.setdefault("axis", 0)
         elif method == "accumulate":
             target = self._ACCUMULATE_TO_WHEST.get(ufunc.__name__)
-            whest_fn = getattr(me, target, None) if target else None
-            np_target_name = target
-            kwargs.setdefault("axis", 0)
-        elif method in ("outer", "reduceat", "at"):
-            raise NotImplementedError(
-                f"ufunc.{method} is not yet supported on WhestArray "
-                f"(operation: {ufunc.__name__}); use the equivalent "
-                f"whest function instead, or open an issue if you need this."
+            if target is not None:
+                whest_fn = getattr(me, target, None)
+                np_target_name = target
+                kwargs.setdefault("axis", 0)
+
+        if whest_fn is not None:
+            # Optimized routing-table path: forward to the dedicated
+            # ``we.*`` wrapper.
+            #
+            # Unwrap single-output ``out`` tuple.
+            if out is not None:
+                if isinstance(out, tuple) and len(out) == 1:
+                    kwargs["out"] = out[0]
+                else:
+                    kwargs["out"] = out
+            # Filter kwargs against the target NumPy callable's signature so
+            # ufunc-internal kwargs (e.g. ``dtype=`` from np.all → np.add.reduce)
+            # don't reach a function-form whest wrapper that doesn't accept
+            # them.
+            if np_target_name is not None:
+                kwargs = _filter_to_np_signature(
+                    getattr(_np, np_target_name, None), kwargs
+                )
+            return whest_fn(*inputs, **kwargs)
+
+        # Generic ufunc-method paths for ops without a dedicated whest
+        # equivalent. Lazy-imported to avoid the _ndarray ↔ _pointwise
+        # circular-dependency loop.
+        if method in ("outer", "reduce", "accumulate", "reduceat", "at"):
+            from whest._pointwise import (
+                _counted_ufunc_accumulate_generic,
+                _counted_ufunc_at,
+                _counted_ufunc_outer,
+                _counted_ufunc_reduce_generic,
+                _counted_ufunc_reduceat,
             )
-        else:
-            whest_fn = None
 
-        if whest_fn is None:
-            return NotImplemented
+            # Unwrap single-output ``out`` tuple for the generic paths
+            # too. ``ufunc.at`` doesn't take ``out``.
+            out_for_generic = out
+            if out is not None and isinstance(out, tuple) and len(out) == 1:
+                out_for_generic = out[0]
 
-        # Unwrap single-output ``out`` tuple.
-        if out is not None:
-            if isinstance(out, tuple) and len(out) == 1:
-                kwargs["out"] = out[0]
-            else:
-                kwargs["out"] = out
+            if method == "outer":
+                return _counted_ufunc_outer(
+                    ufunc, *inputs, out=out_for_generic, **kwargs
+                )
+            if method == "reduce":
+                kwargs.setdefault("axis", 0)
+                return _counted_ufunc_reduce_generic(
+                    ufunc, *inputs, out=out_for_generic, **kwargs
+                )
+            if method == "accumulate":
+                kwargs.setdefault("axis", 0)
+                return _counted_ufunc_accumulate_generic(
+                    ufunc, *inputs, out=out_for_generic, **kwargs
+                )
+            if method == "reduceat":
+                return _counted_ufunc_reduceat(
+                    ufunc, *inputs, out=out_for_generic, **kwargs
+                )
+            if method == "at":
+                # ``ufunc.at`` does not accept ``out=``.
+                return _counted_ufunc_at(ufunc, *inputs, **kwargs)
 
-        # Filter kwargs against the target NumPy callable's signature so
-        # ufunc-internal kwargs (e.g. ``dtype=`` from np.all → np.add.reduce)
-        # don't reach a function-form whest wrapper that doesn't accept
-        # them.
-        if np_target_name is not None:
-            kwargs = _filter_to_np_signature(getattr(_np, np_target_name, None), kwargs)
-
-        return whest_fn(*inputs, **kwargs)
+        return NotImplemented
 
     # ----- numpy array-function protocol (NEP 18) -----
 

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -29,6 +29,34 @@ def _me():
     return _whest
 
 
+# Eagerly captured at import time so ``tests/numpy_compat`` monkeypatching
+# (which replaces ``np.<name>`` with ``we.<name>``) doesn't accidentally
+# install the whest-replacements into ``_PASSTHROUGH``. The set holds the
+# *original* numpy callables.
+_PASSTHROUGH_NAMES = (
+    # Zero-FLOP type/shape queries:
+    "ndim", "shape", "size",
+    # Zero-FLOP type-system queries (added by Task 4 for #62/#58 followup):
+    "result_type", "can_cast", "min_scalar_type", "promote_types",
+    "find_common_type", "mintypecode",
+    # Test-harness assertion that should not count FLOPs:
+    "array_equal",
+)
+
+
+def _build_passthrough():
+    """Build the ``_PASSTHROUGH`` set, eagerly at import time."""
+    s = set()
+    for name in _PASSTHROUGH_NAMES:
+        fn = getattr(_np, name, None)
+        if fn is not None:
+            s.add(fn)
+    return s
+
+
+_INITIAL_PASSTHROUGH = _build_passthrough()
+
+
 class WhestArray(_np.ndarray):
     """A numpy ndarray subclass with FLOP-tracked operators.
 
@@ -162,6 +190,155 @@ class WhestArray(_np.ndarray):
             )
 
         return whest_fn(*inputs, **kwargs)
+
+    # ----- numpy array-function protocol (NEP 18) -----
+
+    # Lazy-built dispatch map. Populated on first __array_function__ call
+    # because whest's namespace uses lazy submodule loading.
+    _ARRAY_FUNCTION_DISPATCH: dict | None = None
+    _PASSTHROUGH: set | None = None
+
+    @classmethod
+    def _get_array_function_dispatch(cls):
+        """Build (once) and return the np-callable → whest-callable map."""
+        if cls._ARRAY_FUNCTION_DISPATCH is not None:
+            return cls._ARRAY_FUNCTION_DISPATCH
+
+        me = _me()
+        d: dict = {}
+
+        def _bind(np_attr_path, we_attr_path):
+            """Look up np.<path> and me.<path>, add to dispatch map.
+
+            Silently skip pairs where one side is missing (e.g. linalg
+            functions added in newer NumPy versions).
+            """
+            np_obj = _np
+            for part in np_attr_path.split("."):
+                np_obj = getattr(np_obj, part, None)
+                if np_obj is None:
+                    return
+            we_obj = me
+            for part in we_attr_path.split("."):
+                we_obj = getattr(we_obj, part, None)
+                if we_obj is None:
+                    return
+            if callable(np_obj) and callable(we_obj):
+                d[np_obj] = we_obj
+
+        # ----- Reductions -----
+        for name in (
+            "sum", "prod", "mean", "min", "max", "std", "var", "all", "any",
+            "cumsum", "cumprod", "argmin", "argmax", "ptp", "median",
+            "average", "percentile", "quantile",
+        ):
+            _bind(name, name)
+
+        # ----- Sorting / selection -----
+        for name in (
+            "sort", "argsort", "lexsort", "partition", "argpartition",
+            "searchsorted", "digitize",
+        ):
+            _bind(name, name)
+
+        # ----- Set / unique -----
+        for name in (
+            "unique", "unique_all", "unique_counts", "unique_inverse",
+            "unique_values", "in1d", "isin", "intersect1d", "union1d",
+            "setdiff1d", "setxor1d",
+        ):
+            _bind(name, name)
+
+        # ----- Free / structural (asarray excluded) -----
+        for name in (
+            "where", "tile", "repeat", "flip", "roll", "pad", "triu", "tril",
+            "diagonal", "broadcast_to", "meshgrid", "copy",
+            "astype", "trace", "diff", "gradient", "clip", "round",
+        ):
+            _bind(name, name)
+
+        # ----- Shape / view ops -----
+        # The whest counterparts (``me.transpose``, ``me.swapaxes``,
+        # ``me.moveaxis``, etc.) handle ``SymmetricTensor`` axis
+        # remapping correctly via ``wrap_with_symmetry`` /
+        # ``remap_group_axes``. Routing through the allowlist preserves
+        # symmetry; PASSTHROUGH would silently strip it via
+        # ``_to_base_ndarray_tree`` before the raw NumPy call.
+        for name in (
+            "transpose", "swapaxes", "moveaxis", "reshape", "ravel",
+            "expand_dims", "squeeze",
+            "concatenate", "stack", "vstack", "hstack", "column_stack",
+            "split", "hsplit", "vsplit", "dsplit",
+            "atleast_1d", "atleast_2d", "atleast_3d",
+            "broadcast_to",
+            "matrix_transpose",  # numpy 2.x ufunc-like
+        ):
+            _bind(name, name)
+
+        # ----- Linear algebra -----
+        for name in (
+            "dot", "matmul", "einsum", "tensordot", "inner", "outer", "cross",
+        ):
+            _bind(name, name)
+
+        # ----- Comparisons -----
+        for name in (
+            "allclose", "isclose", "array_equiv",
+            # NOTE: array_equal is in _PASSTHROUGH instead.
+        ):
+            _bind(name, name)
+
+        # ----- Histograms / counts -----
+        for name in (
+            "histogram", "histogram2d", "histogramdd", "histogram_bin_edges",
+            "bincount", "vander", "apply_over_axes", "piecewise",
+        ):
+            _bind(name, name)
+
+        # ----- linalg submodule -----
+        for name in (
+            "norm", "solve", "det", "inv", "pinv", "eig", "eigh", "eigvals",
+            "eigvalsh", "svd", "qr", "cholesky", "matrix_rank", "lstsq",
+            "multi_dot", "matrix_power", "slogdet",
+        ):
+            _bind(f"linalg.{name}", f"linalg.{name}")
+
+        cls._ARRAY_FUNCTION_DISPATCH = d
+        return d
+
+    @classmethod
+    def _get_passthrough(cls):
+        """Return the eagerly-captured passthrough set."""
+        if cls._PASSTHROUGH is not None:
+            return cls._PASSTHROUGH
+        cls._PASSTHROUGH = set(_INITIAL_PASSTHROUGH)
+        return cls._PASSTHROUGH
+
+    def __array_function__(self, func, types, args, kwargs):
+        """Route ``np.<func>(whest, ...)`` calls through whest via an
+        explicit allowlist (see ``_get_array_function_dispatch``).
+
+        Functions in ``_PASSTHROUGH`` are zero-FLOP type/shape queries
+        that bypass tracking and call the underlying NumPy function
+        directly with stripped args.
+
+        Functions not in either set return ``NotImplemented``. NumPy
+        will then raise ``TypeError`` rather than silently bypassing
+        tracking.
+        """
+        # PASSTHROUGH check first: zero-FLOP queries bypass dispatch.
+        if func in self._get_passthrough():
+            stripped_args = _to_base_ndarray_tree(args)
+            stripped_kwargs = {
+                k: _to_base_ndarray_tree(v) for k, v in kwargs.items()
+            }
+            return func(*stripped_args, **stripped_kwargs)
+
+        dispatch = self._get_array_function_dispatch()
+        we_func = dispatch.get(func)
+        if we_func is None:
+            return NotImplemented
+        return we_func(*args, **kwargs)
 
     # ----- Binary arithmetic -----
 
@@ -429,6 +606,12 @@ def _to_base_ndarray(x):
     NumPy's protocol dispatch (which would route WhestArray inputs back
     through ``me.<func>``) does not recurse infinitely.
 
+    Only ``WhestArray`` instances (and subclasses like
+    ``SymmetricTensor``) are stripped — other ``numpy.ndarray``
+    subclasses (e.g. ``np.matrix``, user-defined ``ArraySubclass``)
+    pass through unchanged so NumPy's standard subclass-propagation
+    behaviour preserves their type on the result.
+
     Non-array inputs (Python scalars, lists) pass through unchanged so
     that NEP 50 weak-typing rules continue to apply when whest wrappers
     forward these to NumPy.
@@ -441,7 +624,7 @@ def _to_base_ndarray(x):
     >>> _to_base_ndarray(2.0) == 2.0
     True
     """
-    if isinstance(x, _np.ndarray):
+    if isinstance(x, WhestArray):
         return x.view(_np.ndarray)
     return x
 
@@ -465,8 +648,14 @@ def _to_base_ndarray_tree(x):
 
     Intentional scope: tuples, lists, namedtuples, and bare arrays only.
     Dicts and other generic mappings are NOT recursed into.
+
+    Only ``WhestArray`` instances (and subclasses like
+    ``SymmetricTensor``) are stripped — other ``numpy.ndarray``
+    subclasses (e.g. ``np.matrix``, user-defined ``ArraySubclass``)
+    pass through unchanged so NumPy's standard subclass-propagation
+    behaviour preserves their type on the result.
     """
-    if isinstance(x, _np.ndarray):
+    if isinstance(x, WhestArray):
         return x.view(_np.ndarray)
     if isinstance(x, tuple):
         stripped = tuple(_to_base_ndarray_tree(e) for e in x)

--- a/src/whest/_ndarray.py
+++ b/src/whest/_ndarray.py
@@ -131,25 +131,17 @@ class WhestArray(_np.ndarray):
         - ``np.add.reduce(whest)``     → method='reduce'
         - ``np.add.accumulate(whest)`` → method='accumulate'
 
-        ``out`` is passed by NumPy as a tuple (e.g. ``(out_arr,)`` for a
-        single-output ufunc). Whest functions expect ``out=arr``, so we
-        unwrap the single-element tuple before forwarding.
+        ``out`` is passed by NumPy as a tuple of length ``ufunc.nout``.
+        For single-output ufuncs we unwrap the 1-tuple to ``out=arr``;
+        for multi-output ufuncs (``divmod``, ``frexp``, ``modf``) we
+        forward the tuple as-is to the corresponding ``we.*`` wrapper,
+        which knows how to handle per-slot stripping and identity.
 
-        Unsupported ufunc methods (``outer``, ``reduceat``, ``at``) and
-        multi-output ufuncs (``modf``, ``frexp`` — anything with
-        ``ufunc.nout != 1``) raise ``NotImplementedError`` so callers
-        cannot silently bypass tracking.
+        Unsupported ufunc methods (``outer``, ``reduceat``, ``at``)
+        raise ``NotImplementedError`` so callers cannot silently bypass
+        tracking.
         """
         me = _me()
-
-        # Reject multi-output ufuncs explicitly — whest wrappers do not
-        # currently honor multi-output ``out=(out1, out2)``.
-        if ufunc.nout != 1:
-            raise NotImplementedError(
-                f"ufuncs with nout != 1 are not yet supported on WhestArray "
-                f"(operation: {ufunc.__name__}, nout={ufunc.nout}); use the "
-                f"equivalent whest function (e.g. ``we.modf(a)``) instead."
-            )
 
         np_target_name = None  # used to drive _filter_to_np_signature below
         if method == "__call__":

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins as _builtins
 import inspect as _inspect
+from math import prod as _math_prod
 
 import numpy as _np
 
@@ -27,7 +28,15 @@ from whest._symmetric import (
 from whest._symmetric import (
     is_symmetric as _is_symmetric,
 )
-from whest._symmetry_utils import broadcast_group, intersect_groups, reduce_group
+from whest._symmetry_utils import (
+    broadcast_group,
+    direct_product_groups,
+    intersect_groups,
+    reduce_group,
+    remap_group_axes,
+    restrict_group_to_axes,
+    unique_elements_for_shape,
+)
 from whest._validation import check_nan_inf, require_budget
 from whest.errors import SymmetryError, UnsupportedFunctionError
 
@@ -74,6 +83,41 @@ def _validate_result_symmetry(result, symmetry):
         if axes is None:
             axes = tuple(range(symmetry.degree))
         raise SymmetryError(axes=tuple(axes), max_deviation=float("inf"))
+
+
+def _symmetry_adjusted_cost(dense_cost, output_shape, output_symmetry):
+    """Scale a dense FLOP cost by the output's symmetry-savings ratio.
+
+    Placeholder model: for an output of shape ``output_shape`` with
+    permutation symmetry ``output_symmetry``, the number of *unique*
+    elements is at most ``unique_elements_for_shape(output_symmetry,
+    output_shape)``. We scale the dense cost by ``unique / dense`` so
+    the budget reflects the symmetry savings a symmetry-aware
+    implementation could realise.
+
+    For non-symmetric outputs, the ratio is ``1.0`` and ``cost ==
+    dense_cost`` (no behaviour change for users without
+    SymmetricTensor inputs). For symmetric outputs, the ratio drops
+    below 1 and captures redundant-element savings.
+
+    TODO: this is a placeholder. The real algorithmic cost depends on
+    whether the underlying NumPy call (or the whest wrapper) actually
+    skips redundant work — today, our wrappers compute the dense
+    output and discard the duplicates. Replace with a per-op
+    algorithmic-cost model when one is available.
+    """
+    if output_symmetry is None:
+        return int(dense_cost)
+    # Use the Python builtins to avoid the module-level ``max`` /
+    # ``prod`` reduction wrappers that shadow them in this module.
+    dense_output = _builtins.max(_math_prod(output_shape), 1)
+    if dense_output <= 1:
+        return int(dense_cost)
+    unique = unique_elements_for_shape(output_symmetry, output_shape)
+    if unique >= dense_output:
+        return int(dense_cost)
+    # Integer-division form avoids float drift on large arrays.
+    return _builtins.max(int(dense_cost) * int(unique) // dense_output, 1)
 
 
 def _call_with_optional_out(np_func, *args, out=None, supports_out=False, **kwargs):
@@ -426,6 +470,221 @@ def _counted_binary_multi(np_func, op_name: str):
     except (ValueError, TypeError):
         pass
     return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Generic ufunc-method helpers (outer, reduceat, at, generic reduce/accumulate)
+# ---------------------------------------------------------------------------
+
+
+def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
+    """Cost-tracked ``ufunc.outer(a, b)`` for any binary ufunc.
+
+    Output shape is ``a.shape + b.shape``; output symmetry is the direct
+    product of the input symmetries (with ``b``'s axes lifted by
+    ``a.ndim`` so they refer to the correct slots in the combined
+    output). Cost is symmetry-adjusted: dense ``a.size * b.size``
+    scaled by ``unique / dense`` of the output (see
+    :func:`_symmetry_adjusted_cost`).
+    """
+    budget = require_budget()
+    if not isinstance(a, _np.ndarray):
+        a = _np.asarray(a)
+    if not isinstance(b, _np.ndarray):
+        b = _np.asarray(b)
+    a_sym = _symmetry_of(a)
+    b_sym = _symmetry_of(b)
+    output_shape = tuple(a.shape) + tuple(b.shape)
+    # Lift ``b``'s symmetry axes into the combined output's slot range.
+    b_sym_lifted = b_sym
+    if b_sym is not None and b_sym.axes is not None:
+        axis_map = {ax: ax + a.ndim for ax in b_sym.axes}
+        b_sym_lifted = remap_group_axes(b_sym, axis_map)
+    out_sym = direct_product_groups(a_sym, b_sym_lifted)
+    dense = _builtins.max(a.size * b.size, 1)
+    cost = _symmetry_adjusted_cost(dense, output_shape, out_sym)
+    out_stripped = _to_base_ndarray(out) if out is not None else None
+    with budget.deduct(
+        f"{ufunc.__name__}.outer",
+        flop_cost=cost,
+        subscripts=None,
+        shapes=(a.shape, b.shape),
+    ):
+        result = ufunc.outer(
+            _to_base_ndarray(a),
+            _to_base_ndarray(b),
+            out=out_stripped,
+            **kwargs,
+        )
+    return _wrap_result(result, out=out, symmetry=out_sym)
+
+
+def _counted_ufunc_reduce_generic(
+    ufunc, a, *, axis=0, out=None, keepdims=False, **kwargs
+):
+    """Cost-tracked fallback for ``ufunc.reduce`` of arbitrary binary ufuncs.
+
+    Used for ufuncs not in :class:`WhestArray._REDUCE_TO_WHEST` (e.g.
+    ``subtract``, ``logical_xor``, ``bitwise_or``). Cost equals
+    :func:`reduction_cost` (numel of input, or the symmetry-aware
+    unique count); output symmetry follows
+    :func:`reduce_group(symmetry, ndim, axis, keepdims)`.
+    """
+    budget = require_budget()
+    if not isinstance(a, _np.ndarray):
+        a = _np.asarray(a)
+    sym = _symmetry_of(a)
+    cost = reduction_cost(a.shape, axis=axis, symmetry=sym)
+    out_sym = (
+        reduce_group(sym, ndim=a.ndim, axis=axis, keepdims=keepdims)
+        if sym is not None
+        else None
+    )
+    out_stripped = _to_base_ndarray(out) if out is not None else None
+    with budget.deduct(
+        f"{ufunc.__name__}.reduce",
+        flop_cost=cost,
+        subscripts=None,
+        shapes=(a.shape,),
+    ):
+        result = ufunc.reduce(
+            _to_base_ndarray(a),
+            axis=axis,
+            out=out_stripped,
+            keepdims=keepdims,
+            **kwargs,
+        )
+    return _wrap_result(result, out=out, symmetry=out_sym)
+
+
+def _counted_ufunc_accumulate_generic(ufunc, a, *, axis=0, out=None, **kwargs):
+    """Cost-tracked fallback for ``ufunc.accumulate`` of arbitrary binary ufuncs.
+
+    Used for ufuncs not in :class:`WhestArray._ACCUMULATE_TO_WHEST`.
+    Cost equals :func:`reduction_cost` (cumulative ops touch every
+    element). Output shape matches input shape, but accumulation along
+    ``axis`` breaks any permutation symmetry that includes that axis.
+    Output symmetry: surviving stabilizer with ``keepdims=True`` (drops
+    symmetry on the accumulate axis only).
+    """
+    budget = require_budget()
+    if not isinstance(a, _np.ndarray):
+        a = _np.asarray(a)
+    sym = _symmetry_of(a)
+    cost = reduction_cost(a.shape, axis=axis, symmetry=sym)
+    out_sym = (
+        reduce_group(sym, ndim=a.ndim, axis=axis, keepdims=True)
+        if sym is not None
+        else None
+    )
+    out_stripped = _to_base_ndarray(out) if out is not None else None
+    with budget.deduct(
+        f"{ufunc.__name__}.accumulate",
+        flop_cost=cost,
+        subscripts=None,
+        shapes=(a.shape,),
+    ):
+        result = ufunc.accumulate(
+            _to_base_ndarray(a),
+            axis=axis,
+            out=out_stripped,
+            **kwargs,
+        )
+    return _wrap_result(result, out=out, symmetry=out_sym)
+
+
+def _counted_ufunc_reduceat(ufunc, a, indices, *, axis=0, out=None, **kwargs):
+    """Cost-tracked ``ufunc.reduceat(a, indices, axis=...)``.
+
+    Cost is dense ``numel(input)`` — every element is touched by
+    exactly one segment. Output symmetry is ``None``: arbitrary segment
+    boundaries don't respect any axis-permutation group action.
+    """
+    budget = require_budget()
+    if not isinstance(a, _np.ndarray):
+        a = _np.asarray(a)
+    cost = _builtins.max(int(a.size), 1)
+    out_stripped = _to_base_ndarray(out) if out is not None else None
+    # Strip ``indices`` only when it's already a whest-typed ndarray —
+    # otherwise let numpy handle the dtype coercion (e.g. an empty
+    # Python list must reach numpy as-is so it doesn't get the float64
+    # default that ``np.asarray([])`` would assign).
+    indices_stripped = (
+        _to_base_ndarray(indices) if isinstance(indices, _np.ndarray) else indices
+    )
+    with budget.deduct(
+        f"{ufunc.__name__}.reduceat",
+        flop_cost=cost,
+        subscripts=None,
+        shapes=(a.shape,),
+    ):
+        result = ufunc.reduceat(
+            _to_base_ndarray(a),
+            indices_stripped,
+            axis=axis,
+            out=out_stripped,
+            **kwargs,
+        )
+    return _wrap_result(result, out=out, symmetry=None)
+
+
+def _counted_ufunc_at(ufunc, a, indices, *args, **kwargs):
+    """Cost-tracked ``ufunc.at(a, indices[, values])`` (in-place fancy index).
+
+    ``ufunc.at`` is the in-place unbuffered counterpart to fancy
+    indexing — for repeated indices, each application is performed
+    rather than deduplicated. The mutation propagates back through
+    :func:`_to_base_ndarray`'s zero-copy view-cast.
+
+    **Refusal on SymmetricTensor**: the asymmetric-index write almost
+    certainly breaks the tagged symmetry, so we refuse rather than
+    silently corrupt metadata. Users can downgrade with
+    ``_asplainwhest(a)`` first if they really want the unbuffered
+    update on a view.
+    """
+    if isinstance(a, SymmetricTensor):
+        sym = a.symmetry
+        sym_axes = sym.axes if sym is not None else None
+        raise ValueError(
+            f"in-place ufunc.{ufunc.__name__}.at on a SymmetricTensor would "
+            f"break symmetry on axes {sym_axes}; downgrade to plain WhestArray "
+            f"(e.g. via ``_asplainwhest(a)``) before calling "
+            f"np.{ufunc.__name__}.at(...)."
+        )
+    budget = require_budget()
+    # ``indices`` can be many things: int, list of ints, ndarray, slice,
+    # Ellipsis, or a tuple thereof (for multi-axis fancy indexing).
+    # ``ufunc.at`` accepts all of these. Only convert to ndarray when
+    # it's already array-like; let scalars / slices / Ellipsis through
+    # unchanged so numpy's own semantics apply.
+    indices_stripped = (
+        _to_base_ndarray(indices) if isinstance(indices, _np.ndarray) else indices
+    )
+    if isinstance(indices, _np.ndarray):
+        n_ops = _builtins.max(int(_np.size(indices)), 1)
+    elif hasattr(a, "size"):
+        # Conservative for non-array index forms (slice / Ellipsis): use
+        # the input size as an upper bound on the touched cells.
+        n_ops = _builtins.max(int(a.size), 1)
+    else:
+        n_ops = 1
+    # Strip any whest-typed positional values too.
+    stripped_args = tuple(
+        _to_base_ndarray(v) if isinstance(v, _np.ndarray) else v for v in args
+    )
+    with budget.deduct(
+        f"{ufunc.__name__}.at",
+        flop_cost=n_ops,
+        subscripts=None,
+        shapes=(a.shape,) if hasattr(a, "shape") else (),
+    ):
+        ufunc.at(
+            _to_base_ndarray(a),
+            indices_stripped,
+            *stripped_args,
+            **kwargs,
+        )
+    return None  # numpy's ufunc.at returns None (mutation is the side effect)
 
 
 def _counted_reduction(
@@ -1273,6 +1532,42 @@ def outer(a, b, out=None):
 attach_docstring(outer, _np.outer, "counted_custom", "m * n FLOPs")
 
 
+def _tensordot_parse_axes(a_ndim, b_ndim, axes):
+    """Parse ``np.tensordot``'s ``axes`` argument into ``(a_axes, b_axes)``.
+
+    Accepts the same forms as numpy: ``int N`` (contract last N of ``a``
+    with first N of ``b``), ``(int, int)`` (single-axis pair), or
+    ``(iterable, iterable)`` (per-axis pairing). Returns a pair of
+    tuples of contracted axis indices.
+    """
+    if isinstance(axes, int):
+        return (
+            tuple(range(a_ndim - axes, a_ndim)),
+            tuple(range(axes)),
+        )
+    a_spec, b_spec = axes
+    a_axes = (a_spec,) if isinstance(a_spec, int) else tuple(a_spec)
+    b_axes = (b_spec,) if isinstance(b_spec, int) else tuple(b_spec)
+    return a_axes, b_axes
+
+
+def _surviving_symmetry_after_contraction(group, surviving_axes):
+    """Restrict ``group`` to the axes that remain after contraction.
+
+    Returns ``None`` if the surviving axes don't carry any of the
+    group's permutations (e.g. the contraction broke a 2-axis S₂).
+    The returned group is still indexed in the *original* tensor's
+    axis space — call :func:`remap_group_axes` afterwards to relabel.
+    """
+    if group is None:
+        return None
+    group_axes = group.axes if group.axes is not None else tuple(range(group.degree))
+    wanted = tuple(ax for ax in surviving_axes if ax in group_axes)
+    if len(wanted) < 2:
+        return None
+    return restrict_group_to_axes(group, axes=wanted)
+
+
 def tensordot(a, b, axes=2):
     """Counted version of np.tensordot."""
     budget = require_budget()
@@ -1280,26 +1575,49 @@ def tensordot(a, b, axes=2):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
-    if isinstance(axes, int):
-        contracted = 1
-        for i in range(axes):
-            contracted *= a.shape[a.ndim - axes + i]
-    else:
-        ax0 = axes[0]
-        contracted = 1
-        if isinstance(ax0, int):
-            # axes=(scalar, scalar) form — single axis contracted
-            contracted *= a.shape[ax0] if ax0 < a.ndim else 1
-        else:
-            for i in ax0:
-                contracted *= a.shape[i]
+    a_contract_axes, b_contract_axes = _tensordot_parse_axes(a.ndim, b.ndim, axes)
+    contracted = 1
+    for ax in a_contract_axes:
+        if 0 <= ax < a.ndim:
+            contracted *= a.shape[ax]
+    # Surviving (non-contracted) axes for each operand.
+    a_surviving = tuple(i for i in range(a.ndim) if i not in a_contract_axes)
+    b_surviving = tuple(i for i in range(b.ndim) if i not in b_contract_axes)
+    output_shape = tuple(a.shape[i] for i in a_surviving) + tuple(
+        b.shape[j] for j in b_surviving
+    )
     # output_size * contracted = (a.size / contracted) * (b.size / contracted) * contracted
     # = a.size * b.size / contracted
-    cost = _builtins.max(a.size * b.size // contracted, 1) if contracted > 0 else 1
+    dense = _builtins.max(a.size * b.size // contracted, 1) if contracted > 0 else 1
+    # Compose output symmetry from each input's surviving symmetry, with
+    # b's axes lifted past a's surviving count so they refer to their
+    # final slots in the combined output.
+    a_sym = _symmetry_of(a)
+    b_sym = _symmetry_of(b)
+    a_sym_kept = _surviving_symmetry_after_contraction(a_sym, a_surviving)
+    b_sym_kept = _surviving_symmetry_after_contraction(b_sym, b_surviving)
+    a_sym_remapped = (
+        remap_group_axes(a_sym_kept, {ax: new for new, ax in enumerate(a_surviving)})
+        if a_sym_kept is not None
+        else None
+    )
+    b_offset = len(a_surviving)
+    b_sym_remapped = (
+        remap_group_axes(
+            b_sym_kept,
+            {ax: new + b_offset for new, ax in enumerate(b_surviving)},
+        )
+        if b_sym_kept is not None
+        else None
+    )
+    out_sym = direct_product_groups(a_sym_remapped, b_sym_remapped)
+    cost = _symmetry_adjusted_cost(dense, output_shape, out_sym)
     with budget.deduct(
         "tensordot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
         result = _np.tensordot(_to_base_ndarray(a), _to_base_ndarray(b), axes=axes)
+    if out_sym is not None:
+        return _wrap_result(result, symmetry=out_sym)
     return result
 
 

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -18,7 +18,7 @@ from whest._flops import (
 from whest._flops import (
     analytical_reduction_cost as reduction_cost,
 )
-from whest._ndarray import _aswhest
+from whest._ndarray import _aswhest, _to_base_ndarray, _to_base_ndarray_tree
 from whest._perm_group import SymmetryGroup
 from whest._symmetric import (
     SymmetricTensor,
@@ -77,12 +77,28 @@ def _validate_result_symmetry(result, symmetry):
 
 
 def _call_with_optional_out(np_func, *args, out=None, supports_out=False, **kwargs):
+    # Strip whest subclasses (WhestArray / SymmetricTensor) from arrays so
+    # the raw NumPy call does not re-dispatch through ``__array_ufunc__`` /
+    # ``__array_function__`` and recurse infinitely. Python scalars and
+    # other non-array values pass through unchanged so NEP 50 weak-typing
+    # rules continue to apply at the NumPy boundary.
+    args = tuple(_to_base_ndarray(a) for a in args)
+    # ``where=`` kwarg may be a WhestArray bool mask; strip it. Other
+    # array-valued kwargs (e.g. ``axes`` lists for matmul / einsum
+    # tensor-axis specs) typically aren't ndarrays, but tree-strip is
+    # cheap and safe for nested arg containers.
+    for k, v in list(kwargs.items()):
+        if isinstance(v, _np.ndarray):
+            kwargs[k] = _to_base_ndarray(v)
+        elif isinstance(v, (tuple, list)):
+            kwargs[k] = _to_base_ndarray_tree(v)
+    out_stripped = _to_base_ndarray(out) if out is not None else None
     if out is None:
         return np_func(*args, **kwargs)
     if supports_out:
-        return np_func(*args, out=out, **kwargs)
+        return np_func(*args, out=out_stripped, **kwargs)
     result = np_func(*args, **kwargs)
-    _np.copyto(out, _np.asarray(result), casting="unsafe")
+    _np.copyto(out_stripped, _np.asarray(result), casting="unsafe")
     return out
 
 
@@ -759,7 +775,7 @@ if hasattr(_np, "vecdot"):
         with budget.deduct(
             "vecdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.vecdot(a, b, **kwargs)
+            result = _np.vecdot(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
         return result
 
 else:
@@ -792,7 +808,7 @@ if hasattr(_np, "matvec"):
         with budget.deduct(
             "matvec", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.matvec(a, b, **kwargs)
+            result = _np.matvec(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
         return result
 
 else:
@@ -825,7 +841,7 @@ if hasattr(_np, "vecmat"):
         with budget.deduct(
             "vecmat", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.vecmat(a, b, **kwargs)
+            result = _np.vecmat(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
         return result
 
 else:
@@ -1014,12 +1030,22 @@ def dot(a, b):
         )
     else:
         cost = a.size * b.size
+    # Track whether either operand was already a whest subclass; if so,
+    # preserve the subclass on the result the way ``__array_wrap__`` did
+    # pre-Stage-3 when the raw call dispatched through it. With Stage 3
+    # we strip subclasses before the raw NumPy call (to avoid recursion),
+    # so the wrap must be re-applied explicitly here.
+    inputs_were_whest = isinstance(a, _np.ndarray) and (
+        type(a) is not _np.ndarray or type(b) is not _np.ndarray
+    )
     with budget.deduct(
         "dot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.dot(a, b)
+        # Strip whest subclasses so the raw NumPy call does not re-dispatch
+        # through __array_ufunc__ (matmul is a ufunc) / __array_function__.
+        result = _np.dot(_to_base_ndarray(a), _to_base_ndarray(b))
     check_nan_inf(result, "dot")
-    return result
+    return _aswhest(result) if inputs_were_whest else result
 
 
 attach_docstring(dot, _np.dot, "counted_custom", "depends on operand dimensions")
@@ -1052,13 +1078,16 @@ def matmul(a, b):
         )
     else:
         cost = a.size * b.size
+    inputs_were_whest = isinstance(a, _np.ndarray) and (
+        type(a) is not _np.ndarray or type(b) is not _np.ndarray
+    )
     with budget.deduct(
         "matmul", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
         with _np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-            result = _np.matmul(a, b)
+            result = _np.matmul(_to_base_ndarray(a), _to_base_ndarray(b))
     check_nan_inf(result, "matmul")
-    return result
+    return _aswhest(result) if inputs_were_whest else result
 
 
 attach_docstring(matmul, _np.matmul, "counted_custom", "depends on operand dimensions")

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -208,7 +208,7 @@ def _counted_unary_multi(np_func, op_name: str):
         symmetry = _symmetry_of(x)
         cost = pointwise_cost(x.shape, symmetry=symmetry)
         with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-            result = np_func(x, **kwargs)
+            result = np_func(_to_base_ndarray(x), **kwargs)
         return _wrap_multi_result(result, symmetry=symmetry)
 
     wrapper.__name__ = op_name
@@ -317,7 +317,7 @@ def _counted_binary_multi(np_func, op_name: str):
         with budget.deduct(
             op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
         ):
-            result = np_func(x, y, **kwargs)
+            result = np_func(_to_base_ndarray(x), _to_base_ndarray(y), **kwargs)
         return _wrap_multi_result(result, symmetry=out_symmetry)
 
     wrapper.__name__ = op_name
@@ -650,7 +650,7 @@ def sort_complex(a):
     with budget.deduct(
         "sort_complex", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.sort_complex(a)
+        result = _np.sort_complex(_to_base_ndarray(a))
     return result
 
 
@@ -1314,7 +1314,12 @@ def ediff1d(ary, **kwargs):
         subscripts=None,
         shapes=(ary.shape,),
     ):
-        result = _np.ediff1d(ary, **kwargs)
+        # ``to_begin`` / ``to_end`` kwargs may be WhestArrays — strip via tree.
+        stripped_kwargs = {
+            k: _to_base_ndarray(v) if isinstance(v, _np.ndarray) else v
+            for k, v in kwargs.items()
+        }
+        result = _np.ediff1d(_to_base_ndarray(ary), **stripped_kwargs)
     return result
 
 
@@ -1390,7 +1395,11 @@ def corrcoef(x, y=None, **kwargs):
         x = _np.asarray(x)
     cost = _cov_cost(x, y)
     with budget.deduct("corrcoef", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-        result = _np.corrcoef(x, y=y, **kwargs)
+        result = _np.corrcoef(
+            _to_base_ndarray(x),
+            y=_to_base_ndarray(y) if y is not None else None,
+            **kwargs,
+        )
     return result
 
 
@@ -1405,7 +1414,11 @@ def cov(m, y=None, **kwargs):
         m = _np.asarray(m)
     cost = _cov_cost(m, y)
     with budget.deduct("cov", flop_cost=cost, subscripts=None, shapes=(m.shape,)):
-        result = _np.cov(m, y=y, **kwargs)
+        result = _np.cov(
+            _to_base_ndarray(m),
+            y=_to_base_ndarray(y) if y is not None else None,
+            **kwargs,
+        )
     return result
 
 
@@ -1421,7 +1434,12 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     with budget.deduct(
         "trapezoid", flop_cost=y.size, subscripts=None, shapes=(y.shape,)
     ):
-        result = _np.trapezoid(y, x=x, dx=dx, axis=axis)
+        result = _np.trapezoid(
+            _to_base_ndarray(y),
+            x=_to_base_ndarray(x) if x is not None else None,
+            dx=dx,
+            axis=axis,
+        )
     return result
 
 
@@ -1438,7 +1456,12 @@ if hasattr(_np, "trapz"):
         with budget.deduct(
             "trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,)
         ):
-            result = _np.trapz(y, x=x, dx=dx, axis=axis)
+            result = _np.trapz(
+                _to_base_ndarray(y),
+                x=_to_base_ndarray(x) if x is not None else None,
+                dx=dx,
+                axis=axis,
+            )
         return result
 
     attach_docstring(trapz, _np.trapz, "counted_custom", "numel(input) FLOPs")
@@ -1463,7 +1486,12 @@ def interp(x, xp, fp, **kwargs):
     with budget.deduct(
         "interp", flop_cost=cost, subscripts=None, shapes=(x.shape, xp_arr.shape)
     ):
-        result = _np.interp(x, xp, fp, **kwargs)
+        result = _np.interp(
+            _to_base_ndarray(x),
+            _to_base_ndarray(xp),
+            _to_base_ndarray(fp),
+            **kwargs,
+        )
     return result
 
 

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -1657,7 +1657,16 @@ def _surviving_symmetry_after_contraction(group, surviving_axes):
 
 
 def tensordot(a, b, axes=2):
-    """Counted version of np.tensordot."""
+    """Counted version of ``np.tensordot``.
+
+    The dense FLOP cost is ``a.size * b.size / contracted_size``. When
+    either operand carries a :class:`SymmetricTensor` symmetry, whest
+    composes the surviving (post-contraction) symmetry on the output
+    axes via :func:`whest._symmetry_utils.direct_product_groups` and
+    scales the cost by the unique-element fraction of the output (see
+    :func:`_symmetry_adjusted_cost`). Above degree 12 the adjustment is
+    skipped and :class:`whest.errors.CostFallbackWarning` fires.
+    """
     budget = require_budget()
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -102,6 +102,44 @@ def _call_with_optional_out(np_func, *args, out=None, supports_out=False, **kwar
     return out
 
 
+def _call_with_optional_multi_out(np_func, *args, out=None, nout, **kwargs):
+    """Multi-output sibling of :func:`_call_with_optional_out`.
+
+    ``out`` is either ``None`` (numpy allocates all outputs) or a tuple of
+    length ``nout``. Each slot is either an ndarray write-target or
+    ``None`` (let numpy allocate that one slot).
+
+    Returns a tuple of length ``nout``. Identity is preserved per-slot:
+    if the caller supplied a non-``None`` array at slot *i*, the
+    returned tuple's *i*-th element is exactly the same object. ``None``
+    slots are filled with the freshly-allocated plain ndarray that numpy
+    returned.
+    """
+    args = tuple(_to_base_ndarray(a) for a in args)
+    for k, v in list(kwargs.items()):
+        if isinstance(v, _np.ndarray):
+            kwargs[k] = _to_base_ndarray(v)
+        elif isinstance(v, (tuple, list)):
+            kwargs[k] = _to_base_ndarray_tree(v)
+    if out is None:
+        return np_func(*args, **kwargs)
+    if not isinstance(out, tuple) or len(out) != nout:
+        length_repr = len(out) if hasattr(out, "__len__") else "?"
+        raise TypeError(
+            f"multi-output {getattr(np_func, '__name__', '?')} requires "
+            f"out= to be a tuple of length {nout}; got "
+            f"{type(out).__name__} of length {length_repr}"
+        )
+    stripped = tuple(_to_base_ndarray(o) if o is not None else None for o in out)
+    result = np_func(*args, out=stripped, **kwargs)
+    # Numpy returns a tuple of the stripped buffers (or fresh allocations
+    # for None slots). Replace each non-None slot with the caller's
+    # original to preserve object identity.
+    return tuple(
+        orig if orig is not None else r for orig, r in zip(out, result, strict=True)
+    )
+
+
 def _wrap_result(result, *, out=None, symmetry=None):
     if out is not None:
         if not isinstance(out, SymmetricTensor):
@@ -116,10 +154,24 @@ def _wrap_result(result, *, out=None, symmetry=None):
     return _aswhest(result)
 
 
-def _wrap_multi_result(result, *, symmetry=None):
-    if isinstance(result, tuple):
+def _wrap_multi_result(result, *, out=None, symmetry=None):
+    """Wrap each element of a multi-output result tuple.
+
+    For elementwise multi-output ufuncs (``divmod`` / ``frexp`` /
+    ``modf``), every output inherits the same ``symmetry`` as the
+    (broadcast) input. ``out`` is an optional tuple of caller-provided
+    write targets matching ``result`` 1:1; ``None`` slots get fresh
+    wrappers, non-``None`` slots get identity + symmetry validation
+    routed through :func:`_wrap_result`.
+    """
+    if not isinstance(result, tuple):
+        return _wrap_result(result, out=out, symmetry=symmetry)
+    if out is None:
         return tuple(_wrap_result(part, symmetry=symmetry) for part in result)
-    return _wrap_result(result, symmetry=symmetry)
+    return tuple(
+        _wrap_result(part, out=o, symmetry=symmetry)
+        for part, o in zip(result, out, strict=True)
+    )
 
 
 def _pointwise_symmetry(operands, output_shape):
@@ -189,27 +241,30 @@ def _counted_unary(np_func, op_name: str):
 
 
 def _counted_unary_multi(np_func, op_name: str):
-    """Factory for unary functions that return multiple arrays (e.g., modf, frexp)."""
+    """Factory for unary functions that return multiple arrays (modf, frexp).
+
+    Supports ``out=(out1, out2)`` (or with ``None`` slots for partial
+    allocation) — per-slot stripping and identity preservation are routed
+    through :func:`_call_with_optional_multi_out`. Symmetry of the input
+    is inherited by every output (elementwise ufuncs).
+    """
+    nout = getattr(np_func, "nout", 2)
 
     def wrapper(x, out=None, **kwargs):
-        if out is not None:
-            # Multi-output ``out=(out1, out2)`` requires per-buffer strip +
-            # identity preservation; not implemented yet. Fail loudly so
-            # callers know their ``out=`` was rejected, rather than silently
-            # double-charging FLOPs through __array_function__ recursion.
-            raise NotImplementedError(
-                f"`out=` is not supported by counted multi-output wrappers "
-                f"(op: {op_name}); call without `out=` and assign the "
-                f"returned tuple instead."
-            )
         budget = require_budget()
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
         symmetry = _symmetry_of(x)
         cost = pointwise_cost(x.shape, symmetry=symmetry)
         with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-            result = np_func(_to_base_ndarray(x), **kwargs)
-        return _wrap_multi_result(result, symmetry=symmetry)
+            result = _call_with_optional_multi_out(
+                np_func,
+                x,
+                out=out,
+                nout=nout,
+                **kwargs,
+            )
+        return _wrap_multi_result(result, out=out, symmetry=symmetry)
 
     wrapper.__name__ = op_name
     wrapper.__qualname__ = op_name
@@ -295,30 +350,73 @@ def _counted_binary(np_func, op_name: str):
 
 
 def _counted_binary_multi(np_func, op_name: str):
-    """Factory for binary functions that return multiple arrays (e.g., divmod)."""
+    """Factory for binary functions that return multiple arrays (divmod).
+
+    Mirrors :func:`_counted_binary` for the multi-output case: scalar
+    operand special-case, symmetry-loss warning on unshared input
+    groups, per-slot ``out=`` identity preservation. Cost is charged
+    once (the underlying numpy ufunc produces all outputs in a single
+    pass).
+    """
+    nout = getattr(np_func, "nout", 2)
 
     def wrapper(x, y, out=None, **kwargs):
-        if out is not None:
-            raise NotImplementedError(
-                f"`out=` is not supported by counted multi-output wrappers "
-                f"(op: {op_name}); call without `out=` and assign the "
-                f"returned tuple instead."
-            )
         budget = require_budget()
+        # Preserve original (possibly Python-scalar) values for the actual
+        # numpy call so that NEP 50 weak-typing rules apply correctly. We
+        # only need ndarray views for shape and symmetry inspection below.
+        x_orig, y_orig = x, y
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
         if not isinstance(y, _np.ndarray):
             y = _np.asarray(y)
         output_shape = _np.broadcast_shapes(x.shape, y.shape)
-        out_symmetry, _ = _pointwise_symmetry(
-            ((x, _symmetry_of(x)), (y, _symmetry_of(y))), output_shape
-        )
+        x_sym = _symmetry_of(x)
+        y_sym = _symmetry_of(y)
+        x_is_scalar = x.ndim == 0
+        y_is_scalar = y.ndim == 0
+        if x_is_scalar ^ y_is_scalar:
+            out_symmetry = y_sym if x_is_scalar else x_sym
+            aligned_inputs = [out_symmetry] if out_symmetry is not None else []
+        else:
+            out_symmetry, aligned_inputs = _pointwise_symmetry(
+                ((x, x_sym), (y, y_sym)),
+                output_shape,
+            )
         cost = pointwise_cost(output_shape, symmetry=out_symmetry)
         with budget.deduct(
             op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
         ):
-            result = np_func(_to_base_ndarray(x), _to_base_ndarray(y), **kwargs)
-        return _wrap_multi_result(result, symmetry=out_symmetry)
+            # Pass the ORIGINAL inputs so NEP 50 dtype-promotion rules
+            # apply at the NumPy boundary. Stripping happens inside the
+            # helper for ndarray-typed values only.
+            result = _call_with_optional_multi_out(
+                np_func,
+                x_orig,
+                y_orig,
+                out=out,
+                nout=nout,
+                **kwargs,
+            )
+        # Symmetry-loss warnings (parity with _counted_binary).
+        if out_symmetry is not None:
+            lost = []
+            for group in aligned_inputs:
+                if group != out_symmetry and group.axes is not None:
+                    lost.append(group.axes)
+            if lost:
+                _warn_symmetry_loss(
+                    list(dict.fromkeys(lost)),
+                    f"{op_name} — groups not shared by both operands",
+                )
+        else:
+            lost = [group.axes for group in aligned_inputs if group.axes is not None]
+            if lost:
+                _warn_symmetry_loss(
+                    list(dict.fromkeys(lost)),
+                    f"{op_name} — no symmetry groups shared by both operands",
+                )
+        return _wrap_multi_result(result, out=out, symmetry=out_symmetry)
 
     wrapper.__name__ = op_name
     wrapper.__qualname__ = op_name

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -85,6 +85,23 @@ def _validate_result_symmetry(result, symmetry):
         raise SymmetryError(axes=tuple(axes), max_deviation=float("inf"))
 
 
+# Permutation groups with degree above this threshold are skipped from
+# symmetry-aware cost adjustment. ``SymmetryGroup.order()`` enumerates
+# the group's elements; for ``S_n`` that's ``n!`` work, which already
+# blows past Python's recursion / memory limits at ``n ≈ 20``.
+# ``np.ones((1,)*33)`` produces an S_33 auto-inferred symmetry — the
+# cost adjustment is irrelevant for length-1 axes anyway. Above this
+# rank we bail out and charge dense cost.
+_MAX_SYMMETRY_DEGREE_FOR_COST = 12
+
+
+def _is_oversized_for_cost_model(group):
+    """``True`` if walking ``group``'s elements would be prohibitively slow."""
+    if group is None:
+        return False
+    return group.degree > _MAX_SYMMETRY_DEGREE_FOR_COST
+
+
 def _symmetry_adjusted_cost(dense_cost, output_shape, output_symmetry):
     """Scale a dense FLOP cost by the output's symmetry-savings ratio.
 
@@ -495,14 +512,23 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
     a_sym = _symmetry_of(a)
     b_sym = _symmetry_of(b)
     output_shape = tuple(a.shape) + tuple(b.shape)
-    # Lift ``b``'s symmetry axes into the combined output's slot range.
-    b_sym_lifted = b_sym
-    if b_sym is not None and b_sym.axes is not None:
-        axis_map = {ax: ax + a.ndim for ax in b_sym.axes}
-        b_sym_lifted = remap_group_axes(b_sym, axis_map)
-    out_sym = direct_product_groups(a_sym, b_sym_lifted)
     dense = _builtins.max(a.size * b.size, 1)
-    cost = _symmetry_adjusted_cost(dense, output_shape, out_sym)
+    # Bail on the symmetry composition for high-degree groups: the
+    # direct-product call enumerates ``|a_sym| * |b_sym|`` group
+    # elements, which explodes for auto-inferred S_n on (1,)*n shapes
+    # (np.ones((1,)*33) → S_33 with 33! elements). The cost adjustment
+    # is irrelevant when the output is trivially small anyway.
+    if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
+        out_sym = None
+        cost = dense
+    else:
+        # Lift ``b``'s symmetry axes into the combined output's slot range.
+        b_sym_lifted = b_sym
+        if b_sym is not None and b_sym.axes is not None:
+            axis_map = {ax: ax + a.ndim for ax in b_sym.axes}
+            b_sym_lifted = remap_group_axes(b_sym, axis_map)
+        out_sym = direct_product_groups(a_sym, b_sym_lifted)
+        cost = _symmetry_adjusted_cost(dense, output_shape, out_sym)
     out_stripped = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         f"{ufunc.__name__}.outer",
@@ -1591,27 +1617,34 @@ def tensordot(a, b, axes=2):
     dense = _builtins.max(a.size * b.size // contracted, 1) if contracted > 0 else 1
     # Compose output symmetry from each input's surviving symmetry, with
     # b's axes lifted past a's surviving count so they refer to their
-    # final slots in the combined output.
+    # final slots in the combined output. Bail on the composition for
+    # high-degree groups (see ``_is_oversized_for_cost_model``).
     a_sym = _symmetry_of(a)
     b_sym = _symmetry_of(b)
-    a_sym_kept = _surviving_symmetry_after_contraction(a_sym, a_surviving)
-    b_sym_kept = _surviving_symmetry_after_contraction(b_sym, b_surviving)
-    a_sym_remapped = (
-        remap_group_axes(a_sym_kept, {ax: new for new, ax in enumerate(a_surviving)})
-        if a_sym_kept is not None
-        else None
-    )
-    b_offset = len(a_surviving)
-    b_sym_remapped = (
-        remap_group_axes(
-            b_sym_kept,
-            {ax: new + b_offset for new, ax in enumerate(b_surviving)},
+    if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
+        out_sym = None
+        cost = dense
+    else:
+        a_sym_kept = _surviving_symmetry_after_contraction(a_sym, a_surviving)
+        b_sym_kept = _surviving_symmetry_after_contraction(b_sym, b_surviving)
+        a_sym_remapped = (
+            remap_group_axes(
+                a_sym_kept, {ax: new for new, ax in enumerate(a_surviving)}
+            )
+            if a_sym_kept is not None
+            else None
         )
-        if b_sym_kept is not None
-        else None
-    )
-    out_sym = direct_product_groups(a_sym_remapped, b_sym_remapped)
-    cost = _symmetry_adjusted_cost(dense, output_shape, out_sym)
+        b_offset = len(a_surviving)
+        b_sym_remapped = (
+            remap_group_axes(
+                b_sym_kept,
+                {ax: new + b_offset for new, ax in enumerate(b_surviving)},
+            )
+            if b_sym_kept is not None
+            else None
+        )
+        out_sym = direct_product_groups(a_sym_remapped, b_sym_remapped)
+        cost = _symmetry_adjusted_cost(dense, output_shape, out_sym)
     with budget.deduct(
         "tensordot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import builtins as _builtins
+import functools as _functools
 import inspect as _inspect
+import warnings as _warnings
 from math import prod as _math_prod
 
 import numpy as _np
 
+from whest._config import get_setting as _get_setting
 from whest._docstrings import attach_docstring
 from whest._flops import (
     _ceil_log2,
@@ -38,7 +41,11 @@ from whest._symmetry_utils import (
     unique_elements_for_shape,
 )
 from whest._validation import check_nan_inf, require_budget
-from whest.errors import SymmetryError, UnsupportedFunctionError
+from whest.errors import (
+    CostFallbackWarning,
+    SymmetryError,
+    UnsupportedFunctionError,
+)
 
 # ---------------------------------------------------------------------------
 # Factory helpers
@@ -100,6 +107,57 @@ def _is_oversized_for_cost_model(group):
     if group is None:
         return False
     return group.degree > _MAX_SYMMETRY_DEGREE_FOR_COST
+
+
+@_functools.cache
+def _seen_oversized(op_name: str, degree: int) -> bool:
+    """Return ``True`` once per ``(op, degree)`` pair, ``False`` thereafter.
+
+    The ``lru_cache`` deduplicates: the first call for a given
+    ``(op_name, degree)`` returns ``True`` (and the cache stores it);
+    subsequent identical calls hit the cache and return the stored
+    ``True`` — but we use the *miss-vs-hit* discipline at the call
+    site (``if cache_clear() is None`` style) instead of relying on
+    the value. The simpler pattern is to just call the function and
+    let ``lru_cache`` track which keys we've already seen, then
+    actually emit the warning at the call site only when we know
+    we're on a fresh key. See :func:`_warn_oversized_once`.
+    """
+    return True
+
+
+def _warn_oversized_once(op_name: str, degree: int) -> None:
+    """Emit :class:`CostFallbackWarning` once per ``(op_name, degree)``.
+
+    Hot paths (e.g. numpy compat tests doing thousands of ufunc calls
+    on the same auto-inferred ``S_n`` symmetry) would otherwise spam
+    one warning per call. The warning fires once per process for each
+    ``(op, degree)`` pair so users get the diagnostic without log
+    flooding.
+
+    Honours ``we.configure(symmetry_warnings=False)`` — shares the
+    flag with :class:`SymmetryLossWarning` since both are
+    symmetry-related diagnostics.
+    """
+    if not _get_setting("symmetry_warnings"):
+        return
+    # The miss-vs-hit trick: ``cache_info().hits`` increments only on
+    # a cache hit. We snapshot before, call the cached function (which
+    # is cheap — just returns True), and check whether ``hits`` rose.
+    # If it didn't, this is the first call for this key.
+    info_before = _seen_oversized.cache_info()
+    _seen_oversized(op_name, degree)
+    if _seen_oversized.cache_info().hits > info_before.hits:
+        return  # already warned for this (op, degree) pair
+    _warnings.warn(
+        f"{op_name}: skipping symmetry-aware cost adjustment for a "
+        f"SymmetryGroup of degree {degree} (threshold "
+        f"{_MAX_SYMMETRY_DEGREE_FOR_COST}); charging dense cost. "
+        f"Burnside enumeration on |S_{degree}| = {degree}! is "
+        f"infeasible. Suppress with we.configure(symmetry_warnings=False).",
+        CostFallbackWarning,
+        stacklevel=4,
+    )
 
 
 def _symmetry_adjusted_cost(dense_cost, output_shape, output_symmetry):
@@ -519,6 +577,10 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
     # (np.ones((1,)*33) → S_33 with 33! elements). The cost adjustment
     # is irrelevant when the output is trivially small anyway.
     if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
+        oversized_degree = (
+            a_sym.degree if _is_oversized_for_cost_model(a_sym) else b_sym.degree
+        )
+        _warn_oversized_once(f"{ufunc.__name__}.outer", oversized_degree)
         out_sym = None
         cost = dense
     else:
@@ -1622,6 +1684,10 @@ def tensordot(a, b, axes=2):
     a_sym = _symmetry_of(a)
     b_sym = _symmetry_of(b)
     if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
+        oversized_degree = (
+            a_sym.degree if _is_oversized_for_cost_model(a_sym) else b_sym.degree
+        )
+        _warn_oversized_once("tensordot", oversized_degree)
         out_sym = None
         cost = dense
     else:

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -683,7 +683,7 @@ def isclose(a, b, **kwargs):
     with budget.deduct(
         "isclose", flop_cost=cost, subscripts=None, shapes=(a_arr.shape, b_arr.shape)
     ):
-        result = _np.isclose(a, b, **kwargs)
+        result = _np.isclose(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
     if a_is_scalar and b_is_scalar and _np.ndim(result) == 0:
         return result
     return _wrap_result(result, symmetry=out_symmetry)
@@ -992,7 +992,10 @@ else:
             a = _np.asarray(a)
         cost = reduction_cost(a.shape, axis)
         with budget.deduct("ptp", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-            result = _np.max(a, axis=axis, **kwargs) - _np.min(a, axis=axis, **kwargs)
+            stripped = _to_base_ndarray(a)
+            result = _np.max(stripped, axis=axis, **kwargs) - _np.min(
+                stripped, axis=axis, **kwargs
+            )
         return result
 
     attach_docstring(ptp, _np.max, "counted_reduction", "numel(input) FLOPs")
@@ -1113,7 +1116,7 @@ def inner(a, b):
     with budget.deduct(
         "inner", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.inner(a, b)
+        result = _np.inner(_to_base_ndarray(a), _to_base_ndarray(b))
     return result
 
 
@@ -1137,8 +1140,8 @@ def outer(a, b, out=None):
         "outer", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
         result = _np.outer(
-            a,
-            b,
+            _to_base_ndarray(a),
+            _to_base_ndarray(b),
             out=None if isinstance(out, SymmetricTensor) else out,
         )
     if target_symmetry is None:
@@ -1177,7 +1180,7 @@ def tensordot(a, b, axes=2):
     with budget.deduct(
         "tensordot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.tensordot(a, b, axes=axes)
+        result = _np.tensordot(_to_base_ndarray(a), _to_base_ndarray(b), axes=axes)
     return result
 
 
@@ -1195,7 +1198,7 @@ def vdot(a, b):
     with budget.deduct(
         "vdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.vdot(a, b)
+        result = _np.vdot(_to_base_ndarray(a), _to_base_ndarray(b))
     return result
 
 
@@ -1214,7 +1217,7 @@ def kron(a, b):
     with budget.deduct(
         "kron", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.kron(a, b)
+        result = _np.kron(_to_base_ndarray(a), _to_base_ndarray(b))
     return result
 
 
@@ -1230,7 +1233,7 @@ def cross(a, b, **kwargs):
         b = _np.asarray(b)
     # np.cross supports axisa/axisb/axisc kwargs that change output shape,
     # so we compute the result first, then deduct based on actual output size.
-    result = _np.cross(a, b, **kwargs)
+    result = _np.cross(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
     cost = _builtins.max(_np.asarray(result).size * 3, 1)
     with budget.deduct(
         "cross",
@@ -1263,7 +1266,7 @@ def diff(a, n=1, axis=-1, **kwargs):
         subscripts=None,
         shapes=(a.shape,),
     ):
-        result = _np.diff(a, n=n, axis=axis, **kwargs)
+        result = _np.diff(_to_base_ndarray(a), n=n, axis=axis, **kwargs)
     return result
 
 
@@ -1279,7 +1282,11 @@ def gradient(f, *varargs, **kwargs):
     with budget.deduct(
         "gradient", flop_cost=f.size, subscripts=None, shapes=(f.shape,)
     ):
-        result = _np.gradient(f, *varargs, **kwargs)
+        result = _np.gradient(
+            _to_base_ndarray(f),
+            *[_to_base_ndarray(v) for v in varargs],
+            **kwargs,
+        )
     return result
 
 
@@ -1329,7 +1336,7 @@ def convolve(a, v, mode="full"):
         subscripts=None,
         shapes=(a.shape, v.shape),
     ):
-        result = _np.convolve(a, v, mode=mode)
+        result = _np.convolve(_to_base_ndarray(a), _to_base_ndarray(v), mode=mode)
     return result
 
 
@@ -1350,7 +1357,7 @@ def correlate(a, v, mode="valid"):
         subscripts=None,
         shapes=(a.shape, v.shape),
     ):
-        result = _np.correlate(a, v, mode=mode)
+        result = _np.correlate(_to_base_ndarray(a), _to_base_ndarray(v), mode=mode)
     return result
 
 

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -175,14 +175,24 @@ def _counted_unary(np_func, op_name: str):
 def _counted_unary_multi(np_func, op_name: str):
     """Factory for unary functions that return multiple arrays (e.g., modf, frexp)."""
 
-    def wrapper(x):
+    def wrapper(x, out=None, **kwargs):
+        if out is not None:
+            # Multi-output ``out=(out1, out2)`` requires per-buffer strip +
+            # identity preservation; not implemented yet. Fail loudly so
+            # callers know their ``out=`` was rejected, rather than silently
+            # double-charging FLOPs through __array_function__ recursion.
+            raise NotImplementedError(
+                f"`out=` is not supported by counted multi-output wrappers "
+                f"(op: {op_name}); call without `out=` and assign the "
+                f"returned tuple instead."
+            )
         budget = require_budget()
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
         symmetry = _symmetry_of(x)
         cost = pointwise_cost(x.shape, symmetry=symmetry)
         with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-            result = np_func(x)
+            result = np_func(x, **kwargs)
         return _wrap_multi_result(result, symmetry=symmetry)
 
     wrapper.__name__ = op_name
@@ -271,7 +281,13 @@ def _counted_binary(np_func, op_name: str):
 def _counted_binary_multi(np_func, op_name: str):
     """Factory for binary functions that return multiple arrays (e.g., divmod)."""
 
-    def wrapper(x, y):
+    def wrapper(x, y, out=None, **kwargs):
+        if out is not None:
+            raise NotImplementedError(
+                f"`out=` is not supported by counted multi-output wrappers "
+                f"(op: {op_name}); call without `out=` and assign the "
+                f"returned tuple instead."
+            )
         budget = require_budget()
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
@@ -285,7 +301,7 @@ def _counted_binary_multi(np_func, op_name: str):
         with budget.deduct(
             op_name, flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
         ):
-            result = np_func(x, y)
+            result = np_func(x, y, **kwargs)
         return _wrap_multi_result(result, symmetry=out_symmetry)
 
     wrapper.__name__ = op_name
@@ -303,13 +319,56 @@ def _counted_reduction(
 ):
     supports_out = _supports_out_argument(np_func)
 
-    def wrapper(a, axis=None, **kwargs):
+    # Per-factory signature introspection for positional `out`.
+    # NumPy reductions place `out` at different positional slots;
+    # method overrides forwarding through ``*args`` need to find it
+    # correctly for each underlying function. ``_axis_is_second_positional``
+    # tracks whether `axis` is at slot 1 AND positional-acceptable (true for
+    # sum/prod/argmax) or otherwise (false for cumulative_sum where axis is
+    # KEYWORD_ONLY, and for percentile/quantile whose slot 1 is `q`).
+    try:
+        _sig_params = _inspect.signature(np_func).parameters
+        _params = list(_sig_params)
+    except (ValueError, TypeError):
+        _sig_params = {}
+        _params = []
+    _axis_is_second_positional = (
+        len(_params) >= 2
+        and _params[1] == "axis"
+        and _sig_params["axis"].kind
+        in (
+            _inspect.Parameter.POSITIONAL_ONLY,
+            _inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    )
+    _args_offset = 2 if _axis_is_second_positional else 1
+    _out_args_idx = (
+        _params.index("out") - _args_offset
+        if "out" in _params and _params.index("out") >= _args_offset
+        else None
+    )
+
+    def wrapper(a, axis=None, *args, **kwargs):
         budget = require_budget()
         if not isinstance(a, _np.ndarray):
             a = _np.asarray(a)
         symmetry = a.symmetry if isinstance(a, SymmetricTensor) else None
         keepdims = kwargs.get("keepdims", False)
-        out = kwargs.get("out")
+
+        # Resolve `out` from either kwargs OR a positional slot in args
+        # (per-function — see _out_args_idx computed at factory build time).
+        args_list = list(args)
+        out = kwargs.pop("out", None)
+        out_came_from_args = False
+        if (
+            out is None
+            and _out_args_idx is not None
+            and 0 <= _out_args_idx < len(args_list)
+            and isinstance(args_list[_out_args_idx], _np.ndarray)
+        ):
+            out = args_list[_out_args_idx]
+            out_came_from_args = True
+
         new_symmetry = (
             reduce_group(symmetry, ndim=len(a.shape), axis=axis, keepdims=keepdims)
             if symmetry is not None
@@ -329,17 +388,38 @@ def _counted_reduction(
                     out_shape = a.shape[:ax] + a.shape[ax + 1 :]
                 extra_cost = pointwise_cost(out_shape)
             cost += extra_cost
-        numpy_kwargs = dict(kwargs)
-        numpy_kwargs.pop("out", None)
+        out_for_np = None if isinstance(out, SymmetricTensor) else out
+        if out_came_from_args:
+            # Stripped out goes back into the same positional slot.
+            args_list[_out_args_idx] = out_for_np
+            np_out_kwarg = None
+            np_supports_out_for_call = False
+        else:
+            np_out_kwarg = out_for_np
+            np_supports_out_for_call = supports_out
+
         with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-            result = _call_with_optional_out(
-                np_func,
-                a,
-                axis=axis,
-                out=None if isinstance(out, SymmetricTensor) else out,
-                supports_out=supports_out,
-                **numpy_kwargs,
-            )
+            if _axis_is_second_positional:
+                result = _call_with_optional_out(
+                    np_func,
+                    a,
+                    axis,
+                    *args_list,
+                    out=np_out_kwarg,
+                    supports_out=np_supports_out_for_call,
+                    **kwargs,
+                )
+            else:
+                # axis is keyword-only or at slot 3+; pass via kwargs.
+                result = _call_with_optional_out(
+                    np_func,
+                    a,
+                    *args_list,
+                    axis=axis,
+                    out=np_out_kwarg,
+                    supports_out=np_supports_out_for_call,
+                    **kwargs,
+                )
 
         # Propagate symmetry through reduction.
         if out is not None:

--- a/src/whest/_pointwise.py
+++ b/src/whest/_pointwise.py
@@ -772,11 +772,18 @@ if hasattr(_np, "vecdot"):
             if out_shape
             else contracted
         )
+        out = kwargs.pop("out", None)
+        out_stripped = _to_base_ndarray(out) if out is not None else None
         with budget.deduct(
             "vecdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.vecdot(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
-        return result
+            result = _np.vecdot(
+                _to_base_ndarray(a),
+                _to_base_ndarray(b),
+                out=out_stripped,
+                **kwargs,
+            )
+        return out if out is not None else result
 
 else:
 
@@ -805,11 +812,18 @@ if hasattr(_np, "matvec"):
             int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted,
             1,
         )
+        out = kwargs.pop("out", None)
+        out_stripped = _to_base_ndarray(out) if out is not None else None
         with budget.deduct(
             "matvec", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.matvec(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
-        return result
+            result = _np.matvec(
+                _to_base_ndarray(a),
+                _to_base_ndarray(b),
+                out=out_stripped,
+                **kwargs,
+            )
+        return out if out is not None else result
 
 else:
 
@@ -838,11 +852,18 @@ if hasattr(_np, "vecmat"):
             int(_np.prod(batch)) * out_m * contracted if batch else out_m * contracted,
             1,
         )
+        out = kwargs.pop("out", None)
+        out_stripped = _to_base_ndarray(out) if out is not None else None
         with budget.deduct(
             "vecmat", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.vecmat(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
-        return result
+            result = _np.vecmat(
+                _to_base_ndarray(a),
+                _to_base_ndarray(b),
+                out=out_stripped,
+                **kwargs,
+            )
+        return out if out is not None else result
 
 else:
 

--- a/src/whest/_sorting_ops.py
+++ b/src/whest/_sorting_ops.py
@@ -8,6 +8,7 @@ import numpy as _np
 
 from whest._docstrings import attach_docstring
 from whest._flops import search_cost, sort_cost
+from whest._ndarray import _to_base_ndarray, _to_base_ndarray_tree
 from whest._validation import require_budget
 from whest.errors import UnsupportedFunctionError
 
@@ -54,7 +55,7 @@ def sort(a, axis=-1, **kwargs):
         ax = axis % a.ndim
         cost = _sort_cost_nd(a, ax)
     with budget.deduct("sort", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.sort(a, axis=axis, **kwargs)
+        result = _np.sort(_to_base_ndarray(a), axis=axis, **kwargs)
     return result
 
 
@@ -75,7 +76,7 @@ def argsort(a, axis=-1, **kwargs):
         ax = axis % a.ndim
         cost = _sort_cost_nd(a, ax)
     with budget.deduct("argsort", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.argsort(a, axis=axis, **kwargs)
+        result = _np.argsort(_to_base_ndarray(a), axis=axis, **kwargs)
     return result
 
 
@@ -103,7 +104,7 @@ def lexsort(keys, axis=-1):
         cost = max(k * sort_cost(n), 1)
     shapes = tuple(_np.asarray(key).shape for key in keys_list)
     with budget.deduct("lexsort", flop_cost=cost, subscripts=None, shapes=shapes):
-        result = _np.lexsort(keys_list, axis=axis)
+        result = _np.lexsort(_to_base_ndarray_tree(keys_list), axis=axis)
     return result
 
 
@@ -129,7 +130,7 @@ def partition(a, kth, axis=-1, **kwargs):
         num_slices = numel // n if n > 0 else 1
         cost = max(num_slices * n * kth_count, 1)
     with budget.deduct("partition", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.partition(a, kth, axis=axis, **kwargs)
+        result = _np.partition(_to_base_ndarray(a), kth, axis=axis, **kwargs)
     return result
 
 
@@ -160,7 +161,7 @@ def argpartition(a, kth, axis=-1, **kwargs):
     with budget.deduct(
         "argpartition", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.argpartition(a, kth, axis=axis, **kwargs)
+        result = _np.argpartition(_to_base_ndarray(a), kth, axis=axis, **kwargs)
     return result
 
 
@@ -196,7 +197,7 @@ def searchsorted(a, v, **kwargs):
         subscripts=None,
         shapes=(a.shape, v_arr.shape),
     ):
-        result = _np.searchsorted(a, v, **kwargs)
+        result = _np.searchsorted(_to_base_ndarray(a), _to_base_ndarray(v), **kwargs)
     return result
 
 
@@ -225,7 +226,7 @@ def digitize(x, bins, **kwargs):
         subscripts=None,
         shapes=(x_arr.shape, bins_arr.shape),
     ):
-        result = _np.digitize(x, bins, **kwargs)
+        result = _np.digitize(_to_base_ndarray(x), _to_base_ndarray(bins), **kwargs)
     return result
 
 
@@ -277,7 +278,7 @@ def unique(ar, **kwargs):
         and not _returns_tuple
         and ar_arr.dtype.kind in _UNSORTED_IN_NP_2_3
     ):
-        result = _np.sort(result)
+        result = _np.sort(_to_base_ndarray(result))
     return result
 
 
@@ -375,7 +376,7 @@ if hasattr(_np, "in1d"):
         with budget.deduct(
             "in1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
         ):
-            result = _np.in1d(ar1, ar2, **kwargs)
+            result = _np.in1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
         return result
 
     attach_docstring(in1d, _np.in1d, "counted_custom", "(n+m)*ceil(log2(n+m)) FLOPs")
@@ -396,7 +397,7 @@ def isin(element, test_elements, **kwargs):
     with budget.deduct(
         "isin", flop_cost=cost, subscripts=None, shapes=(el.shape, te.shape)
     ):
-        result = _np.isin(element, test_elements, **kwargs)
+        result = _np.isin(_to_base_ndarray(element), _to_base_ndarray(test_elements), **kwargs)
     return result
 
 
@@ -413,7 +414,7 @@ def intersect1d(ar1, ar2, **kwargs):
     with budget.deduct(
         "intersect1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.intersect1d(ar1, ar2, **kwargs)
+        result = _np.intersect1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
     return result
 
 
@@ -432,7 +433,7 @@ def union1d(ar1, ar2):
     with budget.deduct(
         "union1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.union1d(ar1, ar2)
+        result = _np.union1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2))
     return result
 
 
@@ -448,7 +449,7 @@ def setdiff1d(ar1, ar2, **kwargs):
     with budget.deduct(
         "setdiff1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.setdiff1d(ar1, ar2, **kwargs)
+        result = _np.setdiff1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
     return result
 
 
@@ -467,7 +468,7 @@ def setxor1d(ar1, ar2, **kwargs):
     with budget.deduct(
         "setxor1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.setxor1d(ar1, ar2, **kwargs)
+        result = _np.setxor1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
     return result
 
 

--- a/src/whest/_sorting_ops.py
+++ b/src/whest/_sorting_ops.py
@@ -397,7 +397,9 @@ def isin(element, test_elements, **kwargs):
     with budget.deduct(
         "isin", flop_cost=cost, subscripts=None, shapes=(el.shape, te.shape)
     ):
-        result = _np.isin(_to_base_ndarray(element), _to_base_ndarray(test_elements), **kwargs)
+        result = _np.isin(
+            _to_base_ndarray(element), _to_base_ndarray(test_elements), **kwargs
+        )
     return result
 
 

--- a/src/whest/_unwrap.py
+++ b/src/whest/_unwrap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as _np
 
 from whest._docstrings import attach_docstring
+from whest._ndarray import _to_base_ndarray
 from whest._validation import require_budget
 
 
@@ -41,7 +42,7 @@ def unwrap(p, discont=None, axis=-1, *, period=6.283185307179586):
     if discont is not None:
         kwargs["discont"] = discont
     with budget.deduct("unwrap", flop_cost=cost, subscripts=None, shapes=(p.shape,)):
-        result = _np.unwrap(p, **kwargs)
+        result = _np.unwrap(_to_base_ndarray(p), **kwargs)
     return result
 
 

--- a/src/whest/_validation.py
+++ b/src/whest/_validation.py
@@ -53,8 +53,12 @@ def check_nan_inf(result: np.ndarray, op_name: str) -> None:
     # values to detect, so skip the check.
     if result.dtype.kind not in ("f", "c"):
         return
-    nan_count = int(np.isnan(result).sum())
-    inf_count = int(np.isinf(result).sum())
+    # Strip whest subclasses so np.isnan / np.isinf do not re-dispatch
+    # through __array_ufunc__ and recurse into me.isnan / me.isfinite,
+    # which in turn would call check_nan_inf again.
+    plain = result.view(np.ndarray) if type(result) is not np.ndarray else result
+    nan_count = int(np.isnan(plain).sum())
+    inf_count = int(np.isinf(plain).sum())
     if nan_count > 0 or inf_count > 0:
         warnings.warn(
             f"{op_name} produced {nan_count} NaN and {inf_count} Inf values "

--- a/src/whest/errors.py
+++ b/src/whest/errors.py
@@ -135,3 +135,19 @@ class WhestWarning(UserWarning):
 
 class SymmetryLossWarning(WhestWarning):
     """Warning issued when an operation causes loss of symmetry metadata."""
+
+
+class CostFallbackWarning(WhestWarning):
+    """Warning issued when whest skips its symmetry-aware cost adjustment.
+
+    The output's symmetry group is too large for the placeholder cost
+    model's Burnside enumeration (degree above the per-call threshold,
+    typically 12). The op runs correctly with the dense cost charged
+    instead — only the FLOP accounting is conservative; the data is
+    unaffected. Common trigger: ``np.ones((1,)*n)`` for large ``n`` or
+    other auto-inferred ``S_n`` symmetries on degenerate shapes.
+
+    Suppress with ``we.configure(symmetry_warnings=False)`` (shares the
+    flag with :class:`SymmetryLossWarning` since both are
+    symmetry-related diagnostics).
+    """

--- a/src/whest/fft/_free.py
+++ b/src/whest/fft/_free.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as _np
 
 from whest._docstrings import attach_docstring
+from whest._ndarray import _to_base_ndarray
 
 
 def fftfreq(n, d=1.0, device=None):
@@ -32,7 +33,7 @@ attach_docstring(rfftfreq, _np.fft.rfftfreq, "free", "0 FLOPs")
 
 def fftshift(x, axes=None):
     """Shift zero-frequency component to center. Cost: 0 FLOPs."""
-    return _np.fft.fftshift(x, axes=axes)
+    return _np.fft.fftshift(_to_base_ndarray(x), axes=axes)
 
 
 attach_docstring(fftshift, _np.fft.fftshift, "free", "0 FLOPs")
@@ -40,7 +41,7 @@ attach_docstring(fftshift, _np.fft.fftshift, "free", "0 FLOPs")
 
 def ifftshift(x, axes=None):
     """Inverse of fftshift. Cost: 0 FLOPs."""
-    return _np.fft.ifftshift(x, axes=axes)
+    return _np.fft.ifftshift(_to_base_ndarray(x), axes=axes)
 
 
 attach_docstring(ifftshift, _np.fft.ifftshift, "free", "0 FLOPs")

--- a/src/whest/fft/_transforms.py
+++ b/src/whest/fft/_transforms.py
@@ -12,6 +12,7 @@ import math
 import numpy as _np
 
 from whest._docstrings import attach_docstring
+from whest._ndarray import _to_base_ndarray
 from whest._validation import require_budget
 
 
@@ -171,7 +172,7 @@ def fft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.fft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fft(a, n=n, axis=axis, norm=norm, out=out)
+        result = _np.fft.fft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
     return result
 
 
@@ -188,7 +189,7 @@ def ifft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.ifft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifft(a, n=n, axis=axis, norm=norm, out=out)
+        result = _np.fft.ifft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
     return result
 
 
@@ -205,7 +206,7 @@ def rfft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.rfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfft(a, n=n, axis=axis, norm=norm, out=out)
+        result = _np.fft.rfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
     return result
 
 
@@ -222,7 +223,7 @@ def irfft(a, n=None, axis=-1, norm=None, out=None):
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.irfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.irfft(a, n=n, axis=axis, norm=norm, out=out)
+        result = _np.fft.irfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
     return result
 
 
@@ -244,7 +245,7 @@ def fft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.fft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fft2(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.fft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -268,7 +269,7 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.ifft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifft2(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.ifft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -292,7 +293,7 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)
     with budget.deduct("fft.rfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfft2(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.rfft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -321,7 +322,7 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     with budget.deduct(
         "fft.irfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.fft.irfft2(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.irfft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -347,7 +348,7 @@ def fftn(a, s=None, axes=None, norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.fftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fftn(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.fftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -372,7 +373,7 @@ def ifftn(a, s=None, axes=None, norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.ifftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifftn(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.ifftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -397,7 +398,7 @@ def rfftn(a, s=None, axes=None, norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)
     with budget.deduct("fft.rfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfftn(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.rfftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -436,7 +437,7 @@ def irfftn(a, s=None, axes=None, norm=None, out=None):
     with budget.deduct(
         "fft.irfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.fft.irfftn(a, s=s, axes=axes, norm=norm, out=out)
+        result = _np.fft.irfftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
     return result
 
 
@@ -457,7 +458,7 @@ def hfft(a, n=None, axis=-1, norm=None, out=None):
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.hfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.hfft(a, n=n, axis=axis, norm=norm, out=out)
+        result = _np.fft.hfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
     return result
 
 
@@ -477,7 +478,7 @@ def ihfft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.ihfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ihfft(a, n=n, axis=axis, norm=norm, out=out)
+        result = _np.fft.ihfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
     return result
 
 

--- a/src/whest/fft/_transforms.py
+++ b/src/whest/fft/_transforms.py
@@ -172,8 +172,14 @@ def fft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.fft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
-    return result
+        result = _np.fft.fft(
+            _to_base_ndarray(a),
+            n=n,
+            axis=axis,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -189,8 +195,14 @@ def ifft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.ifft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
-    return result
+        result = _np.fft.ifft(
+            _to_base_ndarray(a),
+            n=n,
+            axis=axis,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -206,8 +218,14 @@ def rfft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.rfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
-    return result
+        result = _np.fft.rfft(
+            _to_base_ndarray(a),
+            n=n,
+            axis=axis,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -223,8 +241,14 @@ def irfft(a, n=None, axis=-1, norm=None, out=None):
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.irfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.irfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
-    return result
+        result = _np.fft.irfft(
+            _to_base_ndarray(a),
+            n=n,
+            axis=axis,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -245,8 +269,14 @@ def fft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.fft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.fft2(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -269,8 +299,14 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.ifft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.ifft2(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -293,8 +329,14 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)
     with budget.deduct("fft.rfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.rfft2(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -322,8 +364,14 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     with budget.deduct(
         "fft.irfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.fft.irfft2(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.irfft2(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -348,8 +396,14 @@ def fftn(a, s=None, axes=None, norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.fftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.fftn(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -373,8 +427,14 @@ def ifftn(a, s=None, axes=None, norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)
     with budget.deduct("fft.ifftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.ifftn(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -398,8 +458,14 @@ def rfftn(a, s=None, axes=None, norm=None, out=None):
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)
     with budget.deduct("fft.rfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.rfftn(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -437,8 +503,14 @@ def irfftn(a, s=None, axes=None, norm=None, out=None):
     with budget.deduct(
         "fft.irfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.fft.irfftn(_to_base_ndarray(a), s=s, axes=axes, norm=norm, out=out)
-    return result
+        result = _np.fft.irfftn(
+            _to_base_ndarray(a),
+            s=s,
+            axes=axes,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -458,8 +530,14 @@ def hfft(a, n=None, axis=-1, norm=None, out=None):
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.hfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.hfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
-    return result
+        result = _np.fft.hfft(
+            _to_base_ndarray(a),
+            n=n,
+            axis=axis,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -478,8 +556,14 @@ def ihfft(a, n=None, axis=-1, norm=None, out=None):
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.ihfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ihfft(_to_base_ndarray(a), n=n, axis=axis, norm=norm, out=out)
-    return result
+        result = _np.fft.ihfft(
+            _to_base_ndarray(a),
+            n=n,
+            axis=axis,
+            norm=norm,
+            out=_to_base_ndarray(out) if out is not None else None,
+        )
+    return out if out is not None else result
 
 
 attach_docstring(

--- a/src/whest/linalg/_aliases.py
+++ b/src/whest/linalg/_aliases.py
@@ -27,10 +27,11 @@ def cross(x1, x2, /, *, axis=-1):
     """Cross product (linalg namespace). Uses np.linalg.cross for strict validation."""
     import builtins as _builtins
 
-    from whest._ndarray import _aswhest
+    from whest._ndarray import WhestArray, _aswhest, _to_base_ndarray
     from whest._validation import require_budget
 
     budget = require_budget()
+    inputs_were_whest = isinstance(x1, WhestArray) or isinstance(x2, WhestArray)
     x1_arr = _np.asarray(x1)
     x2_arr = _np.asarray(x2)
     out_shape = _np.broadcast_shapes(x1_arr.shape, x2_arr.shape)
@@ -43,8 +44,8 @@ def cross(x1, x2, /, *, axis=-1):
         subscripts=None,
         shapes=(x1_arr.shape, x2_arr.shape),
     ):
-        result = _np.linalg.cross(x1, x2, axis=axis)
-    if isinstance(result, _np.ndarray):
+        result = _np.linalg.cross(_to_base_ndarray(x1), _to_base_ndarray(x2), axis=axis)
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _aswhest(result)
     return result
 

--- a/src/whest/linalg/_compound.py
+++ b/src/whest/linalg/_compound.py
@@ -68,10 +68,15 @@ def multi_dot(arrays, *, out=None):
     arrays = [a if isinstance(a, _np.ndarray) else _np.asarray(a) for a in arrays]
     shapes = [arr.shape for arr in arrays]
     cost = multi_dot_cost(shapes)
+    out_stripped = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "linalg.multi_dot", flop_cost=cost, subscripts=None, shapes=tuple(shapes)
     ):
-        result = _np.linalg.multi_dot([_to_base_ndarray(a) for a in arrays], out=out)
+        result = _np.linalg.multi_dot(
+            [_to_base_ndarray(a) for a in arrays], out=out_stripped
+        )
+    if out is not None:
+        return out
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _aswhest(result)
     return result

--- a/src/whest/linalg/_compound.py
+++ b/src/whest/linalg/_compound.py
@@ -8,6 +8,7 @@ import numpy as _np
 
 from whest._cost_model import FMA_COST
 from whest._docstrings import attach_docstring
+from whest._ndarray import WhestArray, _aswhest, _to_base_ndarray
 from whest._validation import require_budget
 from whest.linalg._solvers import _batch_size, _has_zero_dim
 
@@ -63,13 +64,18 @@ def multi_dot_cost(shapes: list[tuple[int, ...]]) -> int:
 def multi_dot(arrays, *, out=None):
     """Efficient multi-matrix dot product with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = any(isinstance(a, WhestArray) for a in arrays)
     arrays = [a if isinstance(a, _np.ndarray) else _np.asarray(a) for a in arrays]
     shapes = [arr.shape for arr in arrays]
     cost = multi_dot_cost(shapes)
     with budget.deduct(
         "linalg.multi_dot", flop_cost=cost, subscripts=None, shapes=tuple(shapes)
     ):
-        result = _np.linalg.multi_dot(arrays, out=out)
+        result = _np.linalg.multi_dot(
+            [_to_base_ndarray(a) for a in arrays], out=out
+        )
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -109,6 +115,7 @@ def matrix_power_cost(n: int, k: int) -> int:
 def matrix_power(a, n):
     """Matrix power with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     size = a.shape[-1]
@@ -117,7 +124,9 @@ def matrix_power(a, n):
     with budget.deduct(
         "linalg.matrix_power", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.matrix_power(a, n)
+        result = _np.linalg.matrix_power(_to_base_ndarray(a), n)
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 

--- a/src/whest/linalg/_compound.py
+++ b/src/whest/linalg/_compound.py
@@ -71,9 +71,7 @@ def multi_dot(arrays, *, out=None):
     with budget.deduct(
         "linalg.multi_dot", flop_cost=cost, subscripts=None, shapes=tuple(shapes)
     ):
-        result = _np.linalg.multi_dot(
-            [_to_base_ndarray(a) for a in arrays], out=out
-        )
+        result = _np.linalg.multi_dot([_to_base_ndarray(a) for a in arrays], out=out)
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _aswhest(result)
     return result

--- a/src/whest/linalg/_decompositions.py
+++ b/src/whest/linalg/_decompositions.py
@@ -11,6 +11,7 @@ import numpy as _np
 from numpy.linalg._linalg import EighResult, EigResult, QRResult
 
 from whest._docstrings import attach_docstring
+from whest._ndarray import WhestArray, _aswhest, _to_base_ndarray
 from whest._validation import require_budget
 from whest.linalg._solvers import _batch_size, _has_zero_dim
 
@@ -38,6 +39,7 @@ def cholesky_cost(n: int) -> int:
 def cholesky(a, /, *, upper=False):
     """Cholesky decomposition with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -46,7 +48,9 @@ def cholesky(a, /, *, upper=False):
     with budget.deduct(
         "linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.cholesky(a, upper=upper)
+        result = _np.linalg.cholesky(_to_base_ndarray(a), upper=upper)
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -78,15 +82,21 @@ def qr_cost(m: int, n: int) -> int:
 def qr(a, mode="reduced"):
     """QR decomposition with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     m, n = a.shape[-2], a.shape[-1]
     batch = _batch_size(a.shape)
     cost = qr_cost(m, n) * batch if not _has_zero_dim(a.shape) else 0
     with budget.deduct("linalg.qr", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.linalg.qr(a, mode=mode)
+        result = _np.linalg.qr(_to_base_ndarray(a), mode=mode)
     if mode in ("reduced", "complete"):
-        return QRResult(*result)
+        q, r = result
+        if inputs_were_whest:
+            return QRResult(_aswhest(q), _aswhest(r))
+        return QRResult(q, r)
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -116,6 +126,7 @@ def eig_cost(n: int) -> int:
 def eig(a):
     """Eigendecomposition with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -124,8 +135,10 @@ def eig(a):
     with budget.deduct(
         "linalg.eig", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eig(a)
-    return EigResult(*result)
+        result = _np.linalg.eig(_to_base_ndarray(a))
+    if inputs_were_whest:
+        return EigResult(_aswhest(result.eigenvalues), _aswhest(result.eigenvectors))
+    return result
 
 
 attach_docstring(eig, _np.linalg.eig, "linalg", r"$n^3$ FLOPs")
@@ -154,6 +167,7 @@ def eigh_cost(n: int) -> int:
 def eigh(a, UPLO="L"):
     """Symmetric eigendecomposition with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -162,8 +176,12 @@ def eigh(a, UPLO="L"):
     with budget.deduct(
         "linalg.eigh", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eigh(a, UPLO=UPLO)
-    return EighResult(_np.asarray(result.eigenvalues), _np.asarray(result.eigenvectors))
+        result = _np.linalg.eigh(_to_base_ndarray(a), UPLO=UPLO)
+    if inputs_were_whest:
+        return EighResult(
+            _aswhest(result.eigenvalues), _aswhest(result.eigenvectors)
+        )
+    return result
 
 
 attach_docstring(eigh, _np.linalg.eigh, "linalg", r"$n^3$ FLOPs")
@@ -192,6 +210,7 @@ def eigvals_cost(n: int) -> int:
 def eigvals(a):
     """Eigenvalues (nonsymmetric) with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -200,7 +219,9 @@ def eigvals(a):
     with budget.deduct(
         "linalg.eigvals", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eigvals(a)
+        result = _np.linalg.eigvals(_to_base_ndarray(a))
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -230,6 +251,7 @@ def eigvalsh_cost(n: int) -> int:
 def eigvalsh(a, UPLO="L"):
     """Eigenvalues (symmetric) with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -238,7 +260,9 @@ def eigvalsh(a, UPLO="L"):
     with budget.deduct(
         "linalg.eigvalsh", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eigvalsh(a, UPLO=UPLO)
+        result = _np.linalg.eigvalsh(_to_base_ndarray(a), UPLO=UPLO)
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -274,6 +298,7 @@ def svdvals_cost(m: int, n: int, k: int | None = None) -> int:
 def svdvals(x, /, *, k: int | None = None):
     """Singular values with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(x, WhestArray)
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     m, n = x.shape[-2], x.shape[-1]
@@ -286,9 +311,11 @@ def svdvals(x, /, *, k: int | None = None):
     with budget.deduct(
         "linalg.svdvals", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.svdvals(x)
+        result = _np.linalg.svdvals(_to_base_ndarray(x))
     if k < min(m, n):
         result = result[..., :k]
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 

--- a/src/whest/linalg/_decompositions.py
+++ b/src/whest/linalg/_decompositions.py
@@ -95,6 +95,14 @@ def qr(a, mode="reduced"):
         if inputs_were_whest:
             return QRResult(_aswhest(q), _aswhest(r))
         return QRResult(q, r)
+    if mode == "raw":
+        # ``raw`` returns a (h, tau) tuple of two ndarrays with different
+        # shapes — preserve the tuple structure rather than collapsing to
+        # a single array via ``_aswhest``.
+        h, tau = result
+        if inputs_were_whest:
+            return _aswhest(h), _aswhest(tau)
+        return h, tau
     if inputs_were_whest:
         return _aswhest(result)
     return result

--- a/src/whest/linalg/_decompositions.py
+++ b/src/whest/linalg/_decompositions.py
@@ -178,9 +178,7 @@ def eigh(a, UPLO="L"):
     ):
         result = _np.linalg.eigh(_to_base_ndarray(a), UPLO=UPLO)
     if inputs_were_whest:
-        return EighResult(
-            _aswhest(result.eigenvalues), _aswhest(result.eigenvectors)
-        )
+        return EighResult(_aswhest(result.eigenvalues), _aswhest(result.eigenvectors))
     return result
 
 

--- a/src/whest/linalg/_decompositions.py
+++ b/src/whest/linalg/_decompositions.py
@@ -80,7 +80,17 @@ def qr_cost(m: int, n: int) -> int:
 
 
 def qr(a, mode="reduced"):
-    """QR decomposition with FLOP counting."""
+    """QR decomposition with FLOP counting.
+
+    Returns vary by ``mode``:
+
+    - ``"reduced"`` (default) / ``"complete"`` → ``QRResult(q, r)``
+    - ``"r"`` → ``r`` only
+    - ``"raw"`` → 2-tuple ``(h, tau)`` of two ndarrays with mismatched
+      shapes (preserved as a tuple rather than collapsed via
+      ``_aswhest``, which would otherwise fail with
+      ``ValueError: ... inhomogeneous shape``)
+    """
     budget = require_budget()
     inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):

--- a/src/whest/linalg/_properties.py
+++ b/src/whest/linalg/_properties.py
@@ -7,6 +7,7 @@ import numpy as _np
 from numpy.linalg._linalg import SlogdetResult
 
 from whest._docstrings import attach_docstring
+from whest._ndarray import _to_base_ndarray
 from whest._symmetric import SymmetricTensor
 from whest._validation import require_budget
 from whest.linalg._solvers import _batch_size, _has_zero_dim
@@ -364,7 +365,9 @@ def cond(x, p=None):
     m, n = x.shape[-2], x.shape[-1]
     batch = _batch_size(x.shape)
     cost = cond_cost(m, n, p=p) * batch if not _has_zero_dim(x.shape) else 0
-    has_nan = not _has_zero_dim(x.shape) and bool(_np.any(_np.isnan(x)))
+    has_nan = not _has_zero_dim(x.shape) and bool(
+        _np.any(_np.isnan(_to_base_ndarray(x)))
+    )
     with budget.deduct(
         "linalg.cond", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):

--- a/src/whest/linalg/_properties.py
+++ b/src/whest/linalg/_properties.py
@@ -146,8 +146,12 @@ def slogdet(a):
         result = _np.linalg.slogdet(_to_base_ndarray(a))
     if inputs_were_whest:
         return SlogdetResult(
-            _aswhest(result.sign) if isinstance(result.sign, _np.ndarray) else result.sign,
-            _aswhest(result.logabsdet) if isinstance(result.logabsdet, _np.ndarray) else result.logabsdet,
+            _aswhest(result.sign)
+            if isinstance(result.sign, _np.ndarray)
+            else result.sign,
+            _aswhest(result.logabsdet)
+            if isinstance(result.logabsdet, _np.ndarray)
+            else result.logabsdet,
         )
     return result
 
@@ -344,9 +348,7 @@ def matrix_norm(x, ord="fro", keepdims=False):
     with budget.deduct(
         "linalg.matrix_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.matrix_norm(
-            _to_base_ndarray(x), ord=ord, keepdims=keepdims
-        )
+        result = _np.linalg.matrix_norm(_to_base_ndarray(x), ord=ord, keepdims=keepdims)
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _aswhest(result)
     return result

--- a/src/whest/linalg/_properties.py
+++ b/src/whest/linalg/_properties.py
@@ -7,7 +7,7 @@ import numpy as _np
 from numpy.linalg._linalg import SlogdetResult
 
 from whest._docstrings import attach_docstring
-from whest._ndarray import _to_base_ndarray
+from whest._ndarray import WhestArray, _aswhest, _to_base_ndarray
 from whest._symmetric import SymmetricTensor
 from whest._validation import require_budget
 from whest.linalg._solvers import _batch_size, _has_zero_dim
@@ -36,6 +36,7 @@ def trace_cost(n: int) -> int:
 def trace(x, /, *, offset=0, dtype=None):
     """Matrix trace with FLOP counting (numpy 2.0 linalg.trace signature)."""
     budget = require_budget()
+    inputs_were_whest = isinstance(x, WhestArray)
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     n = min(x.shape[-2], x.shape[-1])
@@ -48,7 +49,9 @@ def trace(x, /, *, offset=0, dtype=None):
     with budget.deduct(
         "linalg.trace", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.trace(x, offset=offset, dtype=dtype)
+        result = _np.linalg.trace(_to_base_ndarray(x), offset=offset, dtype=dtype)
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -80,6 +83,7 @@ def det_cost(n: int, symmetric: bool = False) -> int:
 def det(a):
     """Determinant with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -91,7 +95,9 @@ def det(a):
     with budget.deduct(
         "linalg.det", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.det(a)
+        result = _np.linalg.det(_to_base_ndarray(a))
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -123,6 +129,7 @@ def slogdet_cost(n: int, symmetric: bool = False) -> int:
 def slogdet(a):
     """Sign and log-determinant with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -136,8 +143,13 @@ def slogdet(a):
     with budget.deduct(
         "linalg.slogdet", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.slogdet(a)
-    return SlogdetResult(*result)
+        result = _np.linalg.slogdet(_to_base_ndarray(a))
+    if inputs_were_whest:
+        return SlogdetResult(
+            _aswhest(result.sign) if isinstance(result.sign, _np.ndarray) else result.sign,
+            _aswhest(result.logabsdet) if isinstance(result.logabsdet, _np.ndarray) else result.logabsdet,
+        )
+    return result
 
 
 attach_docstring(slogdet, _np.linalg.slogdet, "linalg", r"$n^3$ FLOPs")
@@ -189,6 +201,7 @@ def norm_cost(shape: tuple, ord=None) -> int:
 def norm(x, ord=None, axis=None, keepdims=False):
     """Matrix or vector norm with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(x, WhestArray)
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     # Compute effective shape for FLOP cost, guarding against invalid axis.
@@ -201,18 +214,26 @@ def norm(x, ord=None, axis=None, keepdims=False):
             ndim = x.ndim
             norm_axis = axis + ndim if axis < 0 else axis
             if norm_axis < 0 or norm_axis >= max(ndim, 1):
-                return _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+                return _np.linalg.norm(
+                    _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
+                )
             effective_shape = (x.shape[norm_axis],) if ndim > 0 else ()
         else:
             effective_shape = tuple(x.shape[ax] for ax in axis)
         cost = norm_cost(effective_shape, ord=ord)
     except (IndexError, ValueError):
         # Let numpy raise the proper error with the right type/message
-        return _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        return _np.linalg.norm(
+            _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
+        )
     with budget.deduct(
         "linalg.norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        result = _np.linalg.norm(
+            _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
+        )
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -252,6 +273,7 @@ def vector_norm_cost(shape: tuple, ord=None) -> int:
 def vector_norm(x, ord=2, axis=None, keepdims=False):
     """Vector norm with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(x, WhestArray)
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     if axis is not None:
@@ -265,7 +287,11 @@ def vector_norm(x, ord=2, axis=None, keepdims=False):
     with budget.deduct(
         "linalg.vector_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.vector_norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        result = _np.linalg.vector_norm(
+            _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
+        )
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -311,13 +337,18 @@ def matrix_norm_cost(shape: tuple, ord=None) -> int:
 def matrix_norm(x, ord="fro", keepdims=False):
     """Matrix norm with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(x, WhestArray)
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     cost = matrix_norm_cost(x.shape, ord=ord)
     with budget.deduct(
         "linalg.matrix_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.matrix_norm(x, ord=ord, keepdims=keepdims)
+        result = _np.linalg.matrix_norm(
+            _to_base_ndarray(x), ord=ord, keepdims=keepdims
+        )
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -360,6 +391,7 @@ def cond_cost(m: int, n: int, p=None) -> int:
 def cond(x, p=None):
     """Condition number with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(x, WhestArray)
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)
     m, n = x.shape[-2], x.shape[-1]
@@ -375,7 +407,7 @@ def cond(x, p=None):
             # Batch with NaN: process each matrix individually so NaN
             # propagates per-matrix rather than SVD failing the whole batch.
             batch_shape = x.shape[:-2]
-            flat = x.reshape(-1, x.shape[-2], x.shape[-1])
+            flat = _to_base_ndarray(x).reshape(-1, x.shape[-2], x.shape[-1])
             out = _np.empty(flat.shape[0], dtype=_np.float64)
             for i in range(flat.shape[0]):
                 try:
@@ -386,11 +418,13 @@ def cond(x, p=None):
         elif has_nan:
             # Single matrix with NaN: SVD may fail; return NaN instead.
             try:
-                result = _np.linalg.cond(x, p=p)
+                result = _np.linalg.cond(_to_base_ndarray(x), p=p)
             except _np.linalg.LinAlgError:
                 result = _np.float64(_np.nan)
         else:
-            result = _np.linalg.cond(x, p=p)
+            result = _np.linalg.cond(_to_base_ndarray(x), p=p)
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -427,6 +461,7 @@ def matrix_rank_cost(m: int, n: int) -> int:
 def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     """Matrix rank with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(A, WhestArray)
     if not isinstance(A, _np.ndarray):
         A = _np.asarray(A)
     if A.ndim < 2:
@@ -445,7 +480,9 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     with budget.deduct(
         "linalg.matrix_rank", flop_cost=cost, subscripts=None, shapes=(A.shape,)
     ):
-        result = _np.linalg.matrix_rank(A, **kwargs)
+        result = _np.linalg.matrix_rank(_to_base_ndarray(A), **kwargs)
+    if isinstance(result, _np.ndarray) and inputs_were_whest:
+        return _aswhest(result)
     return result
 
 

--- a/src/whest/linalg/_solvers.py
+++ b/src/whest/linalg/_solvers.py
@@ -52,7 +52,13 @@ def solve_cost(n: int, nrhs: int = 1, symmetric: bool = False) -> int:
 
 
 def solve(a, b):
-    """Solve linear system with FLOP counting."""
+    """Solve linear system ``a @ x = b`` with FLOP counting.
+
+    The result adopts the subclass of ``b`` (matching numpy's
+    ``np.linalg.solve`` policy): if ``b`` is a plain ndarray the
+    solution is plain ndarray even when ``a`` is a ``WhestArray``;
+    if ``b`` is a ``WhestArray`` the solution is wrapped accordingly.
+    """
     budget = require_budget()
     # Match NumPy's ``linalg.solve`` subclass-return policy: the result
     # adopts the subclass of ``b``. ``np.linalg.solve(WhestArray, plain)``
@@ -160,7 +166,15 @@ def lstsq_cost(m: int, n: int) -> int:
 
 
 def lstsq(a, b, rcond=None):
-    """Least-squares solution with FLOP counting."""
+    """Least-squares solution with FLOP counting.
+
+    Returns a 4-tuple ``(solution, residuals, rank, singular_values)``.
+    The solution and the array elements adopt the subclass of ``b``
+    (matching numpy's ``np.linalg.lstsq`` policy): if ``b`` is a plain
+    ndarray the outputs are plain ndarray even when ``a`` is a
+    ``WhestArray``; if ``b`` is a ``WhestArray`` they are wrapped
+    accordingly.
+    """
     budget = require_budget()
     # Match NumPy's ``linalg.lstsq`` subclass-return policy: the solution
     # adopts the subclass of ``b``. The residuals and singular-values

--- a/src/whest/linalg/_solvers.py
+++ b/src/whest/linalg/_solvers.py
@@ -54,7 +54,10 @@ def solve_cost(n: int, nrhs: int = 1, symmetric: bool = False) -> int:
 def solve(a, b):
     """Solve linear system with FLOP counting."""
     budget = require_budget()
-    inputs_were_whest = isinstance(a, WhestArray) or isinstance(b, WhestArray)
+    # Match NumPy's ``linalg.solve`` subclass-return policy: the result
+    # adopts the subclass of ``b``. ``np.linalg.solve(WhestArray, plain)``
+    # therefore returns plain ndarray to keep parity with raw NumPy.
+    b_was_whest = isinstance(b, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
@@ -66,7 +69,7 @@ def solve(a, b):
         "linalg.solve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
         result = _np.linalg.solve(_to_base_ndarray(a), _to_base_ndarray(b))
-    if inputs_were_whest:
+    if b_was_whest:
         return _aswhest(result)
     return result
 
@@ -159,7 +162,10 @@ def lstsq_cost(m: int, n: int) -> int:
 def lstsq(a, b, rcond=None):
     """Least-squares solution with FLOP counting."""
     budget = require_budget()
-    inputs_were_whest = isinstance(a, WhestArray) or isinstance(b, WhestArray)
+    # Match NumPy's ``linalg.lstsq`` subclass-return policy: the solution
+    # adopts the subclass of ``b``. The residuals and singular-values
+    # arrays follow the same rule (whatever wrapping ``b`` would imply).
+    b_was_whest = isinstance(b, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     m, n = a.shape[-2], a.shape[-1]
@@ -169,9 +175,7 @@ def lstsq(a, b, rcond=None):
         "linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
         result = _np.linalg.lstsq(_to_base_ndarray(a), _to_base_ndarray(b), rcond=rcond)
-    # lstsq returns (solution, residuals, rank, singular_values); wrap arrays
-    # only when inputs were whest.
-    if inputs_were_whest:
+    if b_was_whest:
         return tuple(_aswhest(r) if isinstance(r, _np.ndarray) else r for r in result)
     return tuple(result)
 

--- a/src/whest/linalg/_solvers.py
+++ b/src/whest/linalg/_solvers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as _np
 
 from whest._docstrings import attach_docstring
+from whest._ndarray import WhestArray, _aswhest, _to_base_ndarray
 from whest._symmetric import SymmetricTensor, as_symmetric
 from whest._validation import require_budget
 from whest.errors import SymmetryError
@@ -53,6 +54,7 @@ def solve_cost(n: int, nrhs: int = 1, symmetric: bool = False) -> int:
 def solve(a, b):
     """Solve linear system with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray) or isinstance(b, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
@@ -63,7 +65,9 @@ def solve(a, b):
     with budget.deduct(
         "linalg.solve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.solve(a, b)
+        result = _np.linalg.solve(_to_base_ndarray(a), _to_base_ndarray(b))
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -98,6 +102,7 @@ def inv_cost(n: int, symmetric: bool = False) -> int:
 def inv(a):
     """Matrix inverse with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     n = a.shape[-1]
@@ -110,12 +115,14 @@ def inv(a):
     with budget.deduct(
         "linalg.inv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.inv(a)
+        result = _np.linalg.inv(_to_base_ndarray(a))
     if is_symmetric:
         try:
             result = as_symmetric(result, symmetry=input_symmetry)
         except SymmetryError:
             pass
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -152,6 +159,7 @@ def lstsq_cost(m: int, n: int) -> int:
 def lstsq(a, b, rcond=None):
     """Least-squares solution with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray) or isinstance(b, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     m, n = a.shape[-2], a.shape[-1]
@@ -160,8 +168,12 @@ def lstsq(a, b, rcond=None):
     with budget.deduct(
         "linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.lstsq(a, b, rcond=rcond)
-    return result
+        result = _np.linalg.lstsq(_to_base_ndarray(a), _to_base_ndarray(b), rcond=rcond)
+    # lstsq returns (solution, residuals, rank, singular_values); wrap arrays
+    # only when inputs were whest.
+    if inputs_were_whest:
+        return tuple(_aswhest(r) if isinstance(r, _np.ndarray) else r for r in result)
+    return tuple(result)
 
 
 attach_docstring(
@@ -194,6 +206,7 @@ def pinv_cost(m: int, n: int) -> int:
 def pinv(a, rcond=None, hermitian=False, *, rtol=None):
     """Pseudoinverse with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     m, n = a.shape[-2], a.shape[-1]
@@ -207,7 +220,9 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=None):
     with budget.deduct(
         "linalg.pinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.pinv(a, **kwargs)
+        result = _np.linalg.pinv(_to_base_ndarray(a), **kwargs)
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -246,13 +261,16 @@ def tensorsolve_cost(a_shape: tuple, ind: int | None = None) -> int:
 def tensorsolve(a, b, axes=None):
     """Tensor solve with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray) or isinstance(b, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     cost = tensorsolve_cost(a.shape)
     with budget.deduct(
         "linalg.tensorsolve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.tensorsolve(a, b, axes=axes)
+        result = _np.linalg.tensorsolve(_to_base_ndarray(a), _to_base_ndarray(b), axes=axes)
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 
@@ -292,13 +310,16 @@ def tensorinv_cost(a_shape: tuple, ind: int = 2) -> int:
 def tensorinv(a, ind=2):
     """Tensor inverse with FLOP counting."""
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     cost = tensorinv_cost(a.shape, ind=ind)
     with budget.deduct(
         "linalg.tensorinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.tensorinv(a, ind=ind)
+        result = _np.linalg.tensorinv(_to_base_ndarray(a), ind=ind)
+    if inputs_were_whest:
+        return _aswhest(result)
     return result
 
 

--- a/src/whest/linalg/_solvers.py
+++ b/src/whest/linalg/_solvers.py
@@ -268,7 +268,9 @@ def tensorsolve(a, b, axes=None):
     with budget.deduct(
         "linalg.tensorsolve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.tensorsolve(_to_base_ndarray(a), _to_base_ndarray(b), axes=axes)
+        result = _np.linalg.tensorsolve(
+            _to_base_ndarray(a), _to_base_ndarray(b), axes=axes
+        )
     if inputs_were_whest:
         return _aswhest(result)
     return result

--- a/src/whest/linalg/_svd.py
+++ b/src/whest/linalg/_svd.py
@@ -6,6 +6,7 @@ import numpy as _np
 from numpy.linalg._linalg import SVDResult
 
 from whest._flops import svd_cost
+from whest._ndarray import WhestArray, _aswhest, _to_base_ndarray
 from whest._validation import check_nan_inf, require_budget
 
 
@@ -60,6 +61,7 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False, *, k=None):
         S : ndarray
     """
     budget = require_budget()
+    inputs_were_whest = isinstance(a, WhestArray)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if a.ndim < 2:
@@ -78,19 +80,27 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False, *, k=None):
         if compute_uv:
             # When k is specified, always use economy decomposition then slice.
             fm = full_matrices if k is None else False
-            U, S, Vt = _np.linalg.svd(a, full_matrices=fm, hermitian=hermitian)
+            U, S, Vt = _np.linalg.svd(
+                _to_base_ndarray(a), full_matrices=fm, hermitian=hermitian
+            )
             if k is not None:
                 S = S[..., :k]
                 U = U[..., :k]
                 Vt = Vt[..., :k, :]
             check_nan_inf(S, "linalg.svd")
         else:
-            S = _np.linalg.svd(a, compute_uv=False, hermitian=hermitian)
+            S = _np.linalg.svd(
+                _to_base_ndarray(a), compute_uv=False, hermitian=hermitian
+            )
             if k is not None:
                 S = S[..., :k]
             check_nan_inf(S, "linalg.svd")
 
     if compute_uv:
+        if inputs_were_whest:
+            return SVDResult(_aswhest(U), _aswhest(S), _aswhest(Vt))
         return SVDResult(U, S, Vt)
     else:
+        if inputs_were_whest:
+            return _aswhest(S)
         return S

--- a/tests/numpy_compat/conftest.py
+++ b/tests/numpy_compat/conftest.py
@@ -65,6 +65,7 @@ _REBOUND: dict[str, object] = {}
 
 # All whest submodules that import numpy as _np
 _WHEST_MODULES_WITH_NP = [
+    "whest._ndarray",
     "whest._pointwise",
     "whest._free_ops",
     "whest._sorting_ops",

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -322,66 +322,15 @@ XFAIL_PATTERNS: dict[str, str] = {
         "type(obj) != np.ndarray checks; returns NotImplemented then crashes on [0]"
     ),
     # ------------------------------------------------------------------ #
-    # NOT_IMPLEMENTED — ufunc method/protocol rejections                  #
+    # NOT_IMPLEMENTED — private gufuncs and remaining edge cases          #
     # ------------------------------------------------------------------ #
-    # Whest's __array_ufunc__ deliberately rejects ``ufunc.at``,
-    # ``ufunc.reduce``, ``ufunc.reduceat``, ``ufunc.accumulate`` and
-    # ``ufunc.outer`` so that callers cannot silently bypass FLOP
-    # tracking. Equivalent counted whest functions exist for the
-    # underlying operations — but tests that exercise the raw ufunc
-    # method protocol have no whest path and therefore fail with
-    # NotImplemented. (Multi-output ufuncs like ``divmod`` / ``frexp`` /
-    # ``modf`` are now supported via ``__array_ufunc__`` and route to
-    # the corresponding ``we.*`` wrapper.)
-    "*TestUfunc::test_ufunc_at_inner_loops*": (
-        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate, "
-        "use we.* counted functions instead)"
-    ),
-    "*TestUfunc::test_ufunc_at_scalar_value_fastpath*": (
-        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate, "
-        "use we.* counted functions instead)"
-    ),
-    "*TestUfunc::test_ufunc_at_negative": (
-        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_ufunc_at_large": (
-        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_ufunc_at_ellipsis": (
-        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_at_no_loop_for_op": (
-        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_cast_index_fastpath": (
-        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_object_array_reduceat_inplace": (
-        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_reducelike_output_needs_identical_cast": (
-        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_reduce_zero_axis": (
-        "NOT_IMPLEMENTED: ufunc.accumulate rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*TestUfunc::test_empty_reduction_and_identity": (
-        "NOT_IMPLEMENTED: ufunc.reduce rejected by __array_ufunc__ (deliberate)"
-    ),
-    "test_logical_ufuncs_support_anything[logical_xor]": (
-        "NOT_IMPLEMENTED: ufunc.reduce rejected by __array_ufunc__ (deliberate); "
-        "logical_and/or pass because their reduce reaches a terminating "
-        "scalar value before our rejection fires"
-    ),
-    "*test_umath.py::test_reduceat": (
-        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*test_umath.py::test_reduceat_empty": (
-        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
-    ),
-    "*test_umath.py::test_outer_exceeds_maxdims": (
-        "NOT_IMPLEMENTED: ufunc.outer rejected by __array_ufunc__ (deliberate)"
-    ),
+    # ``ufunc.outer`` / ``reduceat`` / ``at`` and the generic
+    # ``reduce`` / ``accumulate`` fallback are now supported via
+    # ``__array_ufunc__`` (Section 15 of the PR description). Multi-
+    # output ufuncs (``divmod`` / ``frexp`` / ``modf``) are also
+    # supported (Section 8). The remaining xfails below are for
+    # private numpy gufuncs and a handful of genuine semantic
+    # divergences.
     # Private numpy gufuncs (cross1d, matrix_multiply, conv1d_full, test_add,
     # euclidean_pdist) live in ``numpy._core.umath_tests`` and are not part
     # of the public NumPy API. Whest's __array_function__ allowlist does not

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -299,6 +299,12 @@ XFAIL_PATTERNS: dict[str, str] = {
         "NUMPY_INTERNAL: refcount check sees unexpected count due to WhestArray subclass "
         "wrapping (fails on numpy 2.2; xpassed on 2.3/2.4 which is acceptable)"
     ),
+    "*TestOut::test_out_wrap_subok": (
+        "SUBCLASS_RETURN: ``subok=False`` semantics not honored — whest always "
+        "wraps freshly-allocated outputs as WhestArray (an ndarray subclass), "
+        "even when the caller asked for plain ndarray. Same root cause as the "
+        "other SUBCLASS_RETURN entries."
+    ),
     # ------------------------------------------------------------------ #
     # SUBCLASS_RETURN — numpy 2.4 ufunc __array_ufunc__ dispatch change  #
     # ------------------------------------------------------------------ #
@@ -319,12 +325,14 @@ XFAIL_PATTERNS: dict[str, str] = {
     # NOT_IMPLEMENTED — ufunc method/protocol rejections                  #
     # ------------------------------------------------------------------ #
     # Whest's __array_ufunc__ deliberately rejects ``ufunc.at``,
-    # ``ufunc.reduce``, ``ufunc.reduceat``, ``ufunc.accumulate``,
-    # ``ufunc.outer`` and multi-output ufuncs (``divmod``, ``frexp``,
-    # ``modf``) so that callers cannot silently bypass FLOP tracking.
-    # Equivalent counted whest functions exist (``we.divmod``,
-    # ``we.modf`` etc.) — but tests that exercise the raw ufunc method
-    # protocol have no whest path and therefore fail with NotImplemented.
+    # ``ufunc.reduce``, ``ufunc.reduceat``, ``ufunc.accumulate`` and
+    # ``ufunc.outer`` so that callers cannot silently bypass FLOP
+    # tracking. Equivalent counted whest functions exist for the
+    # underlying operations — but tests that exercise the raw ufunc
+    # method protocol have no whest path and therefore fail with
+    # NotImplemented. (Multi-output ufuncs like ``divmod`` / ``frexp`` /
+    # ``modf`` are now supported via ``__array_ufunc__`` and route to
+    # the corresponding ``we.*`` wrapper.)
     "*TestUfunc::test_ufunc_at_inner_loops*": (
         "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate, "
         "use we.* counted functions instead)"
@@ -373,43 +381,6 @@ XFAIL_PATTERNS: dict[str, str] = {
     ),
     "*test_umath.py::test_outer_exceeds_maxdims": (
         "NOT_IMPLEMENTED: ufunc.outer rejected by __array_ufunc__ (deliberate)"
-    ),
-    # Multi-output ufuncs (divmod, frexp, modf) — counted whest equivalents
-    # exist (``we.divmod`` / ``we.modf`` / ``we.frexp``) but they are not
-    # ufuncs, so direct ``np.divmod(...)`` of a WhestArray raises.
-    "*TestDivisionIntegerOverflowsAndDivideByZero::test_divide_by_zero*": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.divmod) rejected by "
-        "__array_ufunc__; whest provides we.divmod as a counted alternative"
-    ),
-    "*TestDivisionIntegerOverflowsAndDivideByZero::test_signed_division_overflow*": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.divmod) rejected by "
-        "__array_ufunc__; whest provides we.divmod as a counted alternative"
-    ),
-    # Substring patterns (the `[name]` brackets prevent fnmatch wildcards
-    # from matching, so we rely on conftest's substring-fallback).
-    "test_ufunc_types[divmod]": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
-    ),
-    "test_ufunc_types[frexp]": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
-    ),
-    "test_ufunc_types[modf]": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
-    ),
-    "test_ufunc_noncontiguous[divmod]": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
-    ),
-    "test_ufunc_noncontiguous[frexp]": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
-    ),
-    "test_ufunc_noncontiguous[modf]": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
-    ),
-    "*TestOut::test_out_subok": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.frexp) rejected by __array_ufunc__"
-    ),
-    "*TestOut::test_out_wrap_subok": (
-        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.frexp) rejected by __array_ufunc__"
     ),
     # Private numpy gufuncs (cross1d, matrix_multiply, conv1d_full, test_add,
     # euclidean_pdist) live in ``numpy._core.umath_tests`` and are not part

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -315,4 +315,153 @@ XFAIL_PATTERNS: dict[str, str] = {
         "np.zeros) as out= into OverriddenArray._unwrap which does strict "
         "type(obj) != np.ndarray checks; returns NotImplemented then crashes on [0]"
     ),
+    # ------------------------------------------------------------------ #
+    # NOT_IMPLEMENTED — ufunc method/protocol rejections                  #
+    # ------------------------------------------------------------------ #
+    # Whest's __array_ufunc__ deliberately rejects ``ufunc.at``,
+    # ``ufunc.reduce``, ``ufunc.reduceat``, ``ufunc.accumulate``,
+    # ``ufunc.outer`` and multi-output ufuncs (``divmod``, ``frexp``,
+    # ``modf``) so that callers cannot silently bypass FLOP tracking.
+    # Equivalent counted whest functions exist (``we.divmod``,
+    # ``we.modf`` etc.) — but tests that exercise the raw ufunc method
+    # protocol have no whest path and therefore fail with NotImplemented.
+    "*TestUfunc::test_ufunc_at_inner_loops*": (
+        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate, "
+        "use we.* counted functions instead)"
+    ),
+    "*TestUfunc::test_ufunc_at_scalar_value_fastpath*": (
+        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate, "
+        "use we.* counted functions instead)"
+    ),
+    "*TestUfunc::test_ufunc_at_negative": (
+        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_ufunc_at_large": (
+        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_ufunc_at_ellipsis": (
+        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_at_no_loop_for_op": (
+        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_cast_index_fastpath": (
+        "NOT_IMPLEMENTED: ufunc.at rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_object_array_reduceat_inplace": (
+        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_reducelike_output_needs_identical_cast": (
+        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_reduce_zero_axis": (
+        "NOT_IMPLEMENTED: ufunc.accumulate rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*TestUfunc::test_empty_reduction_and_identity": (
+        "NOT_IMPLEMENTED: ufunc.reduce rejected by __array_ufunc__ (deliberate)"
+    ),
+    "test_logical_ufuncs_support_anything[logical_xor]": (
+        "NOT_IMPLEMENTED: ufunc.reduce rejected by __array_ufunc__ (deliberate); "
+        "logical_and/or pass because their reduce reaches a terminating "
+        "scalar value before our rejection fires"
+    ),
+    "*test_umath.py::test_reduceat": (
+        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*test_umath.py::test_reduceat_empty": (
+        "NOT_IMPLEMENTED: ufunc.reduceat rejected by __array_ufunc__ (deliberate)"
+    ),
+    "*test_umath.py::test_outer_exceeds_maxdims": (
+        "NOT_IMPLEMENTED: ufunc.outer rejected by __array_ufunc__ (deliberate)"
+    ),
+    # Multi-output ufuncs (divmod, frexp, modf) — counted whest equivalents
+    # exist (``we.divmod`` / ``we.modf`` / ``we.frexp``) but they are not
+    # ufuncs, so direct ``np.divmod(...)`` of a WhestArray raises.
+    "*TestDivisionIntegerOverflowsAndDivideByZero::test_divide_by_zero*": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.divmod) rejected by "
+        "__array_ufunc__; whest provides we.divmod as a counted alternative"
+    ),
+    "*TestDivisionIntegerOverflowsAndDivideByZero::test_signed_division_overflow*": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.divmod) rejected by "
+        "__array_ufunc__; whest provides we.divmod as a counted alternative"
+    ),
+    # Substring patterns (the `[name]` brackets prevent fnmatch wildcards
+    # from matching, so we rely on conftest's substring-fallback).
+    "test_ufunc_types[divmod]": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
+    ),
+    "test_ufunc_types[frexp]": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
+    ),
+    "test_ufunc_types[modf]": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
+    ),
+    "test_ufunc_noncontiguous[divmod]": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
+    ),
+    "test_ufunc_noncontiguous[frexp]": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
+    ),
+    "test_ufunc_noncontiguous[modf]": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 rejected by __array_ufunc__"
+    ),
+    "*TestOut::test_out_subok": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.frexp) rejected by __array_ufunc__"
+    ),
+    "*TestOut::test_out_wrap_subok": (
+        "NOT_IMPLEMENTED: ufuncs with nout != 1 (np.frexp) rejected by __array_ufunc__"
+    ),
+    # Private numpy gufuncs (cross1d, matrix_multiply, conv1d_full, test_add,
+    # euclidean_pdist) live in ``numpy._core.umath_tests`` and are not part
+    # of the public NumPy API. Whest's __array_function__ allowlist does not
+    # include them, so calls raise TypeError (NotImplemented).
+    "*TestUfunc::test_cross1d": (
+        "NOT_IMPLEMENTED: private gufunc numpy._core.umath_tests.cross1d not in "
+        "__array_function__ allowlist"
+    ),
+    "*TestUfunc::test_axes_argument": (
+        "NOT_IMPLEMENTED: private gufunc matrix_multiply not in allowlist"
+    ),
+    "*TestUfunc::test_keepdims_argument": (
+        "NOT_IMPLEMENTED: private gufunc matrix_multiply not in allowlist"
+    ),
+    "*TestUfunc::test_can_ignore_signature": (
+        "NOT_IMPLEMENTED: private gufunc matrix_multiply not in allowlist"
+    ),
+    "*TestUfunc::test_matrix_multiply_umath_empty": (
+        "NOT_IMPLEMENTED: private gufunc matrix_multiply not in allowlist"
+    ),
+    "*TestUfunc::test_euclidean_pdist": (
+        "NOT_IMPLEMENTED: private gufunc euclidean_pdist not in allowlist"
+    ),
+    "*TestUfunc::test_ufunc_custom_out": (
+        "NOT_IMPLEMENTED: private gufunc test_add not in allowlist"
+    ),
+    "*TestGUFuncProcessCoreDims::test_conv1d_full_with_out": (
+        "NOT_IMPLEMENTED: private gufunc conv1d_full not in allowlist"
+    ),
+    "*TestGUFuncProcessCoreDims::test_bad_out_shape": (
+        "NOT_IMPLEMENTED: private gufunc conv1d_full not in allowlist"
+    ),
+    "*TestFrompyfunc::test_identity": (
+        "NOT_IMPLEMENTED: frompyfunc creates a custom ufunc whose dispatch "
+        "is not in whest's __array_function__ allowlist"
+    ),
+    # ------------------------------------------------------------------ #
+    # BEHAVIORAL_SHIM — __array_ufunc__ activates symmetry validation     #
+    # ------------------------------------------------------------------ #
+    # ``np.zeros_like(plain_3x3)`` returns a SymmetricTensor (whest auto-
+    # infers symmetry from constant-fill arrays of square shape, since
+    # all-zeros is symmetric in any axis order). On main, ``np.positive(
+    # plain_3x3, out=symmetric_zeros, where=mask)`` worked because numpy
+    # bypassed whest validation entirely (no __array_ufunc__). On v2,
+    # __array_ufunc__ activates ``_prepare_symmetric_out`` which refuses
+    # to write non-symmetric data into a SymmetricTensor — surfacing a
+    # latent semantic conflict the auto-inference creates.
+    "*TestUfunc::test_reduction_with_where*": (
+        "BEHAVIORAL_SHIM: np.zeros_like auto-infers SymmetryGroup on square "
+        "shapes; __array_ufunc__ then validates the write via "
+        "_prepare_symmetric_out and refuses non-symmetric assignments. Main "
+        "bypassed this path (no __array_ufunc__)."
+    ),
 }

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -1,0 +1,578 @@
+"""Tests verifying numpy's __array_ufunc__ and __array_function__ protocols
+route numpy calls through whest's counted functions when the operands are
+WhestArray (or SymmetricTensor).
+
+Includes adversarial coverage for recursion, out= tuples, kwargs passthrough,
+mixed operands, unsupported ufunc methods, and identity preservation.
+
+Translated against post-PR-#51 unified SymmetryGroup API.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import whest as we
+
+
+# ----- __array_ufunc__: ufunc.__call__ -----
+
+UFUNC_CALL_CASES = [
+    ("add", lambda a, b: np.add(a, b), "add"),
+    ("multiply", lambda a, b: np.multiply(a, b), "multiply"),
+    ("subtract", lambda a, b: np.subtract(a, b), "subtract"),
+    ("maximum", lambda a, b: np.maximum(a, b), "maximum"),
+]
+
+
+@pytest.mark.parametrize("name,op,we_name", UFUNC_CALL_CASES)
+def test_np_ufunc_call_tracks_flops(name, op, we_name):
+    a = we.random.randn(8)
+    b = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        op(a, b)
+    we_func = getattr(we, we_name)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we_func(a, b)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_np_unary_ufunc_call_tracks_flops():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.sin(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.sin(a)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+# ----- __array_ufunc__: ufunc.reduce -----
+
+def test_np_add_reduce_tracks_flops():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.add.reduce(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.sum(a)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_np_maximum_reduce_tracks_flops():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.maximum.reduce(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.max(a)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_np_add_reduce_2d_matches_axis0_semantics():
+    """``ufunc.reduce`` defaults to ``axis=0``, whereas ``we.sum`` defaults
+    to ``axis=None`` (full reduction). The ``__array_ufunc__`` dispatch
+    must inject ``axis=0`` so 2D inputs get partial-reduction semantics."""
+    a = we.random.randn(4, 5)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        r1 = np.add.reduce(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        r2 = we.sum(a, axis=0)
+    assert r1.shape == r2.shape == (5,)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+# ----- __array_ufunc__: ufunc.accumulate -----
+
+def test_np_add_accumulate_tracks_flops():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.add.accumulate(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.cumsum(a)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_np_add_accumulate_2d_matches_axis0_semantics():
+    """Same axis-default issue as reduce: ``ufunc.accumulate`` defaults to
+    ``axis=0``, ``we.cumsum`` defaults to ``axis=None`` (flatten)."""
+    a = we.random.randn(4, 5)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        r1 = np.add.accumulate(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        r2 = we.cumsum(a, axis=0)
+    assert r1.shape == r2.shape == (4, 5)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+# ----- Recursion guards (regression-only) -----
+
+def test_dunder_does_not_recurse_after_protocol_enabled():
+    """WhestArray.__add__ → me.add → _np.add must NOT re-dispatch through
+    __array_ufunc__ → me.add → ∞.
+
+    The strip-before-NumPy invariant in counted wrappers prevents this.
+    """
+    a = we.random.randn(8)
+    b = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        c = a + b
+    assert bc.flops_used > 0
+    assert c.shape == (8,)
+
+
+def test_np_add_does_not_recurse():
+    a = we.random.randn(8)
+    b = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        np.add(a, b)
+    assert bc.flops_used > 0
+
+
+def test_np_sort_does_not_recurse():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        np.sort(a)
+    assert bc.flops_used > 0
+
+
+# ----- ufunc kwargs passthrough -----
+
+def test_np_add_out_unwraps_single_output_tuple():
+    """NumPy passes out=(out_arr,) to __array_ufunc__; whest expects out=arr."""
+    a = we.random.randn(8)
+    b = we.random.randn(8)
+    out = we.empty_like(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        returned = np.add(a, b, out=out)
+    assert returned is out
+    assert bc.flops_used > 0
+
+
+def test_np_add_out_refuses_when_out_symmetry_would_be_destroyed():
+    """``np.add(A_sym, B_unsymmetric, out=A_sym)`` would write
+    unsymmetric bytes into a buffer whose metadata still claims
+    symmetry. Same correctness issue as in-place dunders, just via an
+    explicit ``out=``. The wrapper's symmetry validation must refuse
+    before the NumPy call writes any bytes.
+
+    Post-PR-#51, this is enforced by ``_prepare_symmetric_out`` in
+    ``_pointwise.py``: if the out's symmetry doesn't match the result's,
+    it raises (via ``SymmetryError`` or ``ValueError``).
+    """
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    B = we.random.randn(4, 4)  # plain WhestArray, no symmetry
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises((ValueError, we.errors.SymmetryError)):
+            np.add(A, B, out=A)
+
+
+def test_np_add_out_allows_matching_symmetric_out():
+    """Positive case: when the operation's output symmetry matches the
+    declared symmetry on ``out=``, the call goes through cleanly.
+    ``A + 1.0`` preserves every group exactly (binary-with-scalar), so
+    writing into a SymmetricTensor ``out`` with the same axes is safe."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    out = we.symmetrize(
+        we.zeros((4, 4)),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        ret = np.add(A, 1.0, out=out)
+    assert ret is out
+    assert isinstance(out, we.SymmetricTensor)
+    assert bc.flops_used > 0
+
+
+def test_np_transpose_on_whest_fails_loudly_until_supported():
+    """Structural NumPy ops are intentionally NOT in the
+    ``__array_function__`` allowlist. ``np.transpose(whest)`` must
+    therefore raise ``TypeError`` rather than silently strip
+    symmetry. ``A.T`` (property form) goes through ``__array_finalize__``
+    and continues to work — covered by
+    ``test_transpose_of_symmetric_preserves_type`` below."""
+    a = we.random.randn(2, 3)
+    with pytest.raises(TypeError):
+        np.transpose(a)
+
+
+def test_np_add_where_kwarg_tracks():
+    a = we.random.randn(8)
+    b = we.random.randn(8)
+    mask = np.array([True, False] * 4)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        np.add(a, b, where=mask)
+    assert bc.flops_used > 0
+
+
+def test_np_sin_where_kwarg_tracks():
+    """Unary ufunc with ``where=`` mask. Mirrors the binary-``where=``
+    test above, exercising ``_counted_unary``'s ``where`` strip path."""
+    a = we.random.randn(8)
+    mask = np.array([True, False] * 4)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        np.sin(a, where=mask)
+    assert bc.flops_used > 0
+
+
+def test_np_add_dtype_kwarg_tracks():
+    a = we.random.randn(8).astype(np.float32)
+    b = we.random.randn(8).astype(np.float32)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        r = np.add(a, b, dtype=np.float64)
+    assert bc.flops_used > 0
+    assert r.dtype == np.float64
+
+
+# ----- Mixed operands: numpy on left, whest on right -----
+
+def test_mixed_numpy_left_operand_dispatches():
+    """np.ndarray + WhestArray must still dispatch through whest tracking
+    (NEP 13: NumPy defers to subclasses' __array_ufunc__)."""
+    a = np.ones(8)
+    b = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        c = a + b
+    assert bc.flops_used > 0
+    assert isinstance(c, we.ndarray)
+
+
+def test_mixed_python_scalar_left_dispatches():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        c = 2.0 + a
+    assert bc.flops_used > 0
+
+
+# ----- In-place dunder identity preservation -----
+
+def test_inplace_add_preserves_identity():
+    """a += b must mutate a, not rebind it. Currently broken on
+    post-PR-#51 main — fixed in Task 5."""
+    a = we.random.randn(8)
+    old_id = id(a)
+    with we.BudgetContext(flop_budget=int(1e9)):
+        a += 1
+    assert id(a) == old_id
+
+
+def test_inplace_add_scalar_on_symmetric_tensor_preserves_identity():
+    """``A_sym += 1.0`` is symmetry-preserving (binary-with-scalar keeps
+    every group). It must mutate ``A_sym`` in place AND keep the
+    SymmetricTensor type — no spurious downgrade, no rebinding."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    old_id = id(A)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        A += 1.0
+    assert id(A) == old_id
+    assert isinstance(A, we.SymmetricTensor)
+    assert bc.flops_used > 0
+
+
+def test_inplace_add_refuses_when_symmetry_would_be_destroyed():
+    """``A_sym += B_unsymmetric`` would silently overwrite ``A_sym``'s
+    bytes with a non-symmetric result. The in-place dunder must refuse
+    rather than corrupt the symmetry metadata."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    B = we.random.randn(4, 4)  # plain WhestArray, no symmetry
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises(ValueError, match="destroy or weaken symmetry"):
+            A += B
+
+
+# ----- Unsupported ufunc methods fail loudly -----
+
+def test_np_add_outer_fails_loudly():
+    """ufunc.outer is not yet implemented; must raise rather than silently
+    bypass tracking."""
+    a = we.random.randn(4)
+    b = we.random.randn(3)
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises((NotImplementedError, TypeError)):
+            np.add.outer(a, b)
+
+
+def test_np_add_reduceat_fails_loudly():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises((NotImplementedError, TypeError)):
+            np.add.reduceat(a, [0, 4])
+
+
+def test_np_add_at_fails_loudly():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises((NotImplementedError, TypeError)):
+            np.add.at(a, [0, 1], 1.0)
+
+
+# ----- Multi-output ufuncs fail loudly -----
+
+def test_np_modf_fails_loudly():
+    """``np.modf`` is a multi-output ufunc (nout=2). Until whest supports
+    multi-output ``out=(out1, out2)`` properly, it must raise rather than
+    silently bypass tracking on either return slot."""
+    a = we.random.randn(8) + 0.5
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises((NotImplementedError, TypeError)):
+            np.modf(a)
+
+
+def test_np_frexp_fails_loudly():
+    a = we.random.randn(8) + 1.5
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises((NotImplementedError, TypeError)):
+            np.frexp(a)
+
+
+def test_we_modf_rejects_out_kwarg():
+    """The direct ``we.modf(a, out=...)`` path goes through
+    ``_counted_unary_multi`` (not ``__array_ufunc__``) because the
+    operands are already whest. It must reject ``out=`` explicitly with
+    NotImplementedError rather than silently letting NumPy write into
+    whest-typed buffers (which would recurse through
+    ``__array_function__`` and double-charge)."""
+    a = we.random.randn(8) + 0.5
+    out1 = we.empty_like(a)
+    out2 = we.empty_like(a)
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises(NotImplementedError, match="out"):
+            we.modf(a, out=(out1, out2))
+
+
+# ----- Recursion guard for raw whest functions -----
+
+def test_we_add_does_not_recurse_after_protocol_enabled():
+    """``we.add(WhestArray, WhestArray)`` must not enter an infinite loop
+    via ``_np.add`` → ``__array_ufunc__`` → ``we.add`` → ... after Task
+    3 enables ``__array_ufunc__``. The strip in ``_counted_binary``
+    breaks the cycle by viewing both operands as plain ndarray
+    before calling ``_np.add``.
+    """
+    a = we.random.randn(8)
+    b = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        c = we.add(a, b)
+    assert bc.flops_used > 0
+    assert c.shape == (8,)
+    assert isinstance(c, we.ndarray)
+
+
+# ----- __array_function__: np.<func>(whest) -----
+
+def test_np_sort_tracks_flops():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.sort(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.sort(a)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_np_linalg_norm_tracks_flops():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.linalg.norm(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.linalg.norm(a)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_np_where_tracks_flops():
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.where(a > 0, a, 0.0)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.where(a > 0, a, 0.0)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_np_sum_routes_to_whest():
+    """np.sum(whest) goes through __array_function__ (not __array_ufunc__)."""
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        np.sum(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.sum(a)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+# ----- Structural ops on SymmetricTensor: type follows surviving symmetry -----
+
+def test_diagonal_of_3sym_downgrades_when_no_tensor_axis_symmetry_remains():
+    """Diagonal of a (n,n,n) tensor with full S_3 symmetry along (0,1,2)
+    collapses axes 0/1 (or any pair) into a single diagonal axis, which
+    cannot retain a multi-axis permutation group → result must be
+    ``WhestArray``, not ``SymmetricTensor``."""
+    n = 4
+    A = we.symmetrize(
+        we.random.randn(n, n, n),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1, 2)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        d = we.diagonal(A)
+    assert not isinstance(d, we.SymmetricTensor)
+    assert isinstance(d, we.ndarray)
+
+
+def test_transpose_of_symmetric_preserves_type():
+    """Transposing a 2-axis symmetric matrix preserves the symmetry."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        AT = A.T
+    assert isinstance(AT, we.SymmetricTensor)
+
+
+# ----- Helper unit tests -----
+
+def test_to_base_ndarray_strips_whest_subclass():
+    from whest._ndarray import _to_base_ndarray, WhestArray
+    a = we.random.randn(4)
+    base = _to_base_ndarray(a)
+    assert type(base) is np.ndarray
+    assert not isinstance(base, WhestArray)
+    base[0] = 99.0
+    assert a[0] == 99.0  # zero-copy view
+
+
+def test_to_base_ndarray_preserves_python_scalar():
+    from whest._ndarray import _to_base_ndarray
+    assert _to_base_ndarray(2.0) == 2.0
+    assert isinstance(_to_base_ndarray(2.0), float)
+
+
+def test_to_base_ndarray_tree_strips_in_tuple():
+    from whest._ndarray import _to_base_ndarray_tree
+    a = we.random.randn(4)
+    b = we.random.randn(4)
+    out = _to_base_ndarray_tree((a, b))
+    assert all(type(x) is np.ndarray for x in out)
+
+
+def test_to_base_ndarray_tree_strips_in_list():
+    from whest._ndarray import _to_base_ndarray_tree
+    a = we.random.randn(4)
+    b = we.random.randn(4)
+    out = _to_base_ndarray_tree([a, b])
+    assert all(type(x) is np.ndarray for x in out)
+
+
+def test_to_base_ndarray_tree_preserves_scalars():
+    from whest._ndarray import _to_base_ndarray_tree
+    out = _to_base_ndarray_tree((1.0, 2, "x"))
+    assert out == (1.0, 2, "x")
+
+
+def test_to_base_ndarray_tree_recurses_into_nested():
+    from whest._ndarray import _to_base_ndarray_tree
+    a = we.random.randn(4)
+    out = _to_base_ndarray_tree([(a, 1.0), [a]])
+    assert type(out[0][0]) is np.ndarray
+    assert type(out[1][0]) is np.ndarray
+
+
+# ----- _PASSTHROUGH lock-in -----
+
+def test_np_type_query_passthrough_does_not_charge_flops():
+    """``np.result_type``, ``np.can_cast``, ``np.min_scalar_type``, etc.
+    are zero-FLOP type-query functions that must bypass whest's
+    FLOP-tracking dispatch. They are added to ``_PASSTHROUGH_NAMES`` for
+    this reason."""
+    a = we.empty(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        assert np.result_type(a) == np.float64
+        assert np.can_cast(a, np.float64)
+        assert np.min_scalar_type(a) is not None
+    assert bc.flops_used == 0
+
+
+# ----- Cache-verification test (Stage 2 helper added in Step 2.2) -----
+
+def test_signature_kwargs_accepted_is_cached():
+    """The signature lookup must be cached — it sits on the per-ufunc
+    hot path. PR #51 memoized similar helpers; we do the same here."""
+    from whest._ndarray import _signature_kwargs_accepted
+    # Same callable should return the same frozenset object (cached).
+    a = _signature_kwargs_accepted(np.add)
+    b = _signature_kwargs_accepted(np.add)
+    assert a is b, "_signature_kwargs_accepted is not cached"
+
+
+# ----- Performance regression guards (against PR #51 hot paths) -----
+# Reference: https://github.com/AIcrowd/whest/pull/51#issuecomment-4340098399
+# These are SEED tests demonstrating the pattern. Add stage-specific
+# perf tests in later stages when implementer reasoning identifies
+# hot paths their changes touch.
+
+
+def test_perf_warm_rank8_scalar_comparison_is_fast():
+    """Warm rank-8 scalar comparison ``we.full((2,)*8, 1) == 1`` must
+    finish well under 100ms.
+
+    PR #51 fixed this from ~930ms warm to ~0.04ms warm via:
+    (a) ``SymmetryGroup.__eq__`` identity short-circuit,
+    (b) per-instance ``_canonical_axis_action`` cache,
+    (c) ``@functools.cache`` on ``unique_elements_for_shape``.
+    Generous bound (2500× margin over the post-fix figure) catches
+    order-of-magnitude regressions without flaking on machine variance.
+    """
+    import time
+    a = we.full((2,) * 8, 1)  # rank-8, 256 elements, full S_8 symmetric group
+    # Warm-up: prime the per-instance _canonical_axis_action cache and the
+    # @functools.cache on unique_elements_for_shape.
+    with we.BudgetContext(flop_budget=int(1e12)):
+        _ = (a == 1)
+    # Measure the warm path.
+    with we.BudgetContext(flop_budget=int(1e12)):
+        t0 = time.perf_counter()
+        _ = (a == 1)
+        elapsed = time.perf_counter() - t0
+    assert elapsed < 0.1, (
+        f"warm rank-8 scalar comparison took {elapsed*1000:.1f}ms; "
+        f"PR #51 fixed this to ~0.04ms. Are we re-introducing O(|G|) "
+        f"work in __eq__ / _canonical_axis_action / "
+        f"unique_elements_for_shape, or making OWNDATA-preserving "
+        f"copies in __array_ufunc__?"
+    )
+
+
+def test_perf_array_ufunc_dispatch_does_not_copy():
+    """100 invocations of ``np.add(whest, whest)`` on 1024-element
+    arrays must complete well under 1 second.
+
+    PR #51 dropped OWNDATA-preserving copies in ``__array_wrap__``,
+    ``_aswhest``, ``_asplainwhest`` to keep this path cheap. Our
+    ``__array_ufunc__`` handler must not re-introduce them by, e.g.,
+    calling ``np.array(x, copy=True)`` or wrapping each result in a
+    redundant view-cast that triggers a finalize chain.
+    """
+    import time
+    a = we.random.randn(1024)
+    b = we.random.randn(1024)
+    # Warm-up.
+    with we.BudgetContext(flop_budget=int(1e12)):
+        _ = np.add(a, b)
+    # Measure 100 calls.
+    with we.BudgetContext(flop_budget=int(1e15)):
+        t0 = time.perf_counter()
+        for _ in range(100):
+            _ = np.add(a, b)
+        elapsed = time.perf_counter() - t0
+    assert elapsed < 1.0, (
+        f"100x np.add(whest, whest) took {elapsed:.3f}s; "
+        f"are we re-introducing per-call copies or O(|G|) work in "
+        f"__array_ufunc__ / _filter_to_np_signature?"
+    )

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -344,6 +344,55 @@ def test_np_add_outer_symmetric_cost_lower_than_dense():
     assert sym_bc.flops_used < dense_bc.flops_used
 
 
+def test_np_add_outer_warns_and_bails_on_oversized_symmetry():
+    """High-degree symmetry groups (e.g. ``S_n`` from ``np.ones((1,)*n)``
+    for large ``n``) would require Burnside enumeration on ``n!``
+    elements, which is infeasible. The wrapper bails to dense cost and
+    emits :class:`CostFallbackWarning` once per ``(op, degree)``."""
+    import warnings as _warnings
+
+    from whest.errors import CostFallbackWarning
+
+    deep = we.ones((1,) * 33)  # S_33 auto-inferred symmetry
+    assert isinstance(deep, we.SymmetricTensor)
+    with we.BudgetContext(flop_budget=int(1e10)):
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            # The op itself raises ValueError because numpy refuses
+            # ndim > 32 — but our wrapper still emits the warning before
+            # numpy raises.
+            with pytest.raises(ValueError):
+                np.add.outer(deep, deep)
+    cost_warnings = [w for w in caught if issubclass(w.category, CostFallbackWarning)]
+    assert len(cost_warnings) == 1, [str(w.message) for w in caught]
+    assert "degree 33" in str(cost_warnings[0].message)
+
+
+def test_cost_fallback_warning_suppressed_by_configure():
+    """``we.configure(symmetry_warnings=False)`` silences
+    :class:`CostFallbackWarning` (shares the flag with
+    :class:`SymmetryLossWarning` since both are symmetry diagnostics)."""
+    import warnings as _warnings
+
+    from whest.errors import CostFallbackWarning
+
+    # Use a fresh degree (not 33, which the previous test already cached)
+    # so we hit a cold cache key and the warning would otherwise fire.
+    # rank-20 → output ndim=40 which fits inside numpy 2.x's 64-axis
+    # limit, so the op itself succeeds.
+    deep = we.ones((1,) * 20)
+    we.configure(symmetry_warnings=False)
+    try:
+        with we.BudgetContext(flop_budget=int(1e10)):
+            with _warnings.catch_warnings(record=True) as caught:
+                _warnings.simplefilter("always")
+                np.add.outer(deep, deep)
+    finally:
+        we.configure(symmetry_warnings=True)
+    cost_warnings = [w for w in caught if issubclass(w.category, CostFallbackWarning)]
+    assert cost_warnings == [], [str(w.message) for w in cost_warnings]
+
+
 def test_np_subtract_reduce_uses_generic_path():
     """Non-table reduces (``subtract``, ``true_divide``, …) route through
     the generic ``_counted_ufunc_reduce_generic`` fallback."""

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -294,31 +294,104 @@ def test_inplace_add_refuses_when_symmetry_would_be_destroyed():
             A += B
 
 
-# ----- Unsupported ufunc methods fail loudly -----
+# ----- ufunc.outer / .reduceat / .at / generic .reduce / .accumulate -----
 
 
-def test_np_add_outer_fails_loudly():
-    """ufunc.outer is not yet implemented; must raise rather than silently
-    bypass tracking."""
-    a = we.random.randn(4)
-    b = we.random.randn(3)
-    with we.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises((NotImplementedError, TypeError)):
-            np.add.outer(a, b)
+def test_np_add_outer_routes_through_array_ufunc():
+    """``np.add.outer(WhestArray, WhestArray)`` produces a tracked
+    WhestArray of shape ``a.shape + b.shape`` with FLOPs deducted."""
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([1.0, 2.0, 3.0])
+        b = we.array([10.0, 20.0])
+        result = np.add.outer(a, b)
+    assert isinstance(result, WhestArray)
+    assert result.shape == (3, 2)
+    np.testing.assert_array_equal(np.asarray(result), [[11, 21], [12, 22], [13, 23]])
+    assert bc.flops_used > 0
 
 
-def test_np_add_reduceat_fails_loudly():
-    a = we.random.randn(8)
-    with we.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises((NotImplementedError, TypeError)):
-            np.add.reduceat(a, [0, 4])
+def test_np_add_outer_preserves_direct_product_symmetry():
+    """``np.add.outer(A, B)`` for ``A``, ``B`` SymmetricTensors produces
+    a SymmetricTensor whose symmetry is the direct product of the
+    inputs', with ``B``'s axes lifted past ``A``'s ndim."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        sym = we.SymmetryGroup.symmetric(axes=(0, 1))
+        A = we.symmetrize(we.array([[1.0, 2.0], [2.0, 3.0]]), symmetry=sym)
+        B = we.symmetrize(we.array([[5.0, 6.0], [6.0, 7.0]]), symmetry=sym)
+        result = np.add.outer(A, B)
+    assert isinstance(result, we.SymmetricTensor)
+    assert result.shape == (2, 2, 2, 2)
+    # Output symmetry has both S2 generators (one on (0,1), one on (2,3)).
+    assert result.symmetry is not None
+    assert set(result.symmetry.axes) == {0, 1, 2, 3}
 
 
-def test_np_add_at_fails_loudly():
-    a = we.random.randn(8)
-    with we.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises((NotImplementedError, TypeError)):
-            np.add.at(a, [0, 1], 1.0)
+def test_np_add_outer_symmetric_cost_lower_than_dense():
+    """Symmetric outer charges fewer FLOPs than dense outer (placeholder
+    cost = dense × unique_output / dense_output ratio)."""
+    n = 10
+    sym = we.SymmetryGroup.symmetric(axes=(0, 1))
+    with we.BudgetContext(flop_budget=int(1e10)) as dense_bc:
+        a = we.random.randn(n, n)
+        b = we.random.randn(n, n)
+        _ = np.add.outer(a, b)
+    with we.BudgetContext(flop_budget=int(1e10)) as sym_bc:
+        a = we.symmetrize(we.random.randn(n, n), symmetry=sym)
+        b = we.symmetrize(we.random.randn(n, n), symmetry=sym)
+        _ = np.add.outer(a, b)
+    # Symmetric is strictly cheaper than dense (input setup cost is the
+    # same for both; only the outer-op portion shrinks).
+    assert sym_bc.flops_used < dense_bc.flops_used
+
+
+def test_np_subtract_reduce_uses_generic_path():
+    """Non-table reduces (``subtract``, ``true_divide``, …) route through
+    the generic ``_counted_ufunc_reduce_generic`` fallback."""
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([10.0, 3.0, 2.0, 1.0])
+        result = np.subtract.reduce(a)
+    assert float(result) == 4.0  # 10 - 3 - 2 - 1
+    assert bc.flops_used > 0
+
+
+def test_np_subtract_accumulate_uses_generic_path():
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([10.0, 3.0, 2.0, 1.0])
+        result = np.subtract.accumulate(a)
+    np.testing.assert_array_equal(np.asarray(result), [10.0, 7.0, 5.0, 4.0])
+    assert bc.flops_used > 0
+
+
+def test_np_add_reduceat_routes_through_array_ufunc():
+    """``ufunc.reduceat`` segments are tracked; output symmetry is
+    dropped (segment boundaries don't respect axis-permutation
+    invariance)."""
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        result = np.add.reduceat(a, [0, 3])
+    np.testing.assert_array_equal(np.asarray(result), [6.0, 15.0])
+    assert bc.flops_used > 0
+
+
+def test_np_add_at_on_plain_whest_array_mutates_in_place():
+    """``np.add.at(WhestArray, indices, values)`` mutates the underlying
+    array — repeated indices accumulate (unlike ``a[indices] +=``)."""
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([0.0, 0.0, 0.0])
+        result = np.add.at(a, [0, 0, 1], [1.0, 2.0, 3.0])
+    assert result is None  # ufunc.at returns None
+    np.testing.assert_array_equal(np.asarray(a), [3.0, 3.0, 0.0])
+    assert bc.flops_used > 0
+
+
+def test_np_add_at_on_symmetric_tensor_refuses():
+    """``ufunc.at`` on a SymmetricTensor would corrupt the tagged
+    symmetry; whest refuses with a directive to downgrade first."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        sym = we.SymmetryGroup.symmetric(axes=(0, 1))
+        S = we.symmetrize(we.array([[1.0, 2.0], [2.0, 3.0]]), symmetry=sym)
+        with pytest.raises(ValueError, match="symmetry"):
+            np.add.at(S, ([0],), 1.0)
 
 
 # ----- Multi-output ufuncs route through __array_ufunc__ -----

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -188,16 +188,14 @@ def test_np_add_out_allows_matching_symmetric_out():
     assert bc.flops_used > 0
 
 
-def test_np_transpose_on_whest_fails_loudly_until_supported():
-    """Structural NumPy ops are intentionally NOT in the
-    ``__array_function__`` allowlist. ``np.transpose(whest)`` must
-    therefore raise ``TypeError`` rather than silently strip
-    symmetry. ``A.T`` (property form) goes through ``__array_finalize__``
-    and continues to work — covered by
-    ``test_transpose_of_symmetric_preserves_type`` below."""
+def test_np_transpose_of_whest_returns_whest():
+    """Post-Stage-4: np.transpose dispatches via __array_function__ to
+    me.transpose, which works on WhestArray (zero-FLOP shape op)."""
     a = we.random.randn(2, 3)
-    with pytest.raises(TypeError):
-        np.transpose(a)
+    with we.BudgetContext(flop_budget=int(1e9)):
+        r = np.transpose(a)
+    assert isinstance(r, we.ndarray)
+    assert r.shape == (3, 2)
 
 
 def test_np_add_where_kwarg_tracks():

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -15,7 +15,6 @@ import pytest
 
 import whest as we
 
-
 # ----- __array_ufunc__: ufunc.__call__ -----
 
 UFUNC_CALL_CASES = [
@@ -48,6 +47,7 @@ def test_np_unary_ufunc_call_tracks_flops():
 
 
 # ----- __array_ufunc__: ufunc.reduce -----
+
 
 def test_np_add_reduce_tracks_flops():
     a = we.random.randn(8)
@@ -82,6 +82,7 @@ def test_np_add_reduce_2d_matches_axis0_semantics():
 
 # ----- __array_ufunc__: ufunc.accumulate -----
 
+
 def test_np_add_accumulate_tracks_flops():
     a = we.random.randn(8)
     with we.BudgetContext(flop_budget=int(1e9)) as b1:
@@ -104,6 +105,7 @@ def test_np_add_accumulate_2d_matches_axis0_semantics():
 
 
 # ----- Recursion guards (regression-only) -----
+
 
 def test_dunder_does_not_recurse_after_protocol_enabled():
     """WhestArray.__add__ → me.add → _np.add must NOT re-dispatch through
@@ -135,6 +137,7 @@ def test_np_sort_does_not_recurse():
 
 
 # ----- ufunc kwargs passthrough -----
+
 
 def test_np_add_out_unwraps_single_output_tuple():
     """NumPy passes out=(out_arr,) to __array_ufunc__; whest expects out=arr."""
@@ -228,6 +231,7 @@ def test_np_add_dtype_kwarg_tracks():
 
 # ----- Mixed operands: numpy on left, whest on right -----
 
+
 def test_mixed_numpy_left_operand_dispatches():
     """np.ndarray + WhestArray must still dispatch through whest tracking
     (NEP 13: NumPy defers to subclasses' __array_ufunc__)."""
@@ -247,6 +251,7 @@ def test_mixed_python_scalar_left_dispatches():
 
 
 # ----- In-place dunder identity preservation -----
+
 
 def test_inplace_add_preserves_identity():
     """a += b must mutate a, not rebind it. Currently broken on
@@ -290,6 +295,7 @@ def test_inplace_add_refuses_when_symmetry_would_be_destroyed():
 
 # ----- Unsupported ufunc methods fail loudly -----
 
+
 def test_np_add_outer_fails_loudly():
     """ufunc.outer is not yet implemented; must raise rather than silently
     bypass tracking."""
@@ -315,6 +321,7 @@ def test_np_add_at_fails_loudly():
 
 
 # ----- Multi-output ufuncs fail loudly -----
+
 
 def test_np_modf_fails_loudly():
     """``np.modf`` is a multi-output ufunc (nout=2). Until whest supports
@@ -350,6 +357,7 @@ def test_we_modf_rejects_out_kwarg():
 
 # ----- Recursion guard for raw whest functions -----
 
+
 def test_we_add_does_not_recurse_after_protocol_enabled():
     """``we.add(WhestArray, WhestArray)`` must not enter an infinite loop
     via ``_np.add`` → ``__array_ufunc__`` → ``we.add`` → ... after Task
@@ -367,6 +375,7 @@ def test_we_add_does_not_recurse_after_protocol_enabled():
 
 
 # ----- __array_function__: np.<func>(whest) -----
+
 
 def test_np_sort_tracks_flops():
     a = we.random.randn(8)
@@ -407,6 +416,7 @@ def test_np_sum_routes_to_whest():
 
 # ----- Structural ops on SymmetricTensor: type follows surviving symmetry -----
 
+
 def test_diagonal_of_3sym_downgrades_when_no_tensor_axis_symmetry_remains():
     """Diagonal of a (n,n,n) tensor with full S_3 symmetry along (0,1,2)
     collapses axes 0/1 (or any pair) into a single diagonal axis, which
@@ -436,8 +446,10 @@ def test_transpose_of_symmetric_preserves_type():
 
 # ----- Helper unit tests -----
 
+
 def test_to_base_ndarray_strips_whest_subclass():
-    from whest._ndarray import _to_base_ndarray, WhestArray
+    from whest._ndarray import WhestArray, _to_base_ndarray
+
     a = we.random.randn(4)
     base = _to_base_ndarray(a)
     assert type(base) is np.ndarray
@@ -448,12 +460,14 @@ def test_to_base_ndarray_strips_whest_subclass():
 
 def test_to_base_ndarray_preserves_python_scalar():
     from whest._ndarray import _to_base_ndarray
+
     assert _to_base_ndarray(2.0) == 2.0
     assert isinstance(_to_base_ndarray(2.0), float)
 
 
 def test_to_base_ndarray_tree_strips_in_tuple():
     from whest._ndarray import _to_base_ndarray_tree
+
     a = we.random.randn(4)
     b = we.random.randn(4)
     out = _to_base_ndarray_tree((a, b))
@@ -462,6 +476,7 @@ def test_to_base_ndarray_tree_strips_in_tuple():
 
 def test_to_base_ndarray_tree_strips_in_list():
     from whest._ndarray import _to_base_ndarray_tree
+
     a = we.random.randn(4)
     b = we.random.randn(4)
     out = _to_base_ndarray_tree([a, b])
@@ -470,12 +485,14 @@ def test_to_base_ndarray_tree_strips_in_list():
 
 def test_to_base_ndarray_tree_preserves_scalars():
     from whest._ndarray import _to_base_ndarray_tree
+
     out = _to_base_ndarray_tree((1.0, 2, "x"))
     assert out == (1.0, 2, "x")
 
 
 def test_to_base_ndarray_tree_recurses_into_nested():
     from whest._ndarray import _to_base_ndarray_tree
+
     a = we.random.randn(4)
     out = _to_base_ndarray_tree([(a, 1.0), [a]])
     assert type(out[0][0]) is np.ndarray
@@ -483,6 +500,7 @@ def test_to_base_ndarray_tree_recurses_into_nested():
 
 
 # ----- _PASSTHROUGH lock-in -----
+
 
 def test_np_type_query_passthrough_does_not_charge_flops():
     """``np.result_type``, ``np.can_cast``, ``np.min_scalar_type``, etc.
@@ -499,10 +517,12 @@ def test_np_type_query_passthrough_does_not_charge_flops():
 
 # ----- Cache-verification test (Stage 2 helper added in Step 2.2) -----
 
+
 def test_signature_kwargs_accepted_is_cached():
     """The signature lookup must be cached — it sits on the per-ufunc
     hot path. PR #51 memoized similar helpers; we do the same here."""
     from whest._ndarray import _signature_kwargs_accepted
+
     # Same callable should return the same frozenset object (cached).
     a = _signature_kwargs_accepted(np.add)
     b = _signature_kwargs_accepted(np.add)
@@ -528,18 +548,19 @@ def test_perf_warm_rank8_scalar_comparison_is_fast():
     order-of-magnitude regressions without flaking on machine variance.
     """
     import time
+
     a = we.full((2,) * 8, 1)  # rank-8, 256 elements, full S_8 symmetric group
     # Warm-up: prime the per-instance _canonical_axis_action cache and the
     # @functools.cache on unique_elements_for_shape.
     with we.BudgetContext(flop_budget=int(1e12)):
-        _ = (a == 1)
+        _ = a == 1
     # Measure the warm path.
     with we.BudgetContext(flop_budget=int(1e12)):
         t0 = time.perf_counter()
-        _ = (a == 1)
+        _ = a == 1
         elapsed = time.perf_counter() - t0
     assert elapsed < 0.1, (
-        f"warm rank-8 scalar comparison took {elapsed*1000:.1f}ms; "
+        f"warm rank-8 scalar comparison took {elapsed * 1000:.1f}ms; "
         f"PR #51 fixed this to ~0.04ms. Are we re-introducing O(|G|) "
         f"work in __eq__ / _canonical_axis_action / "
         f"unique_elements_for_shape, or making OWNDATA-preserving "
@@ -558,6 +579,7 @@ def test_perf_array_ufunc_dispatch_does_not_copy():
     redundant view-cast that triggers a finalize chain.
     """
     import time
+
     a = we.random.randn(1024)
     b = we.random.randn(1024)
     # Warm-up.
@@ -599,10 +621,9 @@ def test_perf_warm_inplace_add_scalar_on_symmetric_is_fast():
     along the dispatch chain.
     """
     import time
+
     arr = we.random.randn(4, 4, 4, 4)
-    A_sym = we.symmetrize(
-        arr, symmetry=we.SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
-    )
+    A_sym = we.symmetrize(arr, symmetry=we.SymmetryGroup.symmetric(axes=(0, 1, 2, 3)))
     original_symmetry_ref = A_sym._symmetry
     # Warm-up: prime caches and dispatch tables.
     with we.BudgetContext(flop_budget=int(1e12)):
@@ -618,12 +639,12 @@ def test_perf_warm_inplace_add_scalar_on_symmetric_is_fast():
         A_sym += 1.0
         elapsed = time.perf_counter() - t0
     assert elapsed < 0.05, (
-        f"warm A_sym += 1.0 took {elapsed*1000:.1f}ms; "
+        f"warm A_sym += 1.0 took {elapsed * 1000:.1f}ms; "
         f"PR #51 made this the scalar fast path. Are we missing the "
         f"identity short-circuit in _inplace_from_result, or wrapping "
         f"the scalar in an array in __iadd__ before dispatch?"
     )
     assert A_sym._symmetry is original_symmetry_ref, (
-        f"warm in-place add lost symmetry object identity; "
-        f"_inplace_from_result is constructing a fresh group somewhere"
+        "warm in-place add lost symmetry object identity; "
+        "_inplace_from_result is constructing a fresh group somewhere"
     )

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -574,3 +574,56 @@ def test_perf_array_ufunc_dispatch_does_not_copy():
         f"are we re-introducing per-call copies or O(|G|) work in "
         f"__array_ufunc__ / _filter_to_np_signature?"
     )
+
+
+def test_perf_warm_inplace_add_scalar_on_symmetric_is_fast():
+    """Warm ``A_sym += 1.0`` on a rank-4 SymmetricTensor must finish
+    well under 50 ms, AND must preserve the symmetry object identity.
+
+    This pins three PR #51 fast paths for the in-place dunder rewrite:
+    - class 4 (``_counted_binary`` scalar fast path) — ``A_sym + 1.0``
+      flows through the scalar branch that returns the operand's
+      symmetry unchanged (same object reference).
+    - class 5 (``SymmetryGroup.__eq__`` identity short-circuit) —
+      ``_inplace_from_result`` does ``self_sym != result_sym``; for
+      scalar ops these are the SAME instance, hitting the identity
+      short-circuit and skipping the O(|G|) ``_canonical_axis_action``
+      comparison.
+    - class 6 (per-instance ``_canonical_axis_action`` cache) — even
+      if identity short-circuit somehow misses, the cache still keeps
+      subsequent calls O(1).
+
+    If this test fails with elapsed > 50 ms or identity is lost, the
+    in-place dunder rewrite is constructing a fresh ``SymmetryGroup``
+    for comparison or wrapping the scalar into an array somewhere
+    along the dispatch chain.
+    """
+    import time
+    arr = we.random.randn(4, 4, 4, 4)
+    A_sym = we.symmetrize(
+        arr, symmetry=we.SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
+    )
+    original_symmetry_ref = A_sym._symmetry
+    # Warm-up: prime caches and dispatch tables.
+    with we.BudgetContext(flop_budget=int(1e12)):
+        A_sym += 1.0
+    # The above mutated A_sym; verify identity preserved through warm-up.
+    assert A_sym._symmetry is original_symmetry_ref, (
+        "warm-up in-place add lost symmetry object identity; "
+        "_inplace_from_result is constructing a fresh group somewhere"
+    )
+    # Measure the warm path.
+    with we.BudgetContext(flop_budget=int(1e12)):
+        t0 = time.perf_counter()
+        A_sym += 1.0
+        elapsed = time.perf_counter() - t0
+    assert elapsed < 0.05, (
+        f"warm A_sym += 1.0 took {elapsed*1000:.1f}ms; "
+        f"PR #51 made this the scalar fast path. Are we missing the "
+        f"identity short-circuit in _inplace_from_result, or wrapping "
+        f"the scalar in an array in __iadd__ before dispatch?"
+    )
+    assert A_sym._symmetry is original_symmetry_ref, (
+        f"warm in-place add lost symmetry object identity; "
+        f"_inplace_from_result is constructing a fresh group somewhere"
+    )

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 import whest as we
+from whest._ndarray import WhestArray
 
 # ----- __array_ufunc__: ufunc.__call__ -----
 
@@ -320,39 +321,182 @@ def test_np_add_at_fails_loudly():
             np.add.at(a, [0, 1], 1.0)
 
 
-# ----- Multi-output ufuncs fail loudly -----
+# ----- Multi-output ufuncs route through __array_ufunc__ -----
 
 
-def test_np_modf_fails_loudly():
-    """``np.modf`` is a multi-output ufunc (nout=2). Until whest supports
-    multi-output ``out=(out1, out2)`` properly, it must raise rather than
-    silently bypass tracking on either return slot."""
-    a = we.random.randn(8) + 0.5
-    with we.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises((NotImplementedError, TypeError)):
-            np.modf(a)
+def test_np_divmod_routes_to_we_divmod():
+    """``np.divmod(WhestArray, WhestArray)`` dispatches to ``we.divmod``
+    via ``__array_ufunc__``, returns a tuple of WhestArrays, and
+    deducts FLOPs."""
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([10.0, 20.0, 30.0])
+        b = we.array([3.0, 4.0, 5.0])
+        q, r = np.divmod(a, b)
+    assert isinstance(q, WhestArray)
+    assert isinstance(r, WhestArray)
+    np.testing.assert_array_equal(np.asarray(q), [3.0, 5.0, 6.0])
+    np.testing.assert_array_equal(np.asarray(r), [1.0, 0.0, 0.0])
+    assert bc.flops_used > 0
 
 
-def test_np_frexp_fails_loudly():
-    a = we.random.randn(8) + 1.5
-    with we.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises((NotImplementedError, TypeError)):
-            np.frexp(a)
+def test_np_modf_routes_to_we_modf():
+    """``np.modf`` (nout=2) routes through ``__array_ufunc__`` and
+    returns ``(frac, integer)`` as WhestArrays with FLOPs deducted."""
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([1.5, 2.7, 3.0])
+        frac, integer = np.modf(a)
+    assert isinstance(frac, WhestArray)
+    assert isinstance(integer, WhestArray)
+    np.testing.assert_allclose(np.asarray(integer), [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(np.asarray(frac), [0.5, 0.7, 0.0], atol=1e-12)
+    assert bc.flops_used > 0
 
 
-def test_we_modf_rejects_out_kwarg():
-    """The direct ``we.modf(a, out=...)`` path goes through
-    ``_counted_unary_multi`` (not ``__array_ufunc__``) because the
-    operands are already whest. It must reject ``out=`` explicitly with
-    NotImplementedError rather than silently letting NumPy write into
-    whest-typed buffers (which would recurse through
-    ``__array_function__`` and double-charge)."""
-    a = we.random.randn(8) + 0.5
-    out1 = we.empty_like(a)
-    out2 = we.empty_like(a)
-    with we.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises(NotImplementedError, match="out"):
-            we.modf(a, out=(out1, out2))
+def test_np_frexp_routes_to_we_frexp():
+    """``np.frexp`` returns ``(mantissa, exponent)`` with the exponent
+    in integer dtype; both reach the caller as WhestArrays."""
+    with we.BudgetContext(flop_budget=int(1e10)) as bc:
+        a = we.array([1.5, 2.7, 3.0])
+        mantissa, exponent = np.frexp(a)
+    assert isinstance(mantissa, WhestArray)
+    assert isinstance(exponent, WhestArray)
+    assert np.issubdtype(exponent.dtype, np.integer)
+    assert bc.flops_used > 0
+
+
+def test_np_divmod_with_out_tuple_preserves_identity():
+    """``np.divmod(a, b, out=(q, r))`` writes through both buffers and
+    returns the same Python objects (per-slot identity contract)."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        a = we.array([10.0, 20.0])
+        b = we.array([3.0, 4.0])
+        q = we.zeros(2)
+        r = we.zeros(2)
+        result = np.divmod(a, b, out=(q, r))
+    assert result[0] is q
+    assert result[1] is r
+    np.testing.assert_array_equal(np.asarray(q), [3.0, 5.0])
+    np.testing.assert_array_equal(np.asarray(r), [1.0, 0.0])
+
+
+def test_np_modf_with_out_tuple_preserves_identity():
+    with we.BudgetContext(flop_budget=int(1e10)):
+        a = we.array([1.5, 2.7, 3.0])
+        frac = we.zeros(3)
+        integer = we.zeros(3)
+        result = np.modf(a, out=(frac, integer))
+    assert result[0] is frac
+    assert result[1] is integer
+    np.testing.assert_allclose(np.asarray(integer), [1.0, 2.0, 3.0])
+
+
+def test_np_divmod_with_partial_out_allocates_remaining():
+    """``out=(q, None)`` writes through ``q`` and lets numpy allocate
+    the second buffer; the freshly-allocated slot comes back as a
+    WhestArray."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        a = we.array([10.0, 20.0])
+        b = we.array([3.0, 4.0])
+        q = we.zeros(2)
+        result = np.divmod(a, b, out=(q, None))
+    assert result[0] is q
+    assert isinstance(result[1], WhestArray)
+    np.testing.assert_array_equal(np.asarray(q), [3.0, 5.0])
+    np.testing.assert_array_equal(np.asarray(result[1]), [1.0, 0.0])
+
+
+def test_np_modf_with_positional_out_args():
+    """NumPy normalises positional out args (``np.modf(a, o1, o2)``)
+    into ``out=(o1, o2)`` before reaching ``__array_ufunc__``."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        a = we.array([1.5, 2.7, 3.0])
+        o1 = we.zeros(3)
+        o2 = we.zeros(3)
+        result = np.modf(a, o1, o2)
+    assert result[0] is o1
+    assert result[1] is o2
+
+
+def test_np_divmod_preserves_shared_symmetry():
+    """``np.divmod`` of two SymmetricTensors that share an axis-permutation
+    group produces both outputs as SymmetricTensors with the same
+    symmetry."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        sym = we.SymmetryGroup.symmetric(axes=(0, 1))
+        a = we.symmetrize(we.array([[10.0, 12.0], [12.0, 14.0]]), symmetry=sym)
+        b = we.symmetrize(we.array([[3.0, 4.0], [4.0, 5.0]]), symmetry=sym)
+        q, r = np.divmod(a, b)
+    assert isinstance(q, we.SymmetricTensor)
+    assert isinstance(r, we.SymmetricTensor)
+    assert q.symmetry == sym
+    assert r.symmetry == sym
+
+
+def test_np_modf_preserves_input_symmetry():
+    """``np.modf`` is unary elementwise; both outputs inherit the
+    SymmetricTensor symmetry of the input."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        sym = we.SymmetryGroup.symmetric(axes=(0, 1))
+        S = we.symmetrize(we.array([[1.5, 2.5], [2.5, 3.5]]), symmetry=sym)
+        frac, integer = np.modf(S)
+    assert isinstance(frac, we.SymmetricTensor)
+    assert isinstance(integer, we.SymmetricTensor)
+    assert frac.symmetry == sym
+    assert integer.symmetry == sym
+
+
+def test_np_divmod_loses_unshared_symmetry_with_warning():
+    """When inputs don't share symmetry, both outputs degrade to plain
+    WhestArray and a SymmetryLossWarning is emitted (parity with
+    single-output binary ufuncs)."""
+    import warnings as _warnings
+
+    with we.BudgetContext(flop_budget=int(1e10)):
+        a = we.symmetrize(
+            we.array([[10.0, 12.0], [12.0, 14.0]]),
+            symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+        )
+        b = we.array([[3.0, 4.0], [5.0, 6.0]])  # not symmetric
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            q, r = np.divmod(a, b)
+    messages = [str(item.message).lower() for item in caught]
+    assert any("symmetry" in m for m in messages), messages
+    assert type(q) is WhestArray
+    assert type(r) is WhestArray
+
+
+def test_np_divmod_scalar_left_preserves_array_symmetry():
+    """``np.divmod(scalar, symmetric)`` inherits the array's symmetry on
+    both outputs (scalar special-case in ``_counted_binary_multi``)."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        sym = we.SymmetryGroup.symmetric(axes=(0, 1))
+        S = we.symmetrize(we.array([[3.0, 4.0], [4.0, 5.0]]), symmetry=sym)
+        q, r = np.divmod(20.0, S)
+    assert isinstance(q, we.SymmetricTensor)
+    assert isinstance(r, we.SymmetricTensor)
+    assert q.symmetry == sym
+
+
+def test_we_modf_invalid_out_tuple_length_raises():
+    """``out=`` of wrong length is rejected by the multi-output helper
+    rather than silently passed through to numpy (which would error
+    later with a less helpful message)."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        a = we.array([1.5, 2.5, 3.0])
+        single = we.zeros(3)
+        with pytest.raises(TypeError, match="length"):
+            we.modf(a, out=(single,))
+
+
+def test_we_modf_invalid_out_type_raises():
+    """``out=`` that is not a tuple is rejected by the multi-output
+    helper for clarity."""
+    with we.BudgetContext(flop_budget=int(1e10)):
+        a = we.array([1.5, 2.5, 3.0])
+        single = we.zeros(3)
+        with pytest.raises(TypeError, match="tuple"):
+            we.modf(a, out=single)
 
 
 # ----- Recursion guard for raw whest functions -----

--- a/tests/test_method_tracking.py
+++ b/tests/test_method_tracking.py
@@ -1,0 +1,424 @@
+"""Tests verifying ndarray methods, NumPy protocols, and SymmetricTensor type
+consolidation track FLOPs and propagate symmetry correctly.
+
+Each test pins one bug from #58 (method calls), #38 (SymmetricTensor dunders),
+or #62 (no-symmetry SymmetricTensor type ambiguity).
+
+Translated against post-PR-#51 unified SymmetryGroup API.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import whest as we
+
+
+# ----- #58: ndarray method calls on WhestArray must track FLOPs -----
+
+REDUCTION_METHODS = [
+    ("sum", lambda a: a.sum()),
+    ("mean", lambda a: a.mean()),
+    ("max", lambda a: a.max()),
+    ("min", lambda a: a.min()),
+    ("prod", lambda a: a.prod()),
+    ("std", lambda a: a.std()),
+    ("var", lambda a: a.var()),
+    ("argmax", lambda a: a.argmax()),
+    ("argmin", lambda a: a.argmin()),
+    ("cumsum", lambda a: a.cumsum()),
+    ("cumprod", lambda a: a.cumprod()),
+]
+
+
+@pytest.mark.parametrize("name,op", REDUCTION_METHODS)
+def test_reduction_method_tracks_flops(name, op):
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        op(a)
+    assert bc.flops_used > 0, f"{name}() method bypassed FLOP tracking"
+
+
+@pytest.mark.parametrize("name,op", REDUCTION_METHODS)
+def test_reduction_method_matches_function(name, op):
+    """a.foo() must produce the same FLOP count as we.foo(a)."""
+    we_func = getattr(we, name)
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        op(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we_func(a)
+    assert b1.flops_used == b2.flops_used, (
+        f"{name}: method={b1.flops_used}, function={b2.flops_used}"
+    )
+
+
+# ----- Non-protocol ndarray methods (need explicit overrides) -----
+
+# These methods do NOT route through __array_ufunc__ or __array_function__,
+# so a method override on WhestArray is the only way to track them.
+
+NON_PROTOCOL_METHODS = [
+    ("dot", lambda a: a.dot(a)),
+    ("argsort", lambda a: a.argsort()),
+    ("argpartition", lambda a: a.argpartition(2)),
+    ("take", lambda a: a.take([0, 1, 2])),
+    ("repeat", lambda a: a.repeat(2)),
+    # ``compress`` requires a boolean condition the same length as a's first axis.
+    ("compress", lambda a: a.compress([True] * a.shape[0])),
+    ("conj", lambda a: a.conj()),
+    ("conjugate", lambda a: a.conjugate()),
+    ("clip", lambda a: a.clip(-1.0, 1.0)),
+    ("round", lambda a: a.round()),
+    ("trace", lambda a: a.reshape(2, 4).trace()),
+    ("ptp", lambda a: a.ptp()),
+]
+
+
+@pytest.mark.parametrize("name,op", NON_PROTOCOL_METHODS)
+def test_non_protocol_method_tracks_flops(name, op):
+    """Methods that bypass both __array_ufunc__ and __array_function__
+    (``a.dot``, ``a.argsort``, etc.) must be explicitly overridden on
+    WhestArray to track FLOPs."""
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        op(a)
+    assert bc.flops_used > 0, f"{name}() bypassed FLOP tracking"
+
+
+def test_searchsorted_method_tracks():
+    """``searchsorted`` is non-protocol but needs a sorted array; build
+    one with plain NumPy *outside* any budget so the method-call FLOPs
+    are the only thing in ``bc.flops_used``. Calling ``we.sort`` /
+    ``we.random.randn`` outside a budget would itself raise.
+    """
+    sorted_arr = np.sort(np.random.randn(8)).view(we.ndarray)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        sorted_arr.searchsorted(0.0)
+    assert bc.flops_used > 0
+
+
+# ----- In-place sort / partition -----
+
+def test_inplace_sort_method_tracks_and_mutates():
+    """``a.sort()`` mutates ``a`` in place and returns ``None``. The
+    method override must charge FLOPs through ``me.sort``."""
+    a = we.random.randn(8)
+    old_id = id(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        ret = a.sort()
+    assert ret is None
+    assert id(a) == old_id
+    assert bc.flops_used > 0
+    # ``a`` is now sorted ascending
+    assert np.all(np.diff(np.asarray(a)) >= 0)
+
+
+def test_inplace_partition_method_tracks_and_mutates():
+    a = we.random.randn(8)
+    old_id = id(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        ret = a.partition(3)
+    assert ret is None
+    assert id(a) == old_id
+    assert bc.flops_used > 0
+
+
+def test_inplace_sort_on_symmetric_refuses():
+    """``A_sym.sort()`` would scramble axis order and break the symmetry
+    metadata. The method override must raise rather than silently
+    corrupt the metadata."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises(ValueError, match="symmetry"):
+            A.sort()
+
+
+def test_inplace_partition_on_symmetric_refuses():
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises(ValueError, match="symmetry"):
+            A.partition(2)
+
+
+# ----- Adversarial axis / keepdims / dtype / out coverage -----
+
+def test_method_axis_none_tracks():
+    a = we.random.randn(4, 5)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        a.sum(axis=None)
+    assert bc.flops_used > 0
+
+
+def test_method_negative_axis_tracks():
+    a = we.random.randn(4, 5)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        a.sum(axis=-1)
+    assert bc.flops_used > 0
+
+
+def test_method_tuple_axis_tracks():
+    a = we.random.randn(4, 5, 6)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        a.sum(axis=(0, 2))
+    assert bc.flops_used > 0
+
+
+def test_method_keepdims_tracks():
+    a = we.random.randn(4, 5)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        r = a.sum(axis=0, keepdims=True)
+    assert bc.flops_used > 0
+    assert r.shape == (1, 5)
+
+
+def test_method_dtype_tracks():
+    a = we.random.randn(8).astype(np.float32)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        r = a.sum(dtype=np.float64)
+    assert bc.flops_used > 0
+    assert r.dtype == np.float64
+
+
+def test_method_positional_dtype_tracks():
+    """``a.sum(0, np.float64)`` passes axis and dtype positionally (NumPy
+    signature is ``sum(a, axis, dtype, out, ...)``). The method override
+    must forward through to ``_counted_reduction`` without dropping the
+    positional dtype arg."""
+    a = we.random.randn(4, 5).astype(np.float32)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        r = a.sum(0, np.float64)
+    assert bc.flops_used > 0
+    assert r.dtype == np.float64
+    assert r.shape == (5,)
+
+
+def test_method_out_tracks_and_returns_out():
+    a = we.random.randn(4, 5)
+    out = we.zeros(5)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        ret = a.sum(axis=0, out=out)
+    assert bc.flops_used > 0
+    assert ret is out
+
+
+def test_method_positional_out_tracks_and_returns_out():
+    """``a.sum(axis, dtype, out)`` passes ``out`` *positionally* in the
+    fourth slot. The reduction wrapper must (a) detect positional ``out``
+    via signature inspection, (b) strip its whest subclass before the
+    underlying ``np.sum`` call so ``__array_function__`` does not
+    re-dispatch and double-charge, and (c) return the original ``out``
+    object (identity) rather than a re-wrapped view.
+    """
+    a = we.random.randn(4, 5)
+    out = we.zeros(5)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        ret = a.sum(0, None, out)  # axis=0, dtype=None, out=out (positional)
+    assert bc.flops_used > 0
+    assert ret is out
+    # Cross-check: same FLOP count as the kwarg form.
+    out2 = we.zeros(5)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc2:
+        a.sum(axis=0, out=out2)
+    assert bc.flops_used == bc2.flops_used
+
+
+def test_method_positional_out_argmax_tracks_and_returns_out():
+    """``argmax`` has a different positional layout than ``sum``:
+    NumPy's signature is ``argmax(a, axis=None, out=None, *, keepdims)``.
+    The wrapper's signature inspection must locate ``out`` at the
+    correct positional slot for *each* underlying NumPy function — not
+    just the ``sum``-shaped layout."""
+    a = we.random.randn(4, 5)
+    out = we.zeros(5, dtype=np.intp)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc:
+        ret = a.argmax(0, out)  # axis=0, out=out (positional, no dtype slot)
+    assert bc.flops_used > 0
+    assert ret is out
+
+
+# ----- Symmetry propagation through methods -----
+
+def test_method_propagates_symmetry_through_reduction():
+    """Issue #58: A.sum(axis=0) on a SymmetricTensor must propagate symmetry."""
+    n = 10
+    A = we.symmetrize(
+        we.random.randn(n, n, n),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1, 2)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        S_method = A.sum(axis=0)
+        S_func = we.sum(A, axis=0)
+    # Compare via SymmetryGroup value-equality (post-PR-#51).
+    assert S_method.symmetry == S_func.symmetry
+    assert S_method.symmetry is not None  # surviving symmetry
+
+
+def test_no_double_counting_method_vs_function():
+    """a.sum() should not double-charge by routing through both methods and
+    me.sum (which itself shouldn't re-dispatch via __array_ufunc__).
+    """
+    a = we.random.randn(8)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc1:
+        a.sum()
+    with we.BudgetContext(flop_budget=int(1e9)) as bc2:
+        we.sum(a)
+    with we.BudgetContext(flop_budget=int(1e9)) as bc3:
+        np.sum(a)
+    assert bc1.flops_used == bc2.flops_used == bc3.flops_used > 0
+
+
+# ----- #38: dunder operators on SymmetricTensor must track FLOPs -----
+
+def test_sym_mul_tracks_flops():
+    """Issue #38: SymmetricTensor * SymmetricTensor must track FLOPs."""
+    n = 10
+    A = we.symmetrize(
+        we.random.randn(n, n),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        A * A
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.multiply(A, A)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+def test_sym_add_tracks_flops():
+    n = 10
+    A = we.symmetrize(
+        we.random.randn(n, n),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)) as b1:
+        A + A
+    with we.BudgetContext(flop_budget=int(1e9)) as b2:
+        we.add(A, A)
+    assert b1.flops_used == b2.flops_used > 0
+
+
+# ----- #62: SymmetricTensor with no surviving symmetry should downgrade -----
+# Note: PR #51 implements the downgrade architecturally (via __array_finalize__
+# + __array_wrap__); the original v1 plan's tests for empty-axes /
+# singleton-axes / order-one as_symmetric construction are no longer expressible
+# in the new API (it requires a SymmetryGroup; "empty axes" is not a valid
+# input). We keep only the downgrade tests that are still expressible.
+
+def test_no_symmetry_downgrades_to_whest_array_via_diagonal():
+    """Issue #62: ``we.diagonal`` of a 2-axis-symmetric matrix has no
+    surviving symmetry → result is a WhestArray, not a SymmetricTensor."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        d = we.diagonal(A)
+    assert not isinstance(d, we.SymmetricTensor), (
+        f"got {type(d).__name__} with empty symmetry; expected WhestArray"
+    )
+    assert isinstance(d, we.ndarray)
+
+
+def test_no_symmetry_downgrades_via_full_reduction():
+    """Reducing all symmetric axes should downgrade to WhestArray (or scalar)."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        s = A.sum()  # scalar — but if returned as array, must be WhestArray
+    assert not isinstance(s, we.SymmetricTensor)
+
+
+# ----- Scalar __getitem__ on SymmetricTensor returns Python scalar -----
+
+def test_symmetric_getitem_scalar_returns_python_scalar():
+    """``A[0, 0]`` on a 2D SymmetricTensor returns a single element. It
+    must come back as a Python scalar (``np.isscalar`` true), not a 0-d
+    ndarray, to match plain ndarray semantics."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        v = A[0, 0]
+    assert np.isscalar(v), f"expected Python scalar, got {type(v).__name__}"
+
+
+def test_symmetric_getitem_full_reduction_via_indexing_returns_whest_array():
+    """``A[0]`` on a 2D symmetric (axes=(0,1)) collapses one axis; the
+    remaining 1D slice has no surviving 2-axis group → WhestArray."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        row = A[0]
+    assert not isinstance(row, we.SymmetricTensor)
+    assert isinstance(row, we.ndarray)
+    assert row.shape == (4,)
+
+
+# ----- Verbatim issue reproducers -----
+
+
+def test_issue_58_reproducer():
+    """Verbatim from https://github.com/AIcrowd/whest/issues/58
+    (translated to the post-PR-#51 SymmetryGroup API)."""
+    n = 10
+    with we.BudgetContext(flop_budget=int(1e20)) as bc:
+        with we.namespace("init"):
+            A = we.random.randn(n, n, n)
+            A = we.symmetrize(A, symmetry=we.SymmetryGroup.symmetric(axes=(0, 1, 2)))
+        with we.namespace("sum1"):
+            S1 = A.sum(axis=0)
+        with we.namespace("sum2"):
+            S2 = we.sum(A, axis=0)
+
+    by_ns = bc.summary_dict(by_namespace=True)["by_namespace"]
+    flops_sum1 = by_ns.get("sum1", {}).get("flops_used", 0)
+    flops_sum2 = by_ns.get("sum2", {}).get("flops_used", 0)
+    assert flops_sum1 > 0, "sum1 (method) bypassed tracking"
+    assert flops_sum1 == flops_sum2, (
+        f"method/function FLOP mismatch: {flops_sum1} vs {flops_sum2}"
+    )
+    assert S1.symmetry == S2.symmetry
+    assert S1.symmetry is not None  # surviving symmetry
+
+
+def test_issue_38_reproducer():
+    """Verbatim from https://github.com/AIcrowd/whest/issues/38."""
+    n = 10
+    with we.BudgetContext(flop_budget=int(1e20)) as bc:
+        with we.namespace("init"):
+            A = we.random.randn(n, n)
+            A = we.symmetrize(A, symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)))
+        with we.namespace("mult1"):
+            B = A * A
+        with we.namespace("mult2"):
+            B2 = we.multiply(A, A)
+
+    by_ns = bc.summary_dict(by_namespace=True)["by_namespace"]
+    flops_m1 = by_ns.get("mult1", {}).get("flops_used", 0)
+    flops_m2 = by_ns.get("mult2", {}).get("flops_used", 0)
+    assert flops_m1 == flops_m2 > 0
+
+
+def test_issue_62_reproducer():
+    """https://github.com/AIcrowd/whest/issues/62 — A SymmetricTensor with no
+    surviving symmetry should be a WhestArray, not an empty SymmetricTensor."""
+    A = we.symmetrize(
+        we.random.randn(4, 4),
+        symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+    )
+    with we.BudgetContext(flop_budget=int(1e9)):
+        d = we.diagonal(A)
+    assert not isinstance(d, we.SymmetricTensor)
+    assert isinstance(d, we.ndarray)

--- a/tests/test_method_tracking.py
+++ b/tests/test_method_tracking.py
@@ -14,7 +14,6 @@ import pytest
 
 import whest as we
 
-
 # ----- #58: ndarray method calls on WhestArray must track FLOPs -----
 
 REDUCTION_METHODS = [
@@ -101,6 +100,7 @@ def test_searchsorted_method_tracks():
 
 # ----- In-place sort / partition -----
 
+
 def test_inplace_sort_method_tracks_and_mutates():
     """``a.sort()`` mutates ``a`` in place and returns ``None``. The
     method override must charge FLOPs through ``me.sort``."""
@@ -149,6 +149,7 @@ def test_inplace_partition_on_symmetric_refuses():
 
 
 # ----- Adversarial axis / keepdims / dtype / out coverage -----
+
 
 def test_method_axis_none_tracks():
     a = we.random.randn(4, 5)
@@ -246,6 +247,7 @@ def test_method_positional_out_argmax_tracks_and_returns_out():
 
 # ----- Symmetry propagation through methods -----
 
+
 def test_method_propagates_symmetry_through_reduction():
     """Issue #58: A.sum(axis=0) on a SymmetricTensor must propagate symmetry."""
     n = 10
@@ -276,6 +278,7 @@ def test_no_double_counting_method_vs_function():
 
 
 # ----- #38: dunder operators on SymmetricTensor must track FLOPs -----
+
 
 def test_sym_mul_tracks_flops():
     """Issue #38: SymmetricTensor * SymmetricTensor must track FLOPs."""
@@ -311,6 +314,7 @@ def test_sym_add_tracks_flops():
 # in the new API (it requires a SymmetryGroup; "empty axes" is not a valid
 # input). We keep only the downgrade tests that are still expressible.
 
+
 def test_no_symmetry_downgrades_to_whest_array_via_diagonal():
     """Issue #62: ``we.diagonal`` of a 2-axis-symmetric matrix has no
     surviving symmetry → result is a WhestArray, not a SymmetricTensor."""
@@ -338,6 +342,7 @@ def test_no_symmetry_downgrades_via_full_reduction():
 
 
 # ----- Scalar __getitem__ on SymmetricTensor returns Python scalar -----
+
 
 def test_symmetric_getitem_scalar_returns_python_scalar():
     """``A[0, 0]`` on a 2D SymmetricTensor returns a single element. It

--- a/tests/test_ndarray_subclass_contract.py
+++ b/tests/test_ndarray_subclass_contract.py
@@ -14,13 +14,27 @@ def test_whestarray_ufunc_result_remains_subclass_and_can_be_view_backed():
     np.testing.assert_array_equal(result, np.full((2, 2), 2.0))
 
 
-def test_symmetric_tensor_ufunc_result_can_drop_to_plain_view_backed_whestarray():
+def test_symmetric_tensor_ufunc_result_preserves_symmetry():
+    """Post-v2 (``__array_ufunc__`` enabled), ``np.add(A_sym, A_sym)``
+    routes through ``me.add`` → ``_counted_binary`` → ``_pointwise_symmetry``,
+    which preserves the surviving symmetry of both operands. The result
+    therefore remains a ``SymmetricTensor`` carrying the same symmetry as
+    the inputs — it does NOT drop to a plain ``WhestArray``.
+
+    This supersedes the earlier ``..._can_drop_to_plain_view_backed_whestarray``
+    test from PR #51, which pinned the pre-v2 behaviour where ufunc
+    results lost symmetry metadata. With NEP-13 dispatch, that pathway
+    no longer fires for whest-typed operands.
+    """
     x = we.ones((2, 2))
+
+    assert isinstance(x, we.SymmetricTensor)
+    input_symmetry = x.symmetry
+    assert input_symmetry is not None
 
     result = np.add(x, x)
 
+    assert isinstance(result, we.SymmetricTensor)
     assert isinstance(result, WhestArray)
-    assert type(result) is WhestArray
-    assert result.base is not None
-    assert not hasattr(result, "symmetry")
+    assert result.symmetry == input_symmetry
     np.testing.assert_array_equal(result, np.full((2, 2), 2.0))

--- a/tests/test_pointwise_coverage.py
+++ b/tests/test_pointwise_coverage.py
@@ -664,6 +664,70 @@ class TestMultiOutputOps:
         assert numpy.allclose(result[0], ref[0])
         assert numpy.allclose(result[1], ref[1])
 
+    def test_modf_with_out_tuple(self):
+        x = numpy.array([1.5, 2.7, -3.2])
+        out_frac = numpy.zeros(3)
+        out_int = numpy.zeros(3)
+        with BudgetContext(flop_budget=10**6):
+            result = modf(x, out=(out_frac, out_int))
+        assert result[0] is out_frac
+        assert result[1] is out_int
+        ref = numpy.modf(x)
+        assert numpy.allclose(out_frac, ref[0])
+        assert numpy.allclose(out_int, ref[1])
+
+    def test_frexp_with_out_tuple(self):
+        x = numpy.array([2.0, 4.0, 8.0])
+        out_mant = numpy.zeros(3)
+        out_exp = numpy.zeros(3, dtype=numpy.int32)
+        with BudgetContext(flop_budget=10**6):
+            result = frexp(x, out=(out_mant, out_exp))
+        assert result[0] is out_mant
+        assert result[1] is out_exp
+        ref = numpy.frexp(x)
+        assert numpy.allclose(out_mant, ref[0])
+        assert numpy.array_equal(out_exp, ref[1])
+
+    def test_divmod_with_out_tuple(self):
+        x = numpy.array([7.0, 10.0, 13.0])
+        y = numpy.array([3.0, 4.0, 5.0])
+        out_q = numpy.zeros(3)
+        out_r = numpy.zeros(3)
+        with BudgetContext(flop_budget=10**6):
+            result = divmod(x, y, out=(out_q, out_r))
+        assert result[0] is out_q
+        assert result[1] is out_r
+        ref = numpy.divmod(x, y)
+        assert numpy.allclose(out_q, ref[0])
+        assert numpy.allclose(out_r, ref[1])
+
+    def test_divmod_with_partial_out(self):
+        x = numpy.array([7.0, 10.0])
+        y = numpy.array([3.0, 4.0])
+        out_q = numpy.zeros(2)
+        with BudgetContext(flop_budget=10**6):
+            result = divmod(x, y, out=(out_q, None))
+        assert result[0] is out_q
+        # Second slot was allocated by numpy; should still be a usable array
+        assert result[1] is not None
+        ref = numpy.divmod(x, y)
+        assert numpy.allclose(out_q, ref[0])
+        assert numpy.allclose(result[1], ref[1])
+
+    def test_modf_invalid_out_length_raises(self):
+        x = numpy.array([1.5, 2.7])
+        single = numpy.zeros(2)
+        with BudgetContext(flop_budget=10**6):
+            with pytest.raises(TypeError, match="length"):
+                modf(x, out=(single,))
+
+    def test_modf_invalid_out_type_raises(self):
+        x = numpy.array([1.5, 2.7])
+        single = numpy.zeros(2)
+        with BudgetContext(flop_budget=10**6):
+            with pytest.raises(TypeError, match="tuple"):
+                modf(x, out=single)
+
 
 # ---------------------------------------------------------------------------
 # 10. Scalar / 0-d array paths in unary and binary ops

--- a/tests/test_pointwise_coverage.py
+++ b/tests/test_pointwise_coverage.py
@@ -887,6 +887,61 @@ class TestCustomOps:
         # contracted = 4, result.size = 15, cost = 60
         assert budget.flops_used == 60
 
+    def test_tensordot_no_symmetry_unchanged(self):
+        """Without any input symmetry, the cost equals the dense
+        formula (a.size * b.size / contracted) — no behaviour change
+        from the pre-symmetry-adjustment code."""
+        n = 6
+        a = numpy.ones((n, n))
+        b = numpy.ones((n, n))
+        with BudgetContext(flop_budget=10**8) as budget:
+            tensordot(a, b, axes=1)
+        # output shape (n, n) = 36 elements, contracted = n = 6,
+        # dense = 6*6*6 = 216
+        assert budget.flops_used == n * n * n
+
+    def test_tensordot_surviving_symmetry_lowers_cost(self):
+        """A 4D × 4D contraction that preserves S₂ symmetry on each
+        operand's surviving (uncontracted) axes charges fewer FLOPs
+        than the dense baseline. Output symmetry is the direct product
+        of the two surviving S₂ groups."""
+        n = 8
+        sym = PermutationGroup.symmetric(axes=(0, 1))
+
+        with BudgetContext(flop_budget=10**10) as dense_bc:
+            a = numpy.ones((n, n, n, n))
+            b = numpy.ones((n, n, n, n))
+            dense_result = tensordot(a, b, axes=((2,), (2,)))
+
+        with BudgetContext(flop_budget=10**10) as sym_bc:
+            a_sym = as_symmetric(numpy.ones((n, n, n, n)), symmetry=sym)
+            b_sym = as_symmetric(numpy.ones((n, n, n, n)), symmetry=sym)
+            sym_result = tensordot(a_sym, b_sym, axes=((2,), (2,)))
+
+        # Output shape unchanged.
+        assert sym_result.shape == dense_result.shape == (n, n, n, n, n, n)
+        # Symmetric path's tensordot cost is strictly lower.
+        assert sym_bc.flops_used < dense_bc.flops_used
+        # Output retains the direct-product symmetry on (0,1) and (3,4).
+        assert isinstance(sym_result, SymmetricTensor)
+        assert sym_result.symmetry is not None
+        assert set(sym_result.symmetry.axes) == {0, 1, 3, 4}
+
+    def test_tensordot_contraction_through_sym_axis_drops_symmetry(self):
+        """If the contracted axes overlap with the input's symmetry
+        axes (e.g. a = (n,n) sym(0,1), contract axis 1), the surviving
+        axis is alone — no symmetry survives."""
+        n = 5
+        sym = PermutationGroup.symmetric(axes=(0, 1))
+        a_sym = as_symmetric(numpy.ones((n, n)), symmetry=sym)
+        b = numpy.ones((n, n))
+        with BudgetContext(flop_budget=10**6):
+            result = tensordot(a_sym, b, axes=1)
+        # Output shape = (n, n) — surviving axes are a's axis 0 and b's axis 1.
+        assert result.shape == (n, n)
+        # No surviving axis pair has the original S2 symmetry.
+        assert getattr(result, "symmetry", None) is None
+
     def test_kron_basic(self):
         a = numpy.array([[1, 0], [0, 1]])
         b = numpy.array([[1, 2], [3, 4]])

--- a/website/content/docs/changelog.mdx
+++ b/website/content/docs/changelog.mdx
@@ -7,6 +7,48 @@ title: Changelog
 
 ### Added
 
+- **NumPy `__array_ufunc__` (NEP 13) and `__array_function__` (NEP 18) protocols on
+  `WhestArray`.** Calls like `np.add(whest, x)`, `np.add.reduce(a)`,
+  `np.add.outer(a, b)`, `np.divmod(a, b)`, `np.modf(a)`, `np.frexp(a)`,
+  `np.add.at(a, idx, val)`, `np.add.reduceat(a, idx)`, plus ~108
+  function-form callables (`np.sort`, `np.transpose`, `np.linalg.solve`, …)
+  now route through whest's FLOP-counted wrappers automatically. Closes #58
+  (ndarray methods bypassing tracking), #38 (in-place dunders on
+  `SymmetricTensor` rebinding instead of mutating), and #62 (no-symmetry
+  `SymmetricTensor` type ambiguity). See the new
+  [Edge cases when SymmetricTensors meet NumPy protocols](/docs/guides/symmetry/#edge-cases-when-symmetrictensors-meet-numpy-protocols)
+  section for the corner-case rules.
+
+- **25 ndarray method overrides on `WhestArray`.** `a.sum()`, `a.dot(b)`,
+  `a.argsort()`, `a.compress()`, `a.trace()`, `a.round()`, `a.clip()`, etc.
+  now produce the same FLOP count as `we.sum(a)`, `we.dot(a, b)`, etc.
+
+- **In-place dunder rewrites with symmetry-corruption guards.** `A_sym += B`
+  mutates `A_sym` in place when the result preserves `A_sym`'s declared
+  symmetry, and raises `ValueError` when it would weaken or destroy it
+  (instead of silently rebinding to a new array, the pre-#67 behaviour).
+  Covers `__iadd__`, `__isub__`, `__imul__`, `__itruediv__`, `__ifloordiv__`,
+  `__imod__`, `__ipow__`, `__iand__`, `__ior__`, `__ixor__`, `__ilshift__`,
+  `__irshift__`, `__imatmul__`. In-place `sort` / `partition` similarly refuse
+  on `SymmetricTensor`.
+
+- **Multi-output ufuncs `np.divmod` / `np.frexp` / `np.modf`** now route through
+  whest with full `out=(o1, o2)` support, including partial allocation
+  (`out=(o1, None)`). Both outputs preserve any symmetry the input had.
+
+- **Symmetry-aware cost adjustment for `ufunc.outer` and `tensordot`** —
+  placeholder model charges `dense_cost × unique_output_elements /
+  dense_output_elements` to reflect the savings a symmetry-aware
+  implementation could realise. Above `SymmetryGroup` degree 12, the
+  adjustment is skipped (Burnside enumeration on `S_n` for `n > 12` is
+  infeasible) and a new `CostFallbackWarning` fires once per
+  `(op_name, degree)` pair per process. Suppress via
+  `we.configure(symmetry_warnings=False)` (shares the flag with
+  `SymmetryLossWarning`).
+
+- **`CostFallbackWarning`** added to both the core library and the client
+  package. Subclass of `WhestWarning`.
+
 - **Wall-clock time limits.** `BudgetContext` now accepts `wall_time_limit_s` to
   set a wall-clock deadline. When exceeded, `TimeExhaustedError` is raised at the
   next operation boundary with diagnostic info (operation name, elapsed time, limit).

--- a/website/content/docs/guides/symmetry.mdx
+++ b/website/content/docs/guides/symmetry.mdx
@@ -411,8 +411,8 @@ declared symmetry`.
 If you know the asymmetric write is intentional, downgrade first:
 
 ```python
-A_plain = np.asarray(A_sym).view(we.WhestArray)  # plain WhestArray, no symmetry
-A_plain += B_plain                                # works
+A_plain = A_sym.view(we.ndarray)   # zero-copy view as plain WhestArray, no symmetry
+A_plain += B_plain                  # works
 ```
 
 The same guard applies to `__isub__`, `__imul__`, `__itruediv__`,
@@ -442,12 +442,12 @@ repeat of an index applies again (unlike `a[indices] += values` which dedupes).
 On a `SymmetricTensor` this almost certainly breaks symmetry, so whest
 refuses:
 
-```python
+```text
 np.add.at(A_sym, ([0], [1]), 1.0)   # ValueError
 ```
 
-Downgrade with `np.asarray(A_sym).view(we.WhestArray)` first if you really need
-the unbuffered update.
+Downgrade with `A_sym.view(we.ndarray)` first if you really need the unbuffered
+update.
 
 ### `ufunc.outer` produces direct-product symmetry
 
@@ -455,7 +455,7 @@ When both operands are symmetric, the output of `np.<ufunc>.outer(A, B)`
 inherits the **direct product** of the input symmetries — `A`'s symmetry on
 its own axes, `B`'s symmetry on the lifted slots `A.ndim..A.ndim+B.ndim-1`:
 
-```python
+```text
 A = we.symmetrize(we.random.randn(3, 3),
                   symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)))
 B = we.symmetrize(we.random.randn(2, 2),
@@ -475,7 +475,7 @@ sym = we.SymmetryGroup.symmetric(axes=(0, 1))
 A = we.symmetrize(we.random.randn(4, 4, 4, 4), symmetry=sym)  # axes (0,1) symmetric
 B = we.symmetrize(we.random.randn(4, 4, 4, 4), symmetry=sym)
 
-C = np.tensordot(A, B, axes=((2,), (2,)))
+C = we.tensordot(A, B, axes=((2,), (2,)))
 # A's surviving axes: (0, 1, 3) → S_2 on (0, 1) survives
 # B's surviving axes: (0, 1, 3) → S_2 on (0, 1) survives
 # C: shape (4,4,4,4,4,4), SymmetricTensor with S_2 on (0,1) × S_2 on (3,4)
@@ -493,7 +493,7 @@ inherit the same symmetry as their inputs:
 S = we.symmetrize(we.array([[1.5, 2.5], [2.5, 3.5]]),
                   symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)))
 
-frac, integer = np.modf(S)   # both SymmetricTensor with the same symmetry
+frac, integer = we.modf(S)   # both SymmetricTensor with the same symmetry
 ```
 
 `out=(o1, o2)` works (per-slot identity is preserved), and `out=(o1, None)`
@@ -516,7 +516,11 @@ import warnings
 deep = we.ones((1,) * 33)   # auto-inferred S_33 symmetry
 with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("always")
-    np.add.outer(deep, deep)   # CostFallbackWarning: bailed to dense
+    with we.BudgetContext(flop_budget=int(1e10)):
+        try:
+            we.tensordot(deep, deep, axes=0)   # CostFallbackWarning: bailed to dense
+        except ValueError:
+            pass   # ndim>64 — the warning still fires before numpy refuses
 ```
 
 This is rare in practice — common user tensors have degree ≤ 8 — but high-rank

--- a/website/content/docs/guides/symmetry.mdx
+++ b/website/content/docs/guides/symmetry.mdx
@@ -380,6 +380,153 @@ possible partial weakening via `SymmetryLossWarning`. Treat the warning system
 as helpful guidance, not as a complete audit of every same-axis subgroup
 change.
 
+## Edge cases when SymmetricTensors meet NumPy protocols
+
+Once your tensors flow through arbitrary user code (or third-party libraries), they
+inevitably hit NumPy's `__array_ufunc__` and `__array_function__` machinery —
+`np.add(A, B)`, `np.divmod(A, B)`, `np.add.outer(A, B)`, `np.add.at(A, idx, vals)`,
+`A @= B`, `np.tensordot(A, B, axes=...)`, and so on. Whest's
+protocol implementations are conservative: when an operation would silently
+corrupt your declared symmetry, whest **refuses or strips** rather than letting
+it through. This section is a tour of those edge cases.
+
+### In-place dunders refuse symmetry-corrupting writes
+
+```python
+A_sym = we.symmetrize(
+    we.random.randn(4, 4),
+    symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)),
+)
+B_plain = we.random.randn(4, 4)  # not symmetric
+
+A_sym += B_plain   # raises ValueError
+```
+
+The right-hand-side has no symmetry, so `A_sym + B_plain` returns a plain
+`WhestArray`. Writing that result back into `A_sym`'s buffer would leave the
+metadata claiming symmetry while the data is asymmetric. Whest refuses with
+`ValueError: in-place add on a SymmetricTensor would weaken or destroy the
+declared symmetry`.
+
+If you know the asymmetric write is intentional, downgrade first:
+
+```python
+A_plain = np.asarray(A_sym).view(we.WhestArray)  # plain WhestArray, no symmetry
+A_plain += B_plain                                # works
+```
+
+The same guard applies to `__isub__`, `__imul__`, `__itruediv__`,
+`__ifloordiv__`, `__imod__`, `__ipow__`, `__iand__`, `__ior__`, `__ixor__`,
+`__ilshift__`, `__irshift__`, and `__imatmul__` (which additionally falls back
+to CPython's rebind-the-name semantics when the matmul output shape differs
+from `self.shape`).
+
+### In-place sort / partition refuse on SymmetricTensor
+
+```python
+A_sym.sort(axis=0)                # raises ValueError
+A_sym.partition(2)                # raises ValueError
+```
+
+A reorder along any axis breaks the permutation invariance. Use the out-of-place
+forms instead:
+
+```python
+sorted_arr = we.sort(A_sym, axis=0)   # plain WhestArray, no symmetry
+```
+
+### `ufunc.at` refuses on SymmetricTensor
+
+`np.add.at(a, indices, values)` does an unbuffered fancy-index write — every
+repeat of an index applies again (unlike `a[indices] += values` which dedupes).
+On a `SymmetricTensor` this almost certainly breaks symmetry, so whest
+refuses:
+
+```python
+np.add.at(A_sym, ([0], [1]), 1.0)   # ValueError
+```
+
+Downgrade with `np.asarray(A_sym).view(we.WhestArray)` first if you really need
+the unbuffered update.
+
+### `ufunc.outer` produces direct-product symmetry
+
+When both operands are symmetric, the output of `np.<ufunc>.outer(A, B)`
+inherits the **direct product** of the input symmetries — `A`'s symmetry on
+its own axes, `B`'s symmetry on the lifted slots `A.ndim..A.ndim+B.ndim-1`:
+
+```python
+A = we.symmetrize(we.random.randn(3, 3),
+                  symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)))
+B = we.symmetrize(we.random.randn(2, 2),
+                  symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)))
+
+C = np.add.outer(A, B)   # shape (3, 3, 2, 2), SymmetricTensor
+                         # symmetry: S_2 on (0, 1) × S_2 on (2, 3)
+```
+
+### `tensordot` keeps surviving direct-product symmetry
+
+The contracted axes drop out of each operand's symmetry; what's left of each
+operand's symmetry on the surviving (uncontracted) axes is direct-producted:
+
+```python
+sym = we.SymmetryGroup.symmetric(axes=(0, 1))
+A = we.symmetrize(we.random.randn(4, 4, 4, 4), symmetry=sym)  # axes (0,1) symmetric
+B = we.symmetrize(we.random.randn(4, 4, 4, 4), symmetry=sym)
+
+C = np.tensordot(A, B, axes=((2,), (2,)))
+# A's surviving axes: (0, 1, 3) → S_2 on (0, 1) survives
+# B's surviving axes: (0, 1, 3) → S_2 on (0, 1) survives
+# C: shape (4,4,4,4,4,4), SymmetricTensor with S_2 on (0,1) × S_2 on (3,4)
+```
+
+If the contracted axis is part of the symmetry group, that group is destroyed
+on the corresponding side.
+
+### Multi-output ufuncs preserve symmetry on every output
+
+`np.divmod(A, B)`, `np.frexp(A)`, `np.modf(A)` are elementwise — both outputs
+inherit the same symmetry as their inputs:
+
+```python
+S = we.symmetrize(we.array([[1.5, 2.5], [2.5, 3.5]]),
+                  symmetry=we.SymmetryGroup.symmetric(axes=(0, 1)))
+
+frac, integer = np.modf(S)   # both SymmetricTensor with the same symmetry
+```
+
+`out=(o1, o2)` works (per-slot identity is preserved), and `out=(o1, None)`
+lets numpy allocate just the second slot.
+
+### Cost model is a placeholder above degree 12
+
+Whest charges `dense_cost × unique_output_elements / dense_output_elements` for
+`ufunc.outer` and `tensordot` as a coarse proxy for the savings a
+symmetry-aware implementation could realise. The underlying NumPy call still
+does dense work; only the budget reflects the savings.
+
+For a `SymmetryGroup` with degree above **12**, whest skips this adjustment and
+charges the full dense cost — `Burnside` enumeration on `S_n` for `n > 12`
+becomes infeasible (`13! ≈ 6.2 × 10⁹`). The skip is announced via
+`CostFallbackWarning`:
+
+```python
+import warnings
+deep = we.ones((1,) * 33)   # auto-inferred S_33 symmetry
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    np.add.outer(deep, deep)   # CostFallbackWarning: bailed to dense
+```
+
+This is rare in practice — common user tensors have degree ≤ 8 — but high-rank
+auto-inferred symmetries on degenerate shapes (`(1,)*N` for large `N`) trip
+the cap. The warning fires once per `(op_name, degree)` pair per process to
+avoid log flooding. Suppress with `we.configure(symmetry_warnings=False)`,
+which shares the flag with `SymmetryLossWarning`.
+
+A proper algorithmic-cost model is a follow-up.
+
 ## Under the hood
 
 The propagation rules are easier to predict if you keep three ideas in mind:

--- a/whest-client/src/whest/errors.py
+++ b/whest-client/src/whest/errors.py
@@ -53,6 +53,17 @@ class SymmetryLossWarning(WhestWarning):
     """Warning issued when an operation causes loss of symmetry metadata."""
 
 
+class CostFallbackWarning(WhestWarning):
+    """Warning issued when whest skips its symmetry-aware cost adjustment.
+
+    Surfaces when the output's symmetry group is too large for the
+    placeholder cost model's Burnside enumeration (degree above the
+    per-call threshold). The op runs correctly with the dense cost
+    charged instead. Suppress with
+    ``we.configure(symmetry_warnings=False)``.
+    """
+
+
 class WhestServerError(WhestError):
     """Server-side error that does not map to a more specific exception."""
 

--- a/whest-client/src/whest/errors.py
+++ b/whest-client/src/whest/errors.py
@@ -54,14 +54,7 @@ class SymmetryLossWarning(WhestWarning):
 
 
 class CostFallbackWarning(WhestWarning):
-    """Warning issued when whest skips its symmetry-aware cost adjustment.
-
-    Surfaces when the output's symmetry group is too large for the
-    placeholder cost model's Burnside enumeration (degree above the
-    per-call threshold). The op runs correctly with the dense cost
-    charged instead. Suppress with
-    ``we.configure(symmetry_warnings=False)``.
-    """
+    """Warning issued when whest skips its symmetry-aware cost adjustment (e.g. ``ufunc.outer`` / ``tensordot`` on a symmetry group whose degree exceeds the per-call Burnside-enumeration threshold). The op runs correctly with the dense cost charged instead. Suppress with ``we.configure(symmetry_warnings=False)``."""
 
 
 class WhestServerError(WhestError):


### PR DESCRIPTION
## Summary

This PR makes every operation on a whest-typed array track FLOPs and propagate symmetry — by adding NumPy's NEP 13 (`__array_ufunc__`) and NEP 18 (`__array_function__`) protocols to `WhestArray`, plus 25 explicit method overrides for ndarray methods that bypass both protocols.

The branch builds directly on top of #51 (the unified `SymmetryGroup` API) and reuses its centralized helpers (`_call_with_optional_out`, `_wrap_result`, `_pointwise_symmetry`, `wrap_with_symmetry`, `intersect_groups`, `reduce_group`, `_asplainwhest`, etc.) without duplicating them. #51 closed #38 architecturally by making `SymmetricTensor` inherit `WhestArray`; this PR completes the fix by rewriting the 13 in-place dunders so `A_sym += B` actually mutates `A_sym` in place AND refuses to corrupt the symmetry metadata.

## What changes

### 1. NumPy ufunc protocol on `WhestArray` ([595fc7712](https://github.com/AIcrowd/whest/commit/595fc7712))

- Adds `__array_ufunc__` (NEP 13) so `np.add(whest, x)`, `np.add.reduce(a)`, `np.add.accumulate(a)`, `np.sin(whest)`, etc. dispatch through whest's counted wrappers via `me.<ufunc>`.
- Class-level `_REDUCE_TO_WHEST` (`add→sum, multiply→prod, maximum→max, minimum→min, logical_and→all, logical_or→any`) and `_ACCUMULATE_TO_WHEST` (`add→cumsum, multiply→cumprod`) routing tables.
- Multi-output ufuncs (`np.modf`, `np.frexp`, `np.divmod`) route through to the corresponding `we.*` wrapper with full `out=(o1, o2)` support. Unsupported ufunc methods (`outer`, `reduceat`, `at`) raise `NotImplementedError`. Other methods return `NotImplemented` (sentinel), letting NumPy fall back.
- `out=(arr,)` tuple unwrap: NEP 13 always passes `out` as a tuple; whest wrappers expect `out=arr`.
- `kwargs.setdefault(\"axis\", 0)` on `reduce` / `accumulate` to match NumPy's positional-axis-default semantics.
- Adds `_filter_to_np_signature(np_func, kwargs)` driven by a `@functools.cache`-d `_signature_kwargs_accepted` helper: drops ufunc-internal kwargs (`dtype=`, `keepdims=`) that function-form whest wrappers don't accept. Without this, internal NumPy chains like `np.allclose → np.all → np.add.reduce(..., dtype=bool)` would `TypeError`.

### 2. NumPy array-function protocol on `WhestArray` ([cc21bdc57](https://github.com/AIcrowd/whest/commit/cc21bdc57))

- Adds `__array_function__` (NEP 18) so `np.<func>(whest, ...)` non-ufunc calls dispatch through an explicit allowlist of ~108 NumPy callables → whest counterparts.
- 9 binding groups: reductions, sorting/selection, set/unique, free/structural, shape/view ops, linear algebra, comparisons, histograms, `linalg.*` submodule.
- Lazy-once dispatch dict construction (`_get_array_function_dispatch`) avoids per-call overhead.
- `_PASSTHROUGH` set of zero-FLOP type/shape queries (`np.ndim`, `np.shape`, `np.size`, `np.array_equal`, `np.result_type`, `np.can_cast`, `np.min_scalar_type`, `np.promote_types`, `np.find_common_type`, `np.mintypecode`) bypasses tracking entirely. Eagerly captured at module import time (`_INITIAL_PASSTHROUGH = _build_passthrough()`) to defeat `tests/numpy_compat/conftest.py` monkeypatching of `np.<name>` (#51 follow-up perf class 3 anti-pattern).
- Functions outside both sets return `NotImplemented`, surfacing gaps as `TypeError` rather than silently bypassing tracking.
- Shape/view ops (`reshape`, `transpose`, `swapaxes`, `moveaxis`, `squeeze`, `concatenate`, `stack`/`vstack`/`hstack`/`column_stack`, `split`/`hsplit`/`vsplit`/`dsplit`, `atleast_*`, `broadcast_to`, `matrix_transpose`, etc.) ARE in the allowlist — `me.swapaxes` / `me.transpose` / etc. correctly preserve `SymmetricTensor` symmetry via `wrap_with_symmetry(remap_group_axes(...))`. `np.copyto` is *not* in the allowlist; in-place dunders pre-strip `self` before calling it.

### 3. 25 ndarray method overrides on `WhestArray` ([1a77a3f66](https://github.com/AIcrowd/whest/commit/1a77a3f66))

Closes #58. Each method forwards to `_me().<name>(self, *args, **kwargs)`:

- 17 reductions: `sum`, `mean`, `prod`, `min`, `max`, `std`, `var`, `all`, `any`, `cumsum`, `cumprod`, `argmin`, `argmax`, `ptp`, `trace`, `round`, `clip`.
- 8 non-protocol methods that bypass both NEP 13 and NEP 18: `dot`, `conj`/`conjugate`, `argsort`, `argpartition`, `take`, `repeat`, `searchsorted`, `compress` (with the documented arg-flip: `_me().compress(condition, self, ...)`).

Tests parametrize across all 25 methods AND verify that `a.foo()` produces the same FLOP count as `we.foo(a)` (1:1 budget parity).

### 4. In-place sort / partition refusal guard ([1a77a3f66](https://github.com/AIcrowd/whest/commit/1a77a3f66))

- `_check_inplace_breaks_symmetry(self, op_name)` raises `ValueError` if `self._symmetry` is set.
- In-place `sort` / `partition` overrides call the guard, then route through `_me().sort` / `_me().partition`, then `_np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))`. Returns `None` (matching NumPy's mutating-method contract).

### 5. 13 in-place dunder rewrites ([1a77a3f66](https://github.com/AIcrowd/whest/commit/1a77a3f66))

Closes #38 fully. Pre-v2, `WhestArray.__iadd__` etc. did `return _me().add(self, other)` — rebinding to a new array instead of mutating `self` (breaking NumPy's identity contract). v2 rewrites all 13 in-place dunders (`__iadd__`, `__isub__`, `__imul__`, `__itruediv__`, `__ifloordiv__`, `__imod__`, `__ipow__`, `__iand__`, `__ior__`, `__ixor__`, `__ilshift__`, `__irshift__`, `__imatmul__`) to use `_inplace_from_result(self, result, op_name)`:

- Compares `self._symmetry != result._symmetry` directly (relying on `SymmetryGroup.__eq__`'s identity short-circuit + value equality from #51).
- On match: `_np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))` and `return self` (NumPy identity preserved).
- On mismatch: raises `ValueError` with \"destroy or weaken symmetry\" in the message — refuses silent metadata corruption.

`__imatmul__` is special: matmul output shape may differ from `self.shape`, in which case in-place is impossible. Falls back to returning the new result (CPython's documented in-place fallback).

### 6. Recursion-prevention strip helpers ([483edab49](https://github.com/AIcrowd/whest/commit/483edab49), [595fc7712](https://github.com/AIcrowd/whest/commit/595fc7712), [cc21bdc57](https://github.com/AIcrowd/whest/commit/cc21bdc57), [7a955e0f6](https://github.com/AIcrowd/whest/commit/7a955e0f6))

- `_to_base_ndarray(x)`: zero-copy view-cast of `WhestArray` to plain `np.ndarray`. Distinct from #51's `_asplainwhest` (which returns `WhestArray`, still a subclass that triggers protocol dispatch). Required at every raw `_np.<func>(WhestArray)` call site to break recursion through `__array_ufunc__` / `__array_function__`.
- `_to_base_ndarray_tree(x)`: recursive variant for tuples/lists/namedtuples (preserves namedtuple type via `_fields` introspection).
- ~50 strip sites added across `_pointwise.py`, `_sorting_ops.py`, `_free_ops.py`, `_counting_ops.py`, `_einsum.py`, `_unwrap.py`, `_validation.py`, `fft/_transforms.py`, `fft/_free.py`, `linalg/*.py`.
- `_call_with_optional_out` (#51's central wrapper plumbing) was extended to strip `*args`, ndarray kwargs, tree-strip tuple/list kwargs, and `out=` before the raw NumPy call — so subsequent counted wrappers don't need to strip individually.

### 7. Conditional `_aswhest` re-wraps in linalg ([cc21bdc57](https://github.com/AIcrowd/whest/commit/cc21bdc57))

- 23 sites in `linalg/_decompositions.py`, `linalg/_solvers.py`, `linalg/_compound.py`, `linalg/_properties.py`, `linalg/_svd.py`, `linalg/_aliases.py` use `_aswhest(result)` only when at least one input was already a `WhestArray`. Plain ndarray inputs → plain ndarray outputs (preserves pre-v2 NumPy default subclass-propagation semantics).

### 8. Multi-output ufunc support ([483edab49](https://github.com/AIcrowd/whest/commit/483edab49), [7a955e0f6](https://github.com/AIcrowd/whest/commit/7a955e0f6), [709b32a60](https://github.com/AIcrowd/whest/commit/709b32a60))

`np.divmod(WhestArray, WhestArray)`, `np.modf(WhestArray)`, and `np.frexp(WhestArray)` now route through `__array_ufunc__` to `we.divmod` / `we.modf` / `we.frexp` with full `out=(o1, o2)` support, including partial allocation (`out=(o1, None)`).

- New `_call_with_optional_multi_out(np_func, *args, out, nout, **kwargs)` helper in `_pointwise.py` mirrors `_call_with_optional_out` for the multi-output case. It strips each `out` slot to a plain ndarray view (`None` slots pass through as "let numpy allocate"), calls numpy with the stripped tuple, and returns a tuple where each non-`None` slot retains the caller's original object — preserving `result[i] is out[i]` per-slot identity.
- `_wrap_multi_result(result, *, out=None, symmetry=None)` extended with `out=` so each slot dispatches through `_wrap_result` for identity + symmetry validation.
- `_counted_unary_multi` (modf, frexp) and `_counted_binary_multi` (divmod) rewritten to accept `out=(o1, o2)` and route through the new helper. `_counted_binary_multi` also gains the scalar-operand special case and the `SymmetryLossWarning` emission that `_counted_binary` already had — both were dormant gaps the previous rejection masked.
- `WhestArray.__array_ufunc__` drops the wholesale `nout != 1` rejection. Multi-output ufuncs fall through to the existing dispatch (`getattr(me, ufunc.__name__, None)`) which now picks up the multi-output `we.*` wrappers; the existing `out` unwrap branch passes the multi-output `out` tuple through unchanged.
- 13 new positive tests in `tests/test_array_protocols.py` cover protocol routing, `out=(o1, o2)` identity, partial allocation `out=(o1, None)`, positional out args, shared-symmetry preservation across both outputs, unshared-symmetry warning emission, scalar-input cases, and invalid-`out=` validation. 6 direct `we.*` `out=` tests in `tests/test_pointwise_coverage.py::TestMultiOutputOps`.
- The previous "fail loudly" assertions in `tests/test_array_protocols.py` (`test_np_modf_fails_loudly`, `test_np_frexp_fails_loudly`, `test_we_modf_rejects_out_kwarg`) are deleted — their underlying behavior is now supported.
- ~28 numpy_compat xfails removed (`test_divide_by_zero`, `test_signed_division_overflow`, `test_ufunc_types[divmod/frexp/modf]`, `test_ufunc_noncontiguous[divmod/frexp/modf]`, `TestOut::test_out_subok`). `TestOut::test_out_wrap_subok` retained as `SUBCLASS_RETURN` since we don't honor `subok=False`.

### 9. `_counted_reduction` positional-`out` handling ([483edab49](https://github.com/AIcrowd/whest/commit/483edab49))

- Per-factory `_inspect.signature(np_func)` introspection (computed once at factory build time) detects which positional slot holds `out`. Different reductions place `out` differently: `np.sum(a, axis, dtype, out, keepdims)` (slot 3), `np.argmax(a, axis, out)` (slot 2), `np.percentile(a, q, axis, out)` (slot 3 but `axis` at slot 2).
- Wrapper signature widened to `def wrapper(a, axis=None, *args, **kwargs)` so method overrides forwarding through `*args, **kwargs` correctly route positional `out` to the underlying NumPy function and preserve identity (`a.sum(0, np.float64, out_arr)` returns the same `out_arr` object).

### 10. New tests ([72b0ecb1a](https://github.com/AIcrowd/whest/commit/72b0ecb1a), [feb0dfe4d](https://github.com/AIcrowd/whest/commit/feb0dfe4d))

- `tests/test_method_tracking.py` (424 lines, 28 functions, 59 cases) — reduction methods × parametrized; non-protocol methods × parametrized; in-place sort/partition (+ symmetric refusal); axis/keepdims/dtype/out coverage including positional variants; symmetry propagation through method calls; #38/#58/#62 verbatim reproducers.
- `tests/test_array_protocols.py` (635 lines, 49 functions) — \`__array_ufunc__\` / \`__array_function__\` adversarial coverage: recursion guards (`does_not_recurse_*`), `out=` tuple unwrap, `out=` symmetry guard (positive + negative), `where=` / `dtype=` kwargs, mixed numpy/whest operands, in-place dunder identity preservation + symmetry guard, multi-output ufunc rejection, `outer`/`reduceat`/`at` rejection, `_PASSTHROUGH` lock-in.
- 3 perf smoke tests pinning #51 hot paths: `test_perf_warm_rank8_scalar_comparison_is_fast` (catches O(\|G\|) regressions in `SymmetryGroup.__eq__`/`_canonical_axis_action`/`unique_elements_for_shape`), `test_perf_array_ufunc_dispatch_does_not_copy` (catches OWNDATA-copy regressions), `test_perf_warm_inplace_add_scalar_on_symmetric_is_fast` (verifies `SymmetryGroup.__eq__` identity short-circuit fires — asserts `A_sym._symmetry is original_ref` after `A_sym += 1.0`).
- 1 cache-verification test (`test_signature_kwargs_accepted_is_cached`) pins the `@functools.cache` on the per-ufunc-call hot path (#51 follow-up perf class 6 anti-pattern guard).
- Stage 6 ([feb0dfe4d](https://github.com/AIcrowd/whest/commit/feb0dfe4d)) reconciles the one literal duplicate with #51's `tests/test_ndarray_subclass_contract.py`: **renames + rewrites** `test_symmetric_tensor_ufunc_result_can_drop_to_plain_view_backed_whestarray` → `test_symmetric_tensor_ufunc_result_preserves_symmetry`, asserting the new (post-v2) behavior — `np.add(A_sym, A_sym)` returns `SymmetricTensor` (preserves symmetry), not plain `WhestArray`.

### 11. #51 perf-class adherence

The branch maintains all 6 perf-regression invariants documented in #51's [follow-up performance comment](https://github.com/AIcrowd/whest/pull/51#issuecomment-4340098399):

1. No OWNDATA-preserving copies in protocol handlers (all strips are zero-copy view-casts).
2. Constant-fill / `*_like` constructor caches preserved (we don't touch them).
3. Compat-harness aliasing class-3 anti-pattern guarded via eager `_INITIAL_PASSTHROUGH` capture + the conftest addition of `whest._ndarray` to `_WHEST_MODULES_WITH_NP`.
4. Scalar fast path in `_counted_binary` preserved — `__array_ufunc__` passes Python scalars through unchanged.
5. `SymmetryGroup.__eq__` identity short-circuit relied upon (and tested at runtime) in `_inplace_from_result`.
6. Per-call introspection memoized — `@functools.cache` on `_signature_kwargs_accepted`, lazy-once `_get_array_function_dispatch`.

After the ufunc-method-support work landed (un-xfailing ~165 tests that previously short-circuited via xfail), `make test-numpy-compat` runs in roughly the same wall-clock as `origin/main` (~85s vs ~87s on the local 16-worker xdist run), despite executing those ~165 newly-passing tests for real. Per-test runtime is therefore noticeably faster than the pre-our-work baseline — partly because the new allowlist routes internal NumPy `transpose` cascades to whest's shape-op wrappers cleanly.

### 12. CI fixup ([77dbddb9f](https://github.com/AIcrowd/whest/commit/77dbddb9f))

Unrelated to the protocol work but blocking the push: the project's `.githooks/pre-push` invokes `make lint-commits` which calls `uv run gitlint --commits origin/main..HEAD`. The pre-push protocol's stdin (`local_ref local_sha remote_ref remote_sha` lines) was leaking through to gitlint, which mis-parsed it as a commit subject and flagged false-positive CT1/T1 violations. Adding `--ignore-stdin` to the gitlint invocation fixes the false positives.

(Also rolled in: a `style: ruff format` cleanup at [`7d6920b24`](https://github.com/AIcrowd/whest/commit/7d6920b24) from a forgotten autoformat run after Stage 5.)

### 13. Strip-and-identity regressions in protocol paths ([6085e09bc](https://github.com/AIcrowd/whest/commit/6085e09bc))

Initial protocol rollout caused recursion / crashes in several wrappers that passed unstripped `out=` to numpy. With `__array_ufunc__` / `__array_function__` active, an unstripped WhestArray `out=` recurses back through dispatch and either crashes or doubles tracking. Closes ~30 numpy_compat regressions:

- `whest.fft._transforms` (14 functions): strip `out=` to plain ndarray view; return original `out` so `result is out` round-trips. Closes ~28 `numpy.fft.tests.test_pocketfft` failures previously crashing with `TypeError: 'module' object is not callable`.
- `whest.linalg._compound.multi_dot`: strip `out=` and return original. Closes 3 `TestMultiDot::*_and_out` `RecursionError` regressions.
- `whest._counting_ops.trace`: strip both `a` and `out=`; preserve `out` identity.
- `whest._pointwise.vecdot/matvec/vecmat`: pull `out=` out of `**kwargs`, strip it, return original. Closes `test_out_broadcasts` plus a noncontiguous vecdot regression.
- `whest.linalg._decompositions.qr` mode=`"raw"`: numpy returns a `(h, tau)` tuple with mismatched shapes; preserve the tuple structure rather than feeding it to `_aswhest` (which previously failed with `ValueError: ... inhomogeneous shape`).
- `whest.linalg._solvers.solve` and `lstsq`: match numpy's subclass-return policy ("type of `b`") instead of "if any input was whest". Restores `consistent_subclass(x, b)` parity for `TestSolve`, `TestLstsq`, `TestPinvHermitian`.
- `WhestArray._get_array_function_dispatch`: bind `np.amax`/`np.amin` (numpy 2.x retained these as exported aliases). The previous dispatch only had `max`/`min`.
- `whest._free_ops.require`: stop stripping args. `_np.require` is a thin Python helper around `np.asanyarray` and does not enter the `__array_function__` dispatch path, so passing a WhestArray cannot recurse. Stripping was breaking the `np.require(b).is(b)` identity contract for already-conforming inputs.

### 14. Deliberate xfails for ufunc method/protocol rejections ([a129875ba](https://github.com/AIcrowd/whest/commit/a129875ba))

Three categories of upstream tests still fail because v2's `__array_ufunc__` enforces policies that pre-v2 `main` bypassed; these are tagged in `tests/numpy_compat/xfails.py` so the suite stays green:

1. **`ufunc.at` / `.reduce` / `.reduceat` / `.accumulate` / `.outer` rejections** — we deliberately raise `NotImplementedError` so callers cannot silently bypass FLOP tracking. Tests exercising the raw ufunc method protocol have no whest path. (~165 tests across `test_ufunc_at_inner_loops*`, `test_ufunc_at_*`, `test_logical_ufuncs_support_anything[logical_xor]`, `test_object_array_reduceat_inplace`, `test_outer_exceeds_maxdims`, `test_reduceat[_empty]`, etc.)
2. **Private numpy gufuncs** from `numpy._core.umath_tests` (`cross1d`, `matrix_multiply`, `conv1d_full`, `test_add`, `euclidean_pdist`) — not part of the public NumPy API, not in our `__array_function__` allowlist by design. (~12 tests across `test_cross1d`, `test_axes_argument`, `test_keepdims_argument`, `test_can_ignore_signature`, `test_matrix_multiply_umath_empty`, `test_euclidean_pdist`, `test_ufunc_custom_out`, `TestGUFuncProcessCoreDims::*`, `TestFrompyfunc::test_identity`.)
3. **`_prepare_symmetric_out` activation via `__array_ufunc__`** — `np.zeros_like(plain_3x3)` returns a SymmetricTensor (whest auto-infers symmetry from constant-fill arrays of square shape). On main, `np.positive(plain, out=symmetric_zeros, where=mask)` worked because numpy bypassed whest validation entirely (no `__array_ufunc__`). On v2, `__array_ufunc__` triggers `_prepare_symmetric_out` which refuses to write non-symmetric data into a SymmetricTensor — surfacing the latent semantic conflict the auto-inference creates. Marked `BEHAVIORAL_SHIM`. (~15 tests in `test_reduction_with_where*`.)

After this commit + the multi-output ufunc support, **the numpy_compat suite is green: 7,634 passed, 78 skipped, 260 xfailed, 17 xpassed, 0 failures** (was 268 failures pre-fix).

### 15. Generic ufunc.outer / .reduceat / .at + symmetry-adjusted cost ([c58454d97](https://github.com/AIcrowd/whest/commit/c58454d97))

Closes the remaining ufunc-method gaps in `__array_ufunc__` and adds a symmetry-savings cost model that ``ufunc.outer`` and ``tensordot`` both consume. ~165 more numpy_compat xfails flip to passing.

**`_symmetry_adjusted_cost` placeholder helper** (in `_pointwise.py`):

```
cost = dense_cost × (num_unique_output_elements / num_dense_output_elements)
```

For non-symmetric outputs the ratio is `1.0` (no behaviour change). For symmetric outputs the ratio drops below 1 and captures the redundant-element savings a symmetry-aware implementation could realise. A `# TODO:` comment flags the placeholder pending a per-op algorithmic-cost model.

**Generic ufunc-method helpers**:

- `_counted_ufunc_outer(ufunc, a, b, out=, **kwargs)` — output shape `a.shape + b.shape`; output symmetry from `direct_product_groups(a_sym, b_sym_lifted)` with `b`'s axes shifted by `a.ndim`; cost via `_symmetry_adjusted_cost`.
- `_counted_ufunc_reduce_generic` — fallback for ufuncs not in `_REDUCE_TO_WHEST` (subtract, bitwise_*, logical_xor, …). Cost = `reduction_cost`; symmetry via `reduce_group`.
- `_counted_ufunc_accumulate_generic` — same idea for `accumulate`. Symmetry policy: drop the axis we cumulate along.
- `_counted_ufunc_reduceat` — segment-reduce; cost = `numel(input)`; output symmetry = `None` (segment boundaries don't respect axis-permutation invariance).
- `_counted_ufunc_at` — in-place fancy-index. **Refuses on SymmetricTensor** (the asymmetric write would corrupt the tagged symmetry); on plain WhestArray strips `a` to a base-ndarray view so the mutation propagates back through the user's reference.

**`__array_ufunc__` rewrite**: drops the `method in ("outer", "reduceat", "at")` rejection. `reduce` / `accumulate` first try the existing `_REDUCE_TO_WHEST` / `_ACCUMULATE_TO_WHEST` routing tables; on a miss they fall back to the generic helpers. `outer` / `reduceat` / `at` always use the generic path.

**`tensordot` symmetry-aware cost**: computes output symmetry from each input's surviving (non-contracted) axes (via `restrict_group_to_axes` + `direct_product_groups`) and applies `_symmetry_adjusted_cost`. A symmetric (n,n) × (n,n) tensordot with shared S₂ axes costs ~½ the dense formula; smoke-checked on a 50×50 outer product to give a `unique/dense` ratio of ~0.27 (matches the analytical `((n*(n+1)/2)/(n*n))²` prediction).

**Tests**: deletes the three legacy `*_fails_loudly` tests for outer / reduceat / at; adds 9 positive tests in `tests/test_array_protocols.py` covering protocol routing, direct-product symmetry on outer, symmetric-cost-lower-than-dense for outer, generic `subtract.reduce` / `subtract.accumulate` paths, reduceat segments, `at` mutation on plain WhestArray, and the SymmetricTensor refusal. Adds 3 `tensordot` cost tests in `tests/test_pointwise_coverage.py`.

**xfails removed (16 patterns ≈ 165 tests)**: `test_ufunc_at_inner_loops*` (all dtype variants), `test_ufunc_at_*`, `test_at_no_loop_for_op`, `test_cast_index_fastpath`, `test_object_array_reduceat_inplace`, `test_reducelike_output_needs_identical_cast`, `test_reduce_zero_axis`, `test_empty_reduction_and_identity`, `test_logical_ufuncs_support_anything[logical_xor]`, `test_umath::test_reduceat[_empty]`, `test_umath::test_outer_exceeds_maxdims`. After this commit `test_ufunc.py` runs at **800 passed, 32 xfailed, 1 xpassed, 0 failed** (was 633 passed, 33 xfailed, 167 xpassed before the cleanup).

### 16. Perf-fix for high-degree symmetry groups in cost adjustment ([ed50c3853](https://github.com/AIcrowd/whest/commit/ed50c3853))

The previous push (commit [c58454d97](https://github.com/AIcrowd/whest/commit/c58454d97)) regressed CI from ~5 min to 30+ min on the numpy 2.2/2.3/2.4 jobs. Root cause: the new `_counted_ufunc_outer` and `tensordot` paths called `direct_product_groups` on auto-inferred `S_n` symmetries from `np.ones((1,)*n)`. Composition triggered `SymmetryGroup.order()` which enumerates the group elements — for `n=33` (the rank used by `test_outer_exceeds_maxdims`) that's `33!` walks, hung indefinitely.

Fix: add `_is_oversized_for_cost_model(group)` guard with degree threshold 12 (above which `S_n` already blows past Python's recursion / memory budgets) and bail to dense cost in:

- `_counted_ufunc_outer` — the immediate trigger.
- `tensordot` — same composition pattern via `_surviving_symmetry_after_contraction` + `direct_product_groups`.

The cost adjustment is irrelevant for the trivial `(1,)*n` shapes that surface this anyway — every axis is degenerate, so the dense / unique ratio is 1 regardless. Over-counting the FLOPs is safer than hanging.

Mirrors PR #51's [perf-class-6 fix](https://github.com/AIcrowd/whest/pull/51#issuecomment-4340098399) (memoize `unique_elements_for_shape`) — both protect against `O(|G|)` walks on high-degree groups, but for different call paths.

Verification: `test_umath` returned to 10.88s (was hung indefinitely). Full numpy_compat suite: **7,804 passed, 78 skipped, 89 xfailed, 18 xpassed, 0 failures in 85.91s** (matches the pre-regression baseline of ~5 min with 16-worker xdist on CI).

### 17. Surface the cost-fallback bail with a warning ([f3190fe09](https://github.com/AIcrowd/whest/commit/f3190fe09))

The previous commit [ed50c3853](https://github.com/AIcrowd/whest/commit/ed50c3853) silently bailed to dense cost. For `np.ones((1,)*n)` the over-counting is harmless (single-element array), but if a user deliberately constructs a real high-rank symmetric tensor (16-axis with `S₁₆`, say) they'd be charged the dense `n¹⁶` cost when they expected the sparse `(n+15 choose 15)` cost — without any indication that whest skipped the adjustment.

This commit makes the bail visible:

- New `CostFallbackWarning` (subclass of `WhestWarning`) in `whest.errors` and the matching client-side `whest-client` errors module (parity required by `TestErrorParity`).
- New `_warn_oversized_once(op_name, degree)` helper in `_pointwise.py` that emits the warning **once per `(op, degree)` pair** via a `@functools.cache`-backed sentinel. Hot paths (numpy compat tests doing thousands of ufunc calls on the same auto-inferred `S_n` symmetry) get exactly one warning per process — no log flooding.
- Wired into the bail branches of `_counted_ufunc_outer` and `tensordot`.
- Honours `we.configure(symmetry_warnings=False)` — shares the flag with `SymmetryLossWarning` since both are symmetry-related diagnostics. (No new config flag.)

Tests in `tests/test_array_protocols.py`:

- `test_np_add_outer_warns_and_bails_on_oversized_symmetry` — fires exactly once when `np.add.outer(deep, deep)` is called on `we.ones((1,)*33)` (S₃₃, degree=33).
- `test_cost_fallback_warning_suppressed_by_configure` — `we.configure(symmetry_warnings=False)` silences it.

Net warning count: `test_umath` goes from 43 → 44 captured warnings (+1 from the dedup'd `CostFallbackWarning`); full numpy_compat from 508 → 509. Dedup keeps it from spamming.

### 18. Cosmetic cleanups in `_ndarray.py` ([d59257dc4](https://github.com/AIcrowd/whest/commit/d59257dc4))

Two non-functional cleanups flagged in earlier review rounds:

- **`__imatmul__`** no longer goes through `_np.asarray(result)` to read `.shape`. `result` is already a `WhestArray` (an `ndarray` subclass) so `result.shape` is a direct attribute access; the asarray indirection was a one-line copy-paste artifact.
- **`WhestArray` module docstring** refreshed to match the post-#67 surface area: the protocols (`__array_ufunc__` / `__array_function__`), the 25 ndarray method overrides, the in-place sort/partition refusal guard, the strip helpers (`_to_base_ndarray` / `_to_base_ndarray_tree`), and the symmetry guard on in-place dunders. The pre-#67 docstring only mentioned operator overloads, which understated the module's responsibilities.

### 19. User-facing docs for the new corner cases ([ea94477ac](https://github.com/AIcrowd/whest/commit/ea94477ac))

The protocol work introduces several user-visible behaviour changes that weren't surfaced anywhere in the docs. This commit closes those gaps:

- **`website/content/docs/guides/symmetry.mdx`** gains a new section *"Edge cases when SymmetricTensors meet NumPy protocols"* (placed before *"Under the hood"*). Subsections, each with a runnable example: in-place dunder refusal + the downgrade pattern; in-place sort / partition refusal; `ufunc.at` refusal; `ufunc.outer` direct-product symmetry; `tensordot` surviving-direct-product symmetry; multi-output ufuncs preserving symmetry on every output; the placeholder cost model + `CostFallbackWarning` + degree-12 cap.
- **`website/content/docs/changelog.mdx`** Unreleased section gains entries for the protocols, method overrides, in-place dunder rewrites, multi-output ufunc support, symmetry-aware cost adjustment, and `CostFallbackWarning`. Cross-links into the new guide section.
- **Function docstrings** updated where behaviour changed: `tensordot` (symmetry-aware cost adjustment + the degree-12 cap); `solve` and `lstsq` (the "subclass of `b`" return policy that matches numpy's `np.linalg.solve` / `lstsq`); `qr` (the four return shapes by mode, including the `"raw"` 2-tuple form that this PR's fix preserved).

## Issues fully addressed

The following are fully closed by this PR:

- Closes [#38](https://github.com/AIcrowd/whest/issues/38) — in-place dunder ops on `SymmetricTensor` now mutate self correctly AND refuse silent metadata corruption. Combined with #51's `SymmetricTensor(WhestArray)` inheritance, this fully closes the sibling-class-drift bug.
- Closes [#62](https://github.com/AIcrowd/whest/issues/62) — no-symmetry `SymmetricTensor` results now downgrade to plain `WhestArray` via #51's `__array_finalize__` + `__array_wrap__` machinery; verbatim reproducer `test_issue_62_reproducer` confirms `we.diagonal(A_sym)` returns `WhestArray`, not empty-symmetry `SymmetricTensor`.

## Issues partially addressed

- [#58](https://github.com/AIcrowd/whest/issues/58) — **interception side fully addressed**. `a.sum()`, `a.dot(b)`, `a.argsort()`, `np.add(whest, x)`, `np.linalg.solve(whest, b)`, etc. now route through whest's FLOP-counted wrappers via 25 explicit method overrides + the two NumPy protocols, and produce identical accounting to their `we.*` counterparts. **The symmetry counts themselves still use a placeholder model**: PR #51's `unique_elements_for_shape` (Burnside-cached) for the pointwise / reduction paths, and a `dense × unique_output / dense_output` ratio for `ufunc.outer` / `tensordot`. The proper algorithmic-cost model — and full symmetry propagation across arbitrary symmetries through arbitrary ops — is the upcoming Einsum-Cost work (tracked in [#32](https://github.com/AIcrowd/whest/issues/32)), which will cover einsums, reductions, and many linalg ops. That work will not necessarily cover every cost path in this PR; ops with their own dedicated tracking issues include outer ([#65](https://github.com/AIcrowd/whest/issues/65)), `A @ A` ([#59](https://github.com/AIcrowd/whest/issues/59)), off-by-one in sum/mean ([#56](https://github.com/AIcrowd/whest/issues/56)), and `symmetrize` cost ([#34](https://github.com/AIcrowd/whest/issues/34)). Until those land, #58 stays open.

## Explicitly out of scope for this PR

The following are intentionally not solved here:

- **Shape-op symmetry remap for `SymmetricTensor`** — `me.swapaxes` / `me.transpose` / `me.moveaxis` correctly preserve symmetry, but other shape ops (`reshape`, `concatenate`, `stack`, `split`, etc.) silently downgrade to plain `WhestArray`. Tracked in [#68](https://github.com/AIcrowd/whest/issues/68).
- **Compound NumPy functions over-count via internal ufuncs** — Stage 4's allowlist routes most such calls to whest's own wrappers, but any path that ends in a raw `_np.<func>(stripped, ...)` (fallbacks, ops we deliberately don't model, future numpy additions) can still over- or under-count internal ufunc FLOPs. Tracked in [#69](https://github.com/AIcrowd/whest/issues/69).
- **`np.zeros_like(square_plain)` auto-infers `S_n` symmetry** — surfaces a latent semantic conflict with `_prepare_symmetric_out` under `__array_ufunc__`. The 15 `BEHAVIORAL_SHIM` xfails in `tests/numpy_compat/xfails.py` are all variants. Design question + reproducer in [#70](https://github.com/AIcrowd/whest/issues/70).
- **`SymmetryGroup.order()` is `O(|G|)` on the cold path** — cached per-instance, but composition helpers (`direct_product_groups`, `restrict_group_to_axes`) allocate fresh instances inside `_counted_ufunc_outer` / `tensordot`, so every call re-pays the cost. `S_8.order()` cold takes ~1.8s. PR #67 works around this with the degree-12 cap on `_is_oversized_for_cost_model`; the underlying inefficiency stays. Two complementary fixes tracked: closed-form shortcut for known group families ([#71](https://github.com/AIcrowd/whest/issues/71)) and process-wide interning of `SymmetryGroup` instances by canonical action ([#73](https://github.com/AIcrowd/whest/issues/73)).
- **Adding `np.may_share_memory` / `np.shares_memory` / `np.byte_bounds` to `_PASSTHROUGH_NAMES`** — they currently work via strip routing; passthrough would be cleaner. Tracked in [#72](https://github.com/AIcrowd/whest/issues/72).
- **Symmetry-aware FLOP accounting uses a unique-element placeholder** — across the unified protocol path (`__array_ufunc__`, `__array_function__`, the 25 method overrides) symmetry-aware costs come from PR #51's `unique_elements_for_shape` (Burnside-cached). For `ufunc.outer` and `tensordot` we additionally apply a `dense × unique_output / dense_output` ratio. **Both are placeholders.** The proper algorithmic-cost model — and generalized symmetry propagation across arbitrary symmetries through arbitrary ops — is the upcoming Einsum-Cost work (tracked in [#32](https://github.com/AIcrowd/whest/issues/32)), which is expected to cover einsums, reductions, and many linalg ops. The Einsum-Cost work will not necessarily cover every cost path this PR touches; ops with their own dedicated tracking issues include outer ([#65](https://github.com/AIcrowd/whest/issues/65)), `A @ A` ([#59](https://github.com/AIcrowd/whest/issues/59)), off-by-one in sum/mean ([#56](https://github.com/AIcrowd/whest/issues/56)), and `symmetrize` cost ([#34](https://github.com/AIcrowd/whest/issues/34)). This is the same caveat that keeps [#58](https://github.com/AIcrowd/whest/issues/58) partially-addressed rather than closed. Above SymmetryGroup degree 12 the unique-element calculation itself is skipped (Burnside on `S_n` for `n > 12` is infeasible) and `CostFallbackWarning` fires.

## Merge plan

We do **not** intend to merge this PR immediately. The current plan is:

1. Review the protocol-dispatch design for shape, ergonomics, and correctness — especially the strip-before-NumPy invariant and the `_inplace_from_result` symmetry guard.
2. Test the branch interactively with small runnable examples (a follow-up comment will add snippets).
3. ~~Address the 268 `numpy_compat/` xfails (separate PR).~~ **Done in this PR** — across the strip-and-identity fixes ([6085e09bc](https://github.com/AIcrowd/whest/commit/6085e09bc)), the deliberate-rejection xfails ([a129875ba](https://github.com/AIcrowd/whest/commit/a129875ba)), the multi-output ufunc support ([709b32a60](https://github.com/AIcrowd/whest/commit/709b32a60)), and the generic ufunc-method support ([c58454d97](https://github.com/AIcrowd/whest/commit/c58454d97)). Suite is now green (**7,804 passed, 0 failures, 89 xfailed all categorized & justified**).
4. Optionally address the follow-up issues spun off from this PR ([#68](https://github.com/AIcrowd/whest/issues/68), [#69](https://github.com/AIcrowd/whest/issues/69), [#70](https://github.com/AIcrowd/whest/issues/70), [#71](https://github.com/AIcrowd/whest/issues/71), [#72](https://github.com/AIcrowd/whest/issues/72), [#73](https://github.com/AIcrowd/whest/issues/73)) in separate PRs.
5. Merge only after the protocol design is settled and the perf invariants from #51 are confirmed preserved (per-test runtime stays at #51's improved level).

I'll add a follow-up comment with small runnable protocol-dispatch snippets so reviewers can quickly try the branch in a terminal.








