### PR TITLE
perf(validation): make per-op check_nan_inf opt-in (default off)

### DIFF
--- a/src/flopscope/_config.py
+++ b/src/flopscope/_config.py
@@ -6,6 +6,7 @@ _SETTINGS: dict[str, object] = {
     "symmetry_warnings": True,
     "use_inner_symmetry": True,
     "einsum_path_cache_size": 4096,
+    "check_nan_inf": False,
 }
 
 
@@ -25,6 +26,13 @@ def configure(**kwargs: object) -> None:
         Maximum number of entries in the einsum path cache.
         Changing this rebuilds the cache (old entries are discarded).
         Default ``4096``.
+    check_nan_inf : bool
+        If ``True``, scan every counted op's output for NaN/Inf values and
+        emit a :class:`~flopscope.errors.FlopscopeWarning` if any are found.
+        The scan is two full O(n) sweeps over the result and is silently
+        attributed to ``untracked_time``, so it is off by default for
+        production scoring.  Opt in when debugging an estimator that
+        produces NaN/Inf to identify the introducing op.  Default ``False``.
 
     Returns
     -------
@@ -36,6 +44,7 @@ def configure(**kwargs: object) -> None:
     >>> import flopscope as flops
     >>> flops.configure(einsum_path_cache_size=8192)
     >>> flops.configure(symmetry_warnings=False)
+    >>> flops.configure(check_nan_inf=True)
     """
     for key, value in kwargs.items():
         if key not in _SETTINGS:

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -13,7 +13,7 @@ from flopscope._perm_group import SymmetryGroup
 from flopscope._pointwise import _prepare_symmetric_out, _validate_result_symmetry
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import normalize_symmetry_input, validate_symmetry_group
-from flopscope._validation import check_nan_inf, require_budget
+from flopscope._validation import maybe_check_nan_inf, require_budget
 
 
 def _symmetry_fingerprint(operands, input_parts):
@@ -396,7 +396,7 @@ def einsum(
     if out is not None:
         _validate_result_symmetry(result, target_symmetry)
         _np.copyto(_np.asarray(out), _np.asarray(result), casting="unsafe")
-        check_nan_inf(out, "einsum")
+        maybe_check_nan_inf(out, "einsum")
         return out
 
     if target_symmetry is not None:
@@ -405,7 +405,7 @@ def einsum(
     else:
         result = _asflopscope(_np.asarray(result))
 
-    check_nan_inf(result, "einsum")
+    maybe_check_nan_inf(result, "einsum")
     return result  # type: ignore[return-value]
 
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -47,7 +47,7 @@ from flopscope._symmetry_utils import (
     restrict_group_to_axes,
     unique_elements_for_shape,
 )
-from flopscope._validation import check_nan_inf, require_budget
+from flopscope._validation import maybe_check_nan_inf, require_budget
 from flopscope.errors import (
     CostFallbackWarning,
     SymmetryError,
@@ -355,7 +355,7 @@ def _counted_unary(np_func, op_name: str):
                 supports_out=supports_out,
                 **kwargs,
             )
-        check_nan_inf(result, op_name)
+        maybe_check_nan_inf(result, op_name)
         return _wrap_result(result, out=out, symmetry=symmetry)  # type: ignore[return-value]
 
     wrapper.__name__ = op_name
@@ -453,7 +453,7 @@ def _counted_binary(np_func, op_name: str):
                 supports_out=supports_out,
                 **kwargs,
             )
-        check_nan_inf(result, op_name)
+        maybe_check_nan_inf(result, op_name)
         if out_symmetry is not None:
             lost = []
             for group in aligned_inputs:
@@ -1008,7 +1008,7 @@ def around(
             out=None if isinstance(out, SymmetricTensor) else out,
             supports_out=True,
         )
-    check_nan_inf(result, "around")
+    maybe_check_nan_inf(result, "around")
     if (
         a_is_scalar
         and out is None
@@ -1092,7 +1092,7 @@ def round(
             out=None if isinstance(out, SymmetricTensor) else out,
             supports_out=True,
         )
-    check_nan_inf(result, "round")
+    maybe_check_nan_inf(result, "round")
     if (
         a_is_scalar
         and out is None
@@ -1385,7 +1385,7 @@ def clip(
             **kwargs,
         )
     if a.dtype.kind in ("f", "c"):
-        check_nan_inf(result, "clip")
+        maybe_check_nan_inf(result, "clip")
     return _wrap_result(result, out=out, symmetry=symmetry)  # type: ignore[return-value]
 
 
@@ -1544,7 +1544,7 @@ def dot(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
         # Strip flopscope subclasses so the raw NumPy call does not re-dispatch
         # through __array_ufunc__ (matmul is a ufunc) / __array_function__.
         result = _np.dot(_to_base_ndarray(a), _to_base_ndarray(b))
-    check_nan_inf(result, "dot")
+    maybe_check_nan_inf(result, "dot")
     return _asflopscope(result) if inputs_were_whest else result  # type: ignore[return-value]
 
 
@@ -1586,7 +1586,7 @@ def matmul(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     ):
         with _np.errstate(divide="ignore", over="ignore", invalid="ignore"):
             result = _np.matmul(_to_base_ndarray(a), _to_base_ndarray(b))
-    check_nan_inf(result, "matmul")
+    maybe_check_nan_inf(result, "matmul")
     return _asflopscope(result) if inputs_were_whest else result  # type: ignore[return-value]
 
 

--- a/src/flopscope/_validation.py
+++ b/src/flopscope/_validation.py
@@ -66,3 +66,18 @@ def check_nan_inf(result: np.ndarray, op_name: str) -> None:
             FlopscopeWarning,
             stacklevel=3,
         )
+
+
+def maybe_check_nan_inf(result: object, op_name: str) -> None:
+    """Run :func:`check_nan_inf` only if the global ``check_nan_inf`` setting is on.
+
+    Production scoring runs with the setting off (default) and pays no
+    per-op O(n) scan cost.  Debug callers opt in via
+    ``flopscope.configure(check_nan_inf=True)``.
+    """
+    from flopscope._config import get_setting
+
+    if not get_setting("check_nan_inf"):
+        return
+    if isinstance(result, np.ndarray):
+        check_nan_inf(result, op_name)

--- a/src/flopscope/numpy/linalg/_svd.py
+++ b/src/flopscope/numpy/linalg/_svd.py
@@ -8,7 +8,7 @@ from numpy.typing import ArrayLike
 
 from flopscope._flops import svd_cost
 from flopscope._ndarray import FlopscopeArray, _asflopscope, _to_base_ndarray
-from flopscope._validation import check_nan_inf, require_budget
+from flopscope._validation import maybe_check_nan_inf, require_budget
 
 
 def _batch_size(shape):
@@ -95,14 +95,14 @@ def svd(
                 S = S[..., :k]
                 U = U[..., :k]
                 Vt = Vt[..., :k, :]
-            check_nan_inf(S, "linalg.svd")
+            maybe_check_nan_inf(S, "linalg.svd")
         else:
             S = _np.linalg.svd(
                 _to_base_ndarray(a), compute_uv=False, hermitian=hermitian
             )
             if k is not None:
                 S = S[..., :k]
-            check_nan_inf(S, "linalg.svd")
+            maybe_check_nan_inf(S, "linalg.svd")
 
     if compute_uv:
         if inputs_were_whest:

--- a/tests/test_pointwise.py
+++ b/tests/test_pointwise.py
@@ -137,6 +137,14 @@ def test_counted_op_outside_context():
 
 
 def test_nan_warning():
-    with BudgetContext(flop_budget=10**6):
-        with pytest.warns(match="NaN"):
-            log(numpy.array([0.0]))
+    import flopscope as flops
+    from flopscope._config import get_setting
+
+    original = get_setting("check_nan_inf")
+    try:
+        flops.configure(check_nan_inf=True)
+        with BudgetContext(flop_budget=10**6):
+            with pytest.warns(match="NaN"):
+                log(numpy.array([0.0]))
+    finally:
+        flops.configure(check_nan_inf=original)

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -285,6 +285,90 @@ class TestCheckNanInf:
         assert len(w) == 0
 
 
+class TestMaybeCheckNanInf:
+    """Cover the gated wrapper around check_nan_inf (issue #77)."""
+
+    def test_default_off_skips_check(self):
+        from flopscope._config import get_setting
+        from flopscope._validation import maybe_check_nan_inf
+
+        assert get_setting("check_nan_inf") is False
+        arr = numpy.array([1.0, float("nan"), 3.0])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            maybe_check_nan_inf(arr, "test_op")
+        assert len(w) == 0
+
+    def test_when_on_runs_check(self):
+        import flopscope as flops
+        from flopscope._config import get_setting
+        from flopscope._validation import maybe_check_nan_inf
+        from flopscope.errors import FlopscopeWarning
+
+        original = get_setting("check_nan_inf")
+        try:
+            flops.configure(check_nan_inf=True)
+            arr = numpy.array([1.0, float("nan"), 3.0])
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                maybe_check_nan_inf(arr, "test_op")
+            assert len(w) == 1
+            assert issubclass(w[0].category, FlopscopeWarning)
+            assert "1 NaN" in str(w[0].message)
+        finally:
+            flops.configure(check_nan_inf=original)
+
+    def test_non_array_skipped_when_on(self):
+        import flopscope as flops
+        from flopscope._config import get_setting
+        from flopscope._validation import maybe_check_nan_inf
+
+        original = get_setting("check_nan_inf")
+        try:
+            flops.configure(check_nan_inf=True)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                maybe_check_nan_inf(42, "test_op")
+            assert len(w) == 0
+        finally:
+            flops.configure(check_nan_inf=original)
+
+    def test_wrapper_op_silent_by_default(self):
+        """Production-scoring path: a wrapper op that produces Inf does not warn."""
+        import flopscope.numpy as fnp
+        from flopscope.errors import FlopscopeWarning
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with BudgetContext(flop_budget=10_000), np.errstate(divide="ignore"):
+                fnp.divide(numpy.array([1.0]), numpy.array([0.0]))
+        assert not any(
+            issubclass(rec.category, FlopscopeWarning) and "Inf" in str(rec.message)
+            for rec in w
+        )
+
+    def test_wrapper_op_warns_when_enabled(self):
+        """Debug path: opting in surfaces the Inf-producing op."""
+        import flopscope as flops
+        import flopscope.numpy as fnp
+        from flopscope._config import get_setting
+        from flopscope.errors import FlopscopeWarning
+
+        original = get_setting("check_nan_inf")
+        try:
+            flops.configure(check_nan_inf=True)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                with BudgetContext(flop_budget=10_000), np.errstate(divide="ignore"):
+                    fnp.divide(numpy.array([1.0]), numpy.array([0.0]))
+            assert any(
+                issubclass(rec.category, FlopscopeWarning) and "Inf" in str(rec.message)
+                for rec in w
+            )
+        finally:
+            flops.configure(check_nan_inf=original)
+
+
 class TestCoerceArrays:
     """Cover line 39: coerce_arrays tuple conversion."""
 
@@ -666,6 +750,28 @@ class TestConfigureUnknownSetting:
 
         with pytest.raises(ValueError, match="Unknown setting"):
             configure(nonexistent_option=True)
+
+
+class TestCheckNanInfSetting:
+    """Cover the new check_nan_inf config flag (issue #77)."""
+
+    def test_default_false(self):
+        from flopscope._config import get_setting
+
+        assert get_setting("check_nan_inf") is False
+
+    def test_can_be_toggled(self):
+        import flopscope as flops
+        from flopscope._config import get_setting
+
+        original = get_setting("check_nan_inf")
+        try:
+            flops.configure(check_nan_inf=True)
+            assert get_setting("check_nan_inf") is True
+            flops.configure(check_nan_inf=False)
+            assert get_setting("check_nan_inf") is False
+        finally:
+            flops.configure(check_nan_inf=original)
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #77 (Part 1 only).

## Summary
- Add `check_nan_inf: bool = False` to `flopscope.configure(...)`
- New `maybe_check_nan_inf` helper in `_validation.py` that gates on the setting; `check_nan_inf` itself unchanged
- Rename 11 internal call sites (`_pointwise.py`, `_einsum.py`, `numpy/linalg/_svd.py`) to use the helper

Production scoring stops paying ~1.5 ms / `predict` (~18 % of `untracked_time`) on the cov-prop baseline at width=256 / depth=8. Debug callers opt in via `flopscope.configure(check_nan_inf=True)` to surface ops that introduce NaN/Inf.

## Why this design
- **Default `False`** per the issue spec — production scoring runs unattended and the warnings were never observed; the per-op O(n) scan was pure overhead.
- **Helper, not in-function gate.** The six existing `TestCheckNanInf` tests in [`tests/test_remaining_coverage.py`](tests/test_remaining_coverage.py) call `check_nan_inf` directly; keeping its current contract avoids touching them. The gate lives at the call site under the self-documenting `maybe_check_nan_inf` name, which also avoids paying any function-call overhead when off.
- **Parts 2 + 3 deferred.** The issue ordered the changes by impact and complexity. Part 2 (per-op `can_produce_nan_inf` skip on the `_counted_unary` / `_counted_binary` factories) requires a per-op audit and only saves ~1.0 ms in debug mode. Part 3 (move the call inside the `with budget.deduct(...)` window) reattributes ~1.5 ms from `untracked_time` to `tracked_time` only when the gate is on. Both are tracked as follow-ups.

## Behaviour change
- Anyone relying on `FlopscopeWarning` firing implicitly during scoring will lose those warnings unless they opt in. One existing test (`tests/test_pointwise.py::test_nan_warning`) was updated to `configure(check_nan_inf=True)` for that reason; no other tests depended on the implicit behaviour.

## Test plan
- [x] `make lint` — clean
- [x] `make typecheck` — 0 errors (4 pre-existing warnings unrelated)
- [x] `make test` — 3293 passed, 64 skipped, coverage 91.43 % (≥ 90 % gate); `_validation.py` 100 %
- [x] New tests: `TestMaybeCheckNanInf` (5 cases) + `TestCheckNanInfSetting` (2 cases) in [`tests/test_remaining_coverage.py`](tests/test_remaining_coverage.py)
- [x] End-to-end smoke check:
  - default off → 0 `FlopscopeWarning`
  - `configure(check_nan_inf=True)` → 1 `FlopscopeWarning`