### PR TITLE
Track flopscope's own dispatch overhead as a separate BudgetContext field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## Unreleased
+
+### BREAKING
+
+- `BudgetContext.untracked_time` and `summary_dict()["untracked_time_s"]` now
+  subtract the new `flopscope_overhead_time_s` bucket. Consumers that previously
+  read `untracked_time` as a proxy for "all unattributed time" should switch to
+  `flopscope_overhead_time + untracked_time` for the old value, or stay on
+  `untracked_time` for the new (more meaningful) "genuinely neither" residual.
+
+- `BudgetContext.tracked_time` semantics tightened: now reflects ONLY the wall
+  time of the inner numpy call, not the entire `with budget.deduct(...):`
+  block. Time spent in flopscope's pre/post-numpy work inside the block (view-
+  casts, copyto fallbacks, dispatch logic) is now attributed to
+  `flopscope_overhead_time`.
+
+### Added
+
+- `BudgetContext.flopscope_overhead_time` property — measured wall-clock time
+  spent inside flopscope's own dispatch code.
+- `summary_dict()["flopscope_overhead_time_s"]` and the same key per namespace
+  bucket in `summary_dict(by_namespace=True)`.
+- `OpRecord.flopscope_overhead` — per-op overhead in seconds.
+
+### Changed
+
+- `flopscope.configure(check_nan_inf=True)` — opt-in scan time is now attributed
+  to `flopscope_overhead_time` instead of `untracked_time`.

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -96,6 +96,27 @@ class _OpTimer:
         return False
 
 
+def _call_numpy(fn, *args, **kwargs):
+    """Invoke a numpy callable, attributing only its wall time to tracked_time.
+
+    All numpy calls inside counted-op wrappers MUST go through this helper so
+    that view-casts, copyto, errstate setup, and other flopscope-internal work
+    surrounding the call are correctly bucketed as flopscope_overhead.
+
+    Reports the call's duration to the active _OpTimer (via
+    budget._current_op_timer). When no timer is active (e.g. helper called
+    from a non-counted code path), it is a transparent passthrough.
+    """
+    t0 = time.perf_counter()
+    try:
+        return fn(*args, **kwargs)
+    finally:
+        d = time.perf_counter() - t0
+        budget = get_active_budget()
+        if budget is not None and budget._current_op_timer is not None:
+            budget._current_op_timer._np_duration += d
+
+
 _thread_local = threading.local()
 _all_budget_contexts: weakref.WeakSet[BudgetContext] = weakref.WeakSet()
 

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -216,15 +216,18 @@ def _summarize_by_namespace(op_log: list[OpRecord]) -> dict[str | None, dict]:
 
 
 def _timing_summary(
-    wall_time_s: float | None, tracked_time_s: float | None
-) -> tuple[float | None, float, float | None]:
+    wall_time_s: float | None,
+    tracked_time_s: float | None,
+    overhead_time_s: float | None,
+) -> tuple[float | None, float, float, float | None]:
     tracked = tracked_time_s or 0.0
+    overhead = overhead_time_s or 0.0
     if wall_time_s is None:
-        return None, tracked, None
-    untracked = wall_time_s - tracked
+        return None, tracked, overhead, None
+    untracked = wall_time_s - tracked - overhead
     if untracked < 0 and abs(untracked) < 1e-12:
         untracked = 0.0
-    return wall_time_s, tracked, max(untracked, 0.0)
+    return wall_time_s, tracked, overhead, max(untracked, 0.0)
 
 
 class BudgetContext:
@@ -404,9 +407,10 @@ class BudgetContext:
         wall_time = self._wall_time_s
         if wall_time is None and self._start_time is not None:
             wall_time = self.elapsed_s
-        wall_time, tracked_time, untracked_time = _timing_summary(
-            wall_time, self._total_tracked_time
+        wall_time, tracked_time, overhead_time, untracked_time = _timing_summary(
+            wall_time, self._total_tracked_time, self._total_flopscope_overhead_time
         )
+        del overhead_time  # exposed via summary_dict in Task 5
 
         result = {
             "flop_budget": self._flop_budget,
@@ -656,9 +660,10 @@ class BudgetAccumulator:
             if rec.total_tracked_time is not None:
                 total_tracked = (total_tracked or 0.0) + rec.total_tracked_time
 
-        wall_time, tracked_time, untracked_time = _timing_summary(
-            total_wall_time, total_tracked
+        wall_time, tracked_time, overhead_time, untracked_time = _timing_summary(
+            total_wall_time, total_tracked, None
         )
+        del overhead_time  # accumulator overhead wiring lands in Task 13
 
         result = {
             "flop_budget": total_budget,

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -282,6 +282,7 @@ def _summarize_by_namespace(op_log: list[OpRecord]) -> dict[str | None, dict]:
                 "flops_used": 0,
                 "calls": 0,
                 "tracked_time_s": 0.0,
+                "flopscope_overhead_time_s": 0.0,
                 "operations": {},
             },
         )
@@ -289,6 +290,8 @@ def _summarize_by_namespace(op_log: list[OpRecord]) -> dict[str | None, dict]:
         bucket["calls"] += 1
         if op.duration is not None:
             bucket["tracked_time_s"] += op.duration
+        if op.flopscope_overhead is not None:
+            bucket["flopscope_overhead_time_s"] += op.flopscope_overhead
         _update_operation_summary(bucket["operations"], op)
     return by_namespace
 

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -440,42 +440,54 @@ class BudgetContext:
         self, op_name: str, *, flop_cost: int, subscripts: str | None, shapes: tuple
     ) -> _OpTimer:
         """Deduct FLOPs from the budget and return a timer context manager."""
-        from flopscope._weights import get_weight
+        fs_t0 = time.perf_counter()
+        appended = False
+        try:
+            from flopscope._weights import get_weight
 
-        weight = get_weight(op_name)
-        adjusted_cost = int(flop_cost * self._flop_multiplier * weight)
-        if adjusted_cost > self.flops_remaining:
-            raise BudgetExhaustedError(
-                op_name, flop_cost=adjusted_cost, flops_remaining=self.flops_remaining
+            weight = get_weight(op_name)
+            adjusted_cost = int(flop_cost * self._flop_multiplier * weight)
+            if adjusted_cost > self.flops_remaining:
+                raise BudgetExhaustedError(
+                    op_name, flop_cost=adjusted_cost, flops_remaining=self.flops_remaining
+                )
+            self._flops_used += adjusted_cost
+
+            now = time.perf_counter()
+            timestamp = now - self._start_time if self._start_time is not None else None
+
+            self._op_log.append(
+                OpRecord(
+                    op_name=op_name,
+                    subscripts=subscripts,
+                    shapes=shapes,
+                    flop_cost=adjusted_cost,
+                    cumulative=self._flops_used,
+                    namespace=self.namespace,
+                    timestamp=timestamp,
+                )
             )
-        self._flops_used += adjusted_cost
+            appended = True
 
-        now = time.perf_counter()
-        timestamp = now - self._start_time if self._start_time is not None else None
+            if self._deadline is not None and now > self._deadline:
+                from flopscope.errors import TimeExhaustedError
 
-        self._op_log.append(
-            OpRecord(
-                op_name=op_name,
-                subscripts=subscripts,
-                shapes=shapes,
-                flop_cost=adjusted_cost,
-                cumulative=self._flops_used,
-                namespace=self.namespace,
-                timestamp=timestamp,
-            )
-        )
+                raise TimeExhaustedError(
+                    op_name,
+                    elapsed_s=now - self._start_time,  # type: ignore[operator]
+                    limit_s=self._wall_time_limit_s,  # type: ignore[arg-type]
+                )
 
-        if self._deadline is not None and now > self._deadline:
-            from flopscope.errors import TimeExhaustedError
-
-            raise TimeExhaustedError(
-                op_name,
-                elapsed_s=now - self._start_time,  # type: ignore[operator]
-                limit_s=self._wall_time_limit_s,  # type: ignore[arg-type]
-            )
-
-        op_index = len(self._op_log) - 1
-        return _OpTimer(self, op_index=op_index)
+            op_index = len(self._op_log) - 1
+            return _OpTimer(self, op_index=op_index)
+        finally:
+            deduct_body_time = time.perf_counter() - fs_t0
+            self._total_flopscope_overhead_time += deduct_body_time
+            if appended:
+                op = self._op_log[-1]
+                self._op_log[-1] = op._replace(
+                    flopscope_overhead=(op.flopscope_overhead or 0.0) + deduct_body_time
+                )
 
     def summary_dict(self, by_namespace: bool = False) -> dict:
         """Return structured summary data for this budget context."""

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -283,9 +283,12 @@ class BudgetContext:
         self._deadline: float | None = None
         self._wall_time_s: float | None = None
         self._total_tracked_time: float = 0.0
+        self._total_flopscope_overhead_time: float = 0.0
+        self._current_op_timer: _OpTimer | None = None
         self._recorded_flops_used = 0
         self._recorded_op_count = 0
         self._recorded_tracked_time = 0.0
+        self._recorded_overhead_time: float = 0.0
         self._budget_recorded = False
         _all_budget_contexts.add(self)
 

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -6,7 +6,7 @@ import functools
 import threading
 import time
 import weakref
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 from flopscope.errors import BudgetExhaustedError
 
@@ -114,7 +114,7 @@ class _OpTimer:
         return False
 
 
-def _call_numpy(fn, *args, **kwargs):
+def _call_numpy(fn: Any, *args: Any, **kwargs: Any) -> Any:
     """Invoke a numpy callable, attributing only its wall time to tracked_time.
 
     All numpy calls inside counted-op wrappers MUST go through this helper so
@@ -124,6 +124,10 @@ def _call_numpy(fn, *args, **kwargs):
     Reports the call's duration to the active _OpTimer (via
     budget._current_op_timer). When no timer is active (e.g. helper called
     from a non-counted code path), it is a transparent passthrough.
+
+    Annotated as ``Any -> Any`` to match the existing untyped-internal-helper
+    convention used by ``_call_with_optional_out``. Wrappers' explicit return
+    annotations carry the public type contract.
     """
     t0 = time.perf_counter()
     try:

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -340,6 +340,20 @@ class BudgetContext:
         return self._total_tracked_time
 
     @property
+    def flopscope_overhead_time(self) -> float:
+        """Wall-clock seconds spent inside flopscope's own dispatch code.
+
+        Includes wrapper preambles, BudgetContext.deduct() body, _OpTimer
+        bookkeeping, the flopscope-internal parts of the timed block (view-
+        casts, copyto, dispatch), wrapper postambles (including
+        maybe_check_nan_inf when opted in), and namespace push/pop.
+
+        Measured per op via the @_counted_wrapper decorator. Aggregated per
+        namespace via summary_dict(by_namespace=True).
+        """
+        return self._total_flopscope_overhead_time
+
+    @property
     def untracked_time(self) -> float | None:
         if self._wall_time_s is None:
             return None

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -117,6 +117,43 @@ def _call_numpy(fn, *args, **kwargs):
             budget._current_op_timer._np_duration += d
 
 
+def _counted_wrapper(fn):
+    """Decorator that brackets a flopscope wrapper and bills its non-numpy,
+    non-nested-overhead time to flopscope_overhead_time.
+
+    Formula: wall - tracked_delta - overhead_delta. Handles nesting naturally
+    (outer attributes only its own remainder), so no re-entrancy guard.
+
+    Per-op attribution: wrapper-own overhead is distributed equally across
+    ops created during this call (typically exactly 1 across this codebase).
+    """
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        from flopscope._validation import require_budget
+        budget = require_budget()
+        fs_t0 = time.perf_counter()
+        tracked_baseline = budget._total_tracked_time
+        overhead_baseline = budget._total_flopscope_overhead_time
+        ops_before = len(budget._op_log)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            wall = time.perf_counter() - fs_t0
+            tracked_delta = budget._total_tracked_time - tracked_baseline
+            overhead_delta = budget._total_flopscope_overhead_time - overhead_baseline
+            wrapper_own_overhead = max(wall - tracked_delta - overhead_delta, 0.0)
+            budget._total_flopscope_overhead_time += wrapper_own_overhead
+            ops_added = list(range(ops_before, len(budget._op_log)))
+            if ops_added and wrapper_own_overhead > 0:
+                per_op = wrapper_own_overhead / len(ops_added)
+                for idx in ops_added:
+                    op = budget._op_log[idx]
+                    budget._op_log[idx] = op._replace(
+                        flopscope_overhead=(op.flopscope_overhead or 0.0) + per_op
+                    )
+    return wrapped
+
+
 _thread_local = threading.local()
 _all_budget_contexts: weakref.WeakSet[BudgetContext] = weakref.WeakSet()
 

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -374,6 +374,7 @@ class BudgetContext:
         self._recorded_tracked_time = 0.0
         self._recorded_overhead_time: float = 0.0
         self._budget_recorded = False
+        self._current_op_timer: _OpTimer | None = None
         _all_budget_contexts.add(self)
 
     @property

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -52,35 +52,49 @@ class OpRecord(NamedTuple):
 
 
 class _OpTimer:
-    """Lightweight timer returned by BudgetContext.deduct().
+    """Timer for a counted op's numpy call window.
 
-    Use as a context manager to measure wall-clock duration of the
-    numpy operation that follows the FLOP deduction::
+    Used as a context manager around the numpy call::
 
-        with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=(...)):
-            result = np_func(x)
+        with budget.deduct(op_name, ...):
+            result = _call_numpy(np_func, ...)
 
-    If used without ``with``, duration stays ``None`` on the OpRecord.
+    On __exit__, the block's wall time is split into:
+      - tracked_time:  sum of _call_numpy durations reported during the block
+      - in-block overhead: block_duration - tracked (view-casts, copyto, etc.)
     """
 
-    __slots__ = ("_budget", "_start")
+    __slots__ = ("_budget", "_op_index", "_block_t0", "_np_duration", "_prev_timer")
 
-    def __init__(self, budget: BudgetContext):
+    def __init__(self, budget: BudgetContext, op_index: int):
         self._budget = budget
-        self._start: float | None = None
+        self._op_index = op_index
+        self._block_t0: float | None = None
+        self._np_duration: float = 0.0
+        self._prev_timer: _OpTimer | None = None
 
     def __enter__(self) -> _OpTimer:
-        self._start = time.perf_counter()
+        self._block_t0 = time.perf_counter()
+        # Stack discipline supports the rare case of nested deduct() blocks
+        self._prev_timer = self._budget._current_op_timer
+        self._budget._current_op_timer = self
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
-        if self._start is not None:
-            duration = time.perf_counter() - self._start
-            log = self._budget._op_log
-            log[-1] = log[-1]._replace(duration=duration)
-            self._budget._total_tracked_time += duration
+        if self._block_t0 is not None:
+            block_duration = time.perf_counter() - self._block_t0
+            in_block_overhead = max(block_duration - self._np_duration, 0.0)
 
-            # Post-op deadline check: only if no exception is already propagating
+            self._budget._total_tracked_time += self._np_duration
+            self._budget._total_flopscope_overhead_time += in_block_overhead
+
+            op = self._budget._op_log[self._op_index]
+            self._budget._op_log[self._op_index] = op._replace(
+                duration=self._np_duration,
+                flopscope_overhead=(op.flopscope_overhead or 0.0) + in_block_overhead,
+            )
+
+            # Post-op deadline check (preserves existing behavior)
             if (
                 exc_type is None
                 and self._budget._deadline is not None
@@ -89,10 +103,12 @@ class _OpTimer:
                 from flopscope.errors import TimeExhaustedError
 
                 raise TimeExhaustedError(
-                    log[-1].op_name,
+                    op.op_name,
                     elapsed_s=time.perf_counter() - self._budget._start_time,  # type: ignore[operator]
                     limit_s=self._budget._wall_time_limit_s,  # type: ignore[arg-type]
                 )
+
+        self._budget._current_op_timer = self._prev_timer
         return False
 
 
@@ -458,7 +474,8 @@ class BudgetContext:
                 limit_s=self._wall_time_limit_s,  # type: ignore[arg-type]
             )
 
-        return _OpTimer(self)
+        op_index = len(self._op_log) - 1
+        return _OpTimer(self, op_index=op_index)
 
     def summary_dict(self, by_namespace: bool = False) -> dict:
         """Return structured summary data for this budget context."""

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -410,7 +410,6 @@ class BudgetContext:
         wall_time, tracked_time, overhead_time, untracked_time = _timing_summary(
             wall_time, self._total_tracked_time, self._total_flopscope_overhead_time
         )
-        del overhead_time  # exposed via summary_dict in Task 5
 
         result = {
             "flop_budget": self._flop_budget,
@@ -419,6 +418,7 @@ class BudgetContext:
             "operations": _summarize_operations(self._op_log),
             "wall_time_s": wall_time,
             "tracked_time_s": tracked_time,
+            "flopscope_overhead_time_s": overhead_time,
             "untracked_time_s": untracked_time,
         }
         if by_namespace:

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -460,7 +460,14 @@ class BudgetContext:
         """
         if self._wall_time_s is None:
             return None
-        return self._wall_time_s - self._total_tracked_time
+        residual = (
+            self._wall_time_s
+            - self._total_tracked_time
+            - self._total_flopscope_overhead_time
+        )
+        if residual < 0 and abs(residual) < 1e-12:
+            return 0.0
+        return max(residual, 0.0)
 
     def deduct(
         self, op_name: str, *, flop_cost: int, subscripts: str | None, shapes: tuple

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -439,6 +439,16 @@ class BudgetContext:
 
     @property
     def untracked_time(self) -> float | None:
+        """Wall time minus tracked_time minus flopscope_overhead_time.
+
+        Genuinely 'neither' — user Python between ops, time.sleep, GC pauses,
+        un-instrumented numpy.
+
+        BREAKING (vs versions before issue #76): previously was
+        wall_time - tracked_time. The new value subtracts measured framework
+        overhead. To recover the prior 'all-unattributed' value, compute
+        flopscope_overhead_time + untracked_time.
+        """
         if self._wall_time_s is None:
             return None
         return self._wall_time_s - self._total_tracked_time
@@ -497,7 +507,18 @@ class BudgetContext:
                 )
 
     def summary_dict(self, by_namespace: bool = False) -> dict:
-        """Return structured summary data for this budget context."""
+        """Return structured summary data for this budget context.
+
+        Returns a dict with keys ``flop_budget``, ``flops_used``,
+        ``flops_remaining``, ``operations``, ``wall_time_s``,
+        ``tracked_time_s``, ``flopscope_overhead_time_s``,
+        ``untracked_time_s``, and optionally ``by_namespace`` with per-
+        namespace buckets that each include the same timing keys.
+
+        Decomposition: ``wall_time_s == tracked_time_s
+        + flopscope_overhead_time_s + untracked_time_s`` (within numerical
+        tolerance).
+        """
         wall_time = self._wall_time_s
         if wall_time is None and self._start_time is not None:
             wall_time = self.elapsed_s
@@ -821,8 +842,8 @@ def budget_summary_dict(by_namespace: bool = False) -> dict:
     dict
         Dictionary with keys ``"flop_budget"``, ``"flops_used"``,
         ``"flops_remaining"``, ``"operations"``, ``"wall_time_s"``,
-        ``"tracked_time_s"``, ``"untracked_time_s"``, and optionally
-        ``"by_namespace"`` with exact attribution buckets.
+        ``"tracked_time_s"``, ``"flopscope_overhead_time_s"``,
+        ``"untracked_time_s"``, and optionally ``"by_namespace"``.
 
     Examples
     --------

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -22,7 +22,9 @@ class OpRecord(NamedTuple):
     namespace: str | None = None
     timestamp: float | None = None  # seconds since context __enter__
     duration: float | None = None  # wall-clock seconds of the numpy call
-    flopscope_overhead: float | None = None  # per-op flopscope dispatch time (preamble + deduct body + bookkeeping + postamble)
+    flopscope_overhead: float | None = (
+        None  # per-op flopscope dispatch time (preamble + deduct body + bookkeeping + postamble)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -143,9 +145,11 @@ def _counted_wrapper(fn):
     Per-op attribution: wrapper-own overhead is distributed equally across
     ops created during this call (typically exactly 1 across this codebase).
     """
+
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
         from flopscope._validation import require_budget
+
         budget = require_budget()
         fs_t0 = time.perf_counter()
         tracked_baseline = budget._total_tracked_time
@@ -167,6 +171,7 @@ def _counted_wrapper(fn):
                     budget._op_log[idx] = op._replace(
                         flopscope_overhead=(op.flopscope_overhead or 0.0) + per_op
                     )
+
     return wrapped
 
 
@@ -466,7 +471,9 @@ class BudgetContext:
             adjusted_cost = int(flop_cost * self._flop_multiplier * weight)
             if adjusted_cost > self.flops_remaining:
                 raise BudgetExhaustedError(
-                    op_name, flop_cost=adjusted_cost, flops_remaining=self.flops_remaining
+                    op_name,
+                    flop_cost=adjusted_cost,
+                    flops_remaining=self.flops_remaining,
                 )
             self._flops_used += adjusted_cost
 
@@ -572,7 +579,9 @@ class BudgetContext:
         if tracked_delta < 0 and abs(tracked_delta) < 1e-12:
             tracked_delta = 0.0
 
-        overhead_delta = self._total_flopscope_overhead_time - self._recorded_overhead_time
+        overhead_delta = (
+            self._total_flopscope_overhead_time - self._recorded_overhead_time
+        )
         if overhead_delta < 0 and abs(overhead_delta) < 1e-12:
             overhead_delta = 0.0
 
@@ -784,7 +793,9 @@ class BudgetAccumulator:
             if rec.total_tracked_time is not None:
                 total_tracked = (total_tracked or 0.0) + rec.total_tracked_time
             if rec.total_flopscope_overhead_time is not None:
-                total_overhead = (total_overhead or 0.0) + rec.total_flopscope_overhead_time
+                total_overhead = (
+                    total_overhead or 0.0
+                ) + rec.total_flopscope_overhead_time
 
         wall_time, tracked_time, overhead_time, untracked_time = _timing_summary(
             total_wall_time, total_tracked, total_overhead

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -374,7 +374,6 @@ class BudgetContext:
         self._recorded_tracked_time = 0.0
         self._recorded_overhead_time: float = 0.0
         self._budget_recorded = False
-        self._current_op_timer: _OpTimer | None = None
         _all_budget_contexts.add(self)
 
     @property

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -22,6 +22,7 @@ class OpRecord(NamedTuple):
     namespace: str | None = None
     timestamp: float | None = None  # seconds since context __enter__
     duration: float | None = None  # wall-clock seconds of the numpy call
+    flopscope_overhead: float | None = None  # per-op flopscope dispatch time (preamble + deduct body + bookkeeping + postamble)
 
 
 # ---------------------------------------------------------------------------

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -187,11 +187,15 @@ class _NamespaceScope:
         self._segment = segment
 
     def __enter__(self) -> BudgetContext:
+        t0 = time.perf_counter()
         self._budget._push_namespace(self._segment)
+        self._budget._total_flopscope_overhead_time += time.perf_counter() - t0
         return self._budget
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
+        t0 = time.perf_counter()
         self._budget._pop_namespace(self._segment)
+        self._budget._total_flopscope_overhead_time += time.perf_counter() - t0
         return False
 
 

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -457,6 +457,10 @@ class BudgetContext:
         if tracked_delta < 0 and abs(tracked_delta) < 1e-12:
             tracked_delta = 0.0
 
+        overhead_delta = self._total_flopscope_overhead_time - self._recorded_overhead_time
+        if overhead_delta < 0 and abs(overhead_delta) < 1e-12:
+            overhead_delta = 0.0
+
         return NamespaceRecord(
             namespace=self.namespace,
             flop_budget=0 if self._budget_recorded else self.flop_budget,
@@ -464,6 +468,7 @@ class BudgetContext:
             op_log=list(self._op_log[self._recorded_op_count :]),
             wall_time_s=wall_time,
             total_tracked_time=max(tracked_delta, 0.0),
+            total_flopscope_overhead_time=max(overhead_delta, 0.0),
         )
 
     def _has_unrecorded_activity(self) -> bool:
@@ -473,12 +478,14 @@ class BudgetContext:
         self._recorded_flops_used = self._flops_used
         self._recorded_op_count = len(self._op_log)
         self._recorded_tracked_time = self._total_tracked_time
+        self._recorded_overhead_time = self._total_flopscope_overhead_time
         self._budget_recorded = True
 
     def _mark_reset_baseline(self) -> None:
         self._recorded_flops_used = self._flops_used
         self._recorded_op_count = len(self._op_log)
         self._recorded_tracked_time = self._total_tracked_time
+        self._recorded_overhead_time = self._total_flopscope_overhead_time
         self._budget_recorded = False
 
     def __enter__(self) -> BudgetContext:
@@ -626,6 +633,7 @@ class NamespaceRecord(NamedTuple):
     op_log: list[OpRecord]
     wall_time_s: float | None = None
     total_tracked_time: float | None = None
+    total_flopscope_overhead_time: float | None = None
 
 
 def _snapshot_namespace_record(ctx: BudgetContext) -> NamespaceRecord:
@@ -649,6 +657,7 @@ class BudgetAccumulator:
         total_used = 0
         total_wall_time: float | None = None
         total_tracked: float | None = None
+        total_overhead: float | None = None
         all_ops: list[OpRecord] = []
 
         for rec in self._records:
@@ -659,11 +668,12 @@ class BudgetAccumulator:
                 total_wall_time = (total_wall_time or 0.0) + rec.wall_time_s
             if rec.total_tracked_time is not None:
                 total_tracked = (total_tracked or 0.0) + rec.total_tracked_time
+            if rec.total_flopscope_overhead_time is not None:
+                total_overhead = (total_overhead or 0.0) + rec.total_flopscope_overhead_time
 
         wall_time, tracked_time, overhead_time, untracked_time = _timing_summary(
-            total_wall_time, total_tracked, None
+            total_wall_time, total_tracked, total_overhead
         )
-        del overhead_time  # accumulator overhead wiring lands in Task 13
 
         result = {
             "flop_budget": total_budget,
@@ -672,6 +682,7 @@ class BudgetAccumulator:
             "operations": _summarize_operations(all_ops),
             "wall_time_s": wall_time,
             "tracked_time_s": tracked_time,
+            "flopscope_overhead_time_s": overhead_time,
             "untracked_time_s": untracked_time,
         }
 
@@ -727,7 +738,7 @@ def budget_summary_dict(by_namespace: bool = False) -> dict:
     ...     _ = fnp.add(fnp.array([1.0]), fnp.array([2.0]))
     >>> summary = flops.budget_summary_dict()
     >>> sorted(summary)
-    ['flop_budget', 'flops_remaining', 'flops_used', 'operations', 'tracked_time_s', 'untracked_time_s', 'wall_time_s']
+    ['flop_budget', 'flops_remaining', 'flops_used', 'flopscope_overhead_time_s', 'operations', 'tracked_time_s', 'untracked_time_s', 'wall_time_s']
     """
     acc_copy = BudgetAccumulator()
     acc_copy._records = _snapshot_records()

--- a/src/flopscope/_config.py
+++ b/src/flopscope/_config.py
@@ -29,8 +29,8 @@ def configure(**kwargs: object) -> None:
     check_nan_inf : bool
         If ``True``, scan every counted op's output for NaN/Inf values and
         emit a :class:`~flopscope.errors.FlopscopeWarning` if any are found.
-        The scan is two full O(n) sweeps over the result and is silently
-        attributed to ``untracked_time``, so it is off by default for
+        The scan is two full O(n) sweeps over the result and is attributed
+        to ``flopscope_overhead_time``, so it is off by default for
         production scoring.  Opt in when debugging an estimator that
         produces NaN/Inf to identify the introducing op.  Default ``False``.
 

--- a/src/flopscope/_counting_ops.py
+++ b/src/flopscope/_counting_ops.py
@@ -14,6 +14,7 @@ from typing import Any
 import numpy as _np
 from numpy.typing import ArrayLike, DTypeLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._flops import _ceil_log2
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray, _to_base_ndarray_tree
@@ -24,6 +25,7 @@ from flopscope._validation import require_budget
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def trace(
     a: ArrayLike,
     offset: int = 0,
@@ -37,7 +39,8 @@ def trace(
     cost = _builtins.max(_builtins.min(a.shape[axis1], a.shape[axis2]), 1)
     out_stripped = _to_base_ndarray(out) if out is not None else None
     with budget.deduct("trace", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.trace(
+        result = _call_numpy(
+            _np.trace,
             _to_base_ndarray(a),
             offset=offset,
             axis1=axis1,
@@ -53,6 +56,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def allclose(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> bool:
     budget = require_budget()
     a = _np.asarray(a)
@@ -65,7 +69,7 @@ def allclose(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> bool:
     with budget.deduct(
         "allclose", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.allclose(a, b, **kwargs)
+        result = _call_numpy(_np.allclose, a, b, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -73,6 +77,7 @@ attach_docstring(allclose, _np.allclose, "counted_custom", "numel(a) FLOPs")
 allclose.__signature__ = _inspect.signature(_np.allclose)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def array_equal(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> bool:
     budget = require_budget()
     a = _np.asarray(a)
@@ -82,7 +87,7 @@ def array_equal(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> bool:
     with budget.deduct(
         "array_equal", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.array_equal(a, b, **kwargs)
+        result = _call_numpy(_np.array_equal, a, b, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -90,6 +95,7 @@ attach_docstring(array_equal, _np.array_equal, "counted_custom", "numel(a) FLOPs
 array_equal.__signature__ = _inspect.signature(_np.array_equal)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def array_equiv(a: ArrayLike, b: ArrayLike) -> bool:
     budget = require_budget()
     a = _np.asarray(a)
@@ -106,7 +112,7 @@ def array_equiv(a: ArrayLike, b: ArrayLike) -> bool:
     with budget.deduct(
         "array_equiv", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.array_equiv(a, b)
+        result = _call_numpy(_np.array_equiv, a, b)
     return result  # type: ignore[return-value]
 
 
@@ -119,6 +125,7 @@ array_equiv.__signature__ = _inspect.signature(_np.array_equiv)  # pyright: igno
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def histogram(
     a: ArrayLike,
     bins: int | Sequence[int] | str = 10,
@@ -135,7 +142,7 @@ def histogram(
         bins_arr = _np.asarray(bins)
         cost = _builtins.max(n * _ceil_log2(_builtins.len(bins_arr)), 1)
     with budget.deduct("histogram", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.histogram(a, bins=bins, **kwargs)
+        result = _call_numpy(_np.histogram, a, bins=bins, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -148,6 +155,7 @@ attach_docstring(
 histogram.__signature__ = _inspect.signature(_np.histogram)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def histogram2d(
     x: ArrayLike,
     y: ArrayLike,
@@ -185,7 +193,7 @@ def histogram2d(
     with budget.deduct(
         "histogram2d", flop_cost=cost, subscripts=None, shapes=(x.shape, y.shape)
     ):
-        result = _np.histogram2d(x, y, bins=bins, **kwargs)
+        result = _call_numpy(_np.histogram2d, x, y, bins=bins, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -198,6 +206,7 @@ attach_docstring(
 histogram2d.__signature__ = _inspect.signature(_np.histogram2d)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def histogramdd(
     sample: ArrayLike,
     bins: Any = 10,
@@ -232,7 +241,7 @@ def histogramdd(
     with budget.deduct(
         "histogramdd", flop_cost=cost, subscripts=None, shapes=(sample.shape,)
     ):
-        result = _np.histogramdd(sample, bins=bins, **kwargs)
+        result = _call_numpy(_np.histogramdd, sample, bins=bins, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -245,6 +254,7 @@ attach_docstring(
 histogramdd.__signature__ = _inspect.signature(_np.histogramdd)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def histogram_bin_edges(
     a: ArrayLike,
     bins: int | Sequence[int] | str = 10,
@@ -256,7 +266,7 @@ def histogram_bin_edges(
     with budget.deduct(
         "histogram_bin_edges", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.histogram_bin_edges(a, bins=bins, **kwargs)
+        result = _call_numpy(_np.histogram_bin_edges, a, bins=bins, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -266,12 +276,13 @@ attach_docstring(
 histogram_bin_edges.__signature__ = _inspect.signature(_np.histogram_bin_edges)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def bincount(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     budget = require_budget()
     x = _np.asarray(x)
     cost = _builtins.max(x.size, 1)
     with budget.deduct("bincount", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-        result = _np.bincount(x, **kwargs)
+        result = _call_numpy(_np.bincount, x, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -287,6 +298,7 @@ except (ValueError, TypeError):
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def logspace(
     start: Any,
     stop: Any,
@@ -296,7 +308,7 @@ def logspace(
     budget = require_budget()
     cost = _builtins.max(num, 1)
     with budget.deduct("logspace", flop_cost=cost, subscripts=None, shapes=((num,),)):
-        result = _np.logspace(start, stop, num=num, **kwargs)
+        result = _call_numpy(_np.logspace, start, stop, num=num, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -304,6 +316,7 @@ attach_docstring(logspace, _np.logspace, "counted_custom", "num FLOPs")
 logspace.__signature__ = _inspect.signature(_np.logspace)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def geomspace(
     start: Any,
     stop: Any,
@@ -313,7 +326,7 @@ def geomspace(
     budget = require_budget()
     cost = _builtins.max(num, 1)
     with budget.deduct("geomspace", flop_cost=cost, subscripts=None, shapes=((num,),)):
-        result = _np.geomspace(start, stop, num=num, **kwargs)
+        result = _call_numpy(_np.geomspace, start, stop, num=num, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -321,6 +334,7 @@ attach_docstring(geomspace, _np.geomspace, "counted_custom", "num FLOPs")
 geomspace.__signature__ = _inspect.signature(_np.geomspace)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def vander(
     x: ArrayLike,
     N: int | None = None,
@@ -333,7 +347,7 @@ def vander(
         N = n
     cost = _builtins.max(n * (N - 1), 1)
     with budget.deduct("vander", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-        result = _np.vander(x, N=N, **kwargs)
+        result = _call_numpy(_np.vander, x, N=N, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -345,6 +359,7 @@ vander.__signature__ = _inspect.signature(_np.vander)  # pyright: ignore[reportF
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def apply_along_axis(
     func1d: Any,
     axis: int,
@@ -373,6 +388,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def apply_over_axes(
     func: Any,
     a: ArrayLike,
@@ -399,6 +415,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def piecewise(
     x: ArrayLike,
     condlist: Any,

--- a/src/flopscope/_display.py
+++ b/src/flopscope/_display.py
@@ -83,13 +83,15 @@ def _format_budget_summary_text(
 
     wall_time = data.get("wall_time_s")
     tracked_time = data.get("tracked_time_s", 0.0)
+    overhead_time = data.get("flopscope_overhead_time_s", 0.0)
     untracked_time = data.get("untracked_time_s")
     if wall_time is not None and untracked_time is not None:
         lines += [
             "",
-            f"  Wall time:       {wall_time:.3f}s",
-            f"  Tracked time:    {tracked_time:.3f}s  ({_pct(tracked_time, wall_time)})",
-            f"  Untracked time:  {untracked_time:.3f}s  ({_pct(untracked_time, wall_time)})",
+            f"  Wall time:           {wall_time:.3f}s",
+            f"  Tracked time:        {tracked_time:.3f}s  ({_pct(tracked_time, wall_time)})",
+            f"  Flopscope overhead:  {overhead_time:.3f}s  ({_pct(overhead_time, wall_time)})",
+            f"  Untracked time:      {untracked_time:.3f}s  ({_pct(untracked_time, wall_time)})",
         ]
 
     op_durations = {
@@ -239,6 +241,7 @@ def _rich_totals_table(data: dict):
 
     wall_time = data.get("wall_time_s")
     tracked_time = data.get("tracked_time_s", 0.0)
+    overhead_time = data.get("flopscope_overhead_time_s", 0.0)
     untracked_time = data.get("untracked_time_s")
     if wall_time is not None and untracked_time is not None:
         table.add_section()
@@ -247,6 +250,13 @@ def _rich_totals_table(data: dict):
             "Tracked",
             Text(
                 f"{tracked_time:.3f}s  ({_pct(tracked_time, wall_time)})", style="dim"
+            ),
+        )
+        table.add_row(
+            "Flopscope overhead",
+            Text(
+                f"{overhead_time:.3f}s  ({_pct(overhead_time, wall_time)})",
+                style="dim",
             ),
         )
         table.add_row(

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import numpy as _np
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._config import get_setting
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._perm_group import SymmetryGroup
@@ -182,7 +183,7 @@ def _execute_pairwise(path_info, operands: list):
         # Pop operands in reverse sorted order (same as opt_einsum convention)
         inds = sorted(contract_inds, reverse=True)
         tensors = [ops.pop(i) for i in inds]
-        result = _np.einsum(step.subscript, *[_to_base_ndarray(t) for t in tensors])
+        result = _call_numpy(_np.einsum, step.subscript, *[_to_base_ndarray(t) for t in tensors])
         ops.append(result)
     return ops[0]
 
@@ -299,6 +300,7 @@ def _resolve_output_symmetry(
     return _infer_pathless_output_symmetry(operands, input_parts, output_subscript)
 
 
+@_counted_wrapper
 def einsum(
     subscripts: str,
     *operands: _np.ndarray,
@@ -389,7 +391,8 @@ def einsum(
         if path_info.steps:
             result = _execute_pairwise(path_info, list(operands))
         else:
-            result = _np.einsum(
+            result = _call_numpy(
+                _np.einsum,
                 canonical_subscripts, *[_to_base_ndarray(o) for o in operands]
             )
 
@@ -409,6 +412,7 @@ def einsum(
     return result  # type: ignore[return-value]
 
 
+@_counted_wrapper
 def einsum_path(
     subscripts: str,
     *operands: _np.ndarray,

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -183,7 +183,9 @@ def _execute_pairwise(path_info, operands: list):
         # Pop operands in reverse sorted order (same as opt_einsum convention)
         inds = sorted(contract_inds, reverse=True)
         tensors = [ops.pop(i) for i in inds]
-        result = _call_numpy(_np.einsum, step.subscript, *[_to_base_ndarray(t) for t in tensors])
+        result = _call_numpy(
+            _np.einsum, step.subscript, *[_to_base_ndarray(t) for t in tensors]
+        )
         ops.append(result)
     return ops[0]
 
@@ -393,7 +395,8 @@ def einsum(
         else:
             result = _call_numpy(
                 _np.einsum,
-                canonical_subscripts, *[_to_base_ndarray(o) for o in operands]
+                canonical_subscripts,
+                *[_to_base_ndarray(o) for o in operands],
             )
 
     if out is not None:

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -293,7 +293,9 @@ def full_like(
     a_arr = _np.asarray(a)
     cost = max(a_arr.size, 1)
     with budget.deduct("full_like", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.full_like, _to_base_ndarray(a), fill_value, dtype=dtype, **kwargs)
+        result = _call_numpy(
+            _np.full_like, _to_base_ndarray(a), fill_value, dtype=dtype, **kwargs
+        )
     symmetry = None
     if isinstance(a, SymmetricTensor):
         symmetry = _compatible_symmetry_for_shape(a.symmetry, result.shape)
@@ -431,7 +433,9 @@ def concatenate(
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in arrays), 1)
     with budget.deduct("concatenate", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.concatenate, _to_base_ndarray_tree(arrays), axis=axis, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(
+            _np.concatenate, _to_base_ndarray_tree(arrays), axis=axis, **kwargs
+        )  # type: ignore[arg-type, call-overload]
     return result  # type: ignore[return-value]
 
 
@@ -448,7 +452,9 @@ def stack(
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in arrays), 1)
     with budget.deduct("stack", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(
+            _np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs
+        )  # type: ignore[arg-type, call-overload]
     return result
 
 
@@ -489,7 +495,9 @@ def split(
     with budget.deduct(
         "split", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _call_numpy(_np.split, _to_base_ndarray(ary), indices_or_sections, axis=axis)
+        result = _call_numpy(
+            _np.split, _to_base_ndarray(ary), indices_or_sections, axis=axis
+        )
     return result  # type: ignore[return-value]
 
 
@@ -640,7 +648,9 @@ def repeat(
     else:
         cost = max(int(reps.sum()), 1)
     with budget.deduct("repeat", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.repeat, _to_base_ndarray(a), _to_base_ndarray(repeats), axis=axis)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(
+            _np.repeat, _to_base_ndarray(a), _to_base_ndarray(repeats), axis=axis
+        )  # type: ignore[arg-type, call-overload]
     return result
 
 
@@ -729,8 +739,7 @@ def diagonal(
         "diagonal", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
         result = _call_numpy(
-            _np.diagonal,
-            _to_base_ndarray(a), offset=offset, axis1=axis1, axis2=axis2
+            _np.diagonal, _to_base_ndarray(a), offset=offset, axis1=axis1, axis2=axis2
         )
     return result  # type: ignore[return-value]
 
@@ -878,7 +887,10 @@ def append(
     with budget.deduct("append", flop_cost=cost, subscripts=None, shapes=()):
         result = _call_numpy(
             _np.append,
-            _to_base_ndarray(arr), _to_base_ndarray(values), axis=axis, **kwargs
+            _to_base_ndarray(arr),
+            _to_base_ndarray(values),
+            axis=axis,
+            **kwargs,
         )
     return result  # type: ignore[return-value]
 
@@ -1293,7 +1305,10 @@ def extract(
     ):
         result = _call_numpy(
             _np.extract,
-            _to_base_ndarray(condition), _to_base_ndarray(arr), *args, **kwargs
+            _to_base_ndarray(condition),
+            _to_base_ndarray(arr),
+            *args,
+            **kwargs,
         )
     return result  # type: ignore[return-value]
 
@@ -1317,7 +1332,9 @@ def fill_diagonal(
     ):
         # ``np.fill_diagonal`` mutates ``a`` in-place; ``_to_base_ndarray``
         # is zero-copy so the mutation propagates to the user's array.
-        result = _call_numpy(_np.fill_diagonal, _to_base_ndarray(a), val, wrap=wrap, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(
+            _np.fill_diagonal, _to_base_ndarray(a), val, wrap=wrap, **kwargs
+        )  # type: ignore[arg-type, call-overload]
     return result
 
 
@@ -1490,7 +1507,11 @@ def insert(
     with budget.deduct("insert", flop_cost=cost, subscripts=None, shapes=()):
         result = _call_numpy(
             _np.insert,
-            _to_base_ndarray(arr), obj, _to_base_ndarray(values), axis=axis, **kwargs
+            _to_base_ndarray(arr),
+            obj,
+            _to_base_ndarray(values),
+            axis=axis,
+            **kwargs,
         )
     return result  # type: ignore[return-value]
 

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -27,6 +27,7 @@ from flopscope._symmetry_utils import (
     wrap_with_symmetry,
     wrap_with_trusted_symmetry,
 )
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._validation import require_budget
 from flopscope.errors import SymmetryError, UnsupportedFunctionError
 
@@ -93,6 +94,7 @@ def _infer_structural_constructor_symmetry(*, kind, N=None, M=None, k=0, v_ndim=
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def array(
     object: ArrayLike,
     dtype: DTypeLike | None = None,
@@ -106,7 +108,7 @@ def array(
     with budget.deduct(
         "array", flop_cost=cost, subscripts=None, shapes=(_probe.shape,)
     ):
-        result = _np.array(object, dtype=dtype, **kwargs)
+        result = _call_numpy(_np.array, object, dtype=dtype, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -137,6 +139,7 @@ def ones(
 attach_docstring(ones, _np.ones, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def full(
     shape: int | Sequence[int],
     fill_value: ArrayLike,
@@ -173,6 +176,7 @@ def eye(
 attach_docstring(eye, _np.eye, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def diag(v: ArrayLike, k: int = 0) -> FlopscopeArray:
     """Extract diagonal or construct diagonal array.
 
@@ -189,7 +193,7 @@ def diag(v: ArrayLike, k: int = 0) -> FlopscopeArray:
         m, n = v.shape[0], v.shape[1] if v.ndim > 1 else v.shape[0]
         cost = min(m, n)
     with budget.deduct("diag", flop_cost=cost, subscripts=None, shapes=(v.shape,)):
-        result = _np.diag(v, k=k)
+        result = _call_numpy(_np.diag, v, k=k)
     symmetry = _infer_structural_constructor_symmetry(kind="diag", k=k, v_ndim=v.ndim)
     if symmetry is not None:
         return wrap_with_trusted_symmetry(result, symmetry)  # type: ignore[return-value]
@@ -199,6 +203,7 @@ def diag(v: ArrayLike, k: int = 0) -> FlopscopeArray:
 attach_docstring(diag, _np.diag, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def arange(*args: Any, **kwargs: Any) -> FlopscopeArray:
     """Return evenly spaced values. Cost: numel(output)."""
     budget = require_budget()
@@ -214,6 +219,7 @@ def arange(*args: Any, **kwargs: Any) -> FlopscopeArray:
 attach_docstring(arange, _np.arange, "counted_custom", "numel(output) FLOPs")
 
 
+@_counted_wrapper
 def linspace(
     start: ArrayLike,
     stop: ArrayLike,
@@ -224,7 +230,7 @@ def linspace(
     budget = require_budget()
     cost = max(int(num), 1)
     with budget.deduct("linspace", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.linspace(start, stop, num=num, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(_np.linspace, start, stop, num=num, **kwargs)  # type: ignore[arg-type, call-overload]
     return result
 
 
@@ -275,6 +281,7 @@ def ones_like(
 attach_docstring(ones_like, _np.ones_like, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def full_like(
     a: ArrayLike,
     fill_value: ArrayLike,
@@ -286,7 +293,7 @@ def full_like(
     a_arr = _np.asarray(a)
     cost = max(a_arr.size, 1)
     with budget.deduct("full_like", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.full_like(_to_base_ndarray(a), fill_value, dtype=dtype, **kwargs)
+        result = _call_numpy(_np.full_like, _to_base_ndarray(a), fill_value, dtype=dtype, **kwargs)
     symmetry = None
     if isinstance(a, SymmetricTensor):
         symmetry = _compatible_symmetry_for_shape(a.symmetry, result.shape)
@@ -414,6 +421,7 @@ def moveaxis(
 attach_docstring(moveaxis, _np.moveaxis, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def concatenate(
     arrays: Sequence[ArrayLike],
     axis: int | None = 0,
@@ -423,13 +431,14 @@ def concatenate(
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in arrays), 1)
     with budget.deduct("concatenate", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.concatenate(_to_base_ndarray_tree(arrays), axis=axis, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(_np.concatenate, _to_base_ndarray_tree(arrays), axis=axis, **kwargs)  # type: ignore[arg-type, call-overload]
     return result  # type: ignore[return-value]
 
 
 attach_docstring(concatenate, _np.concatenate, "counted_custom", "numel(output) FLOPs")
 
 
+@_counted_wrapper
 def stack(
     arrays: Sequence[ArrayLike],
     axis: int = 0,
@@ -439,19 +448,20 @@ def stack(
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in arrays), 1)
     with budget.deduct("stack", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.stack(_to_base_ndarray_tree(arrays), axis=axis, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(_np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs)  # type: ignore[arg-type, call-overload]
     return result
 
 
 attach_docstring(stack, _np.stack, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def vstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     """Stack arrays vertically. Cost: numel(output)."""
     budget = require_budget()
     cost = max(sum(_np.asarray(a).size for a in tup), 1)
     with budget.deduct("vstack", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.vstack(_to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(_np.vstack, _to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
     return result
 
 
@@ -466,6 +476,7 @@ def hstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
 attach_docstring(hstack, _np.hstack, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def split(
     ary: ArrayLike,
     indices_or_sections: int | Sequence[int],
@@ -478,7 +489,7 @@ def split(
     with budget.deduct(
         "split", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.split(_to_base_ndarray(ary), indices_or_sections, axis=axis)
+        result = _call_numpy(_np.split, _to_base_ndarray(ary), indices_or_sections, axis=axis)
     return result  # type: ignore[return-value]
 
 
@@ -496,6 +507,7 @@ def hsplit(
 attach_docstring(hsplit, _np.hsplit, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def vsplit(
     ary: ArrayLike,
     indices_or_sections: int | Sequence[int],
@@ -507,7 +519,7 @@ def vsplit(
     with budget.deduct(
         "vsplit", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.vsplit(_to_base_ndarray(ary), indices_or_sections)
+        result = _call_numpy(_np.vsplit, _to_base_ndarray(ary), indices_or_sections)
     return result  # type: ignore[return-value]
 
 
@@ -543,13 +555,14 @@ def expand_dims(
 attach_docstring(expand_dims, _np.expand_dims, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def ravel(a: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Flatten array. Cost: numel(output)."""
     budget = require_budget()
     a_arr = _np.asarray(a)
     cost = max(a_arr.size, 1)
     with budget.deduct("ravel", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)):
-        result = _np.ravel(a_arr, **kwargs)
+        result = _call_numpy(_np.ravel, a_arr, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -567,6 +580,7 @@ def copy(a: ArrayLike, **kwargs: Any) -> FlopscopeArray:
 attach_docstring(copy, _np.copy, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def where(
     condition: ArrayLike,
     x: ArrayLike | None = None,
@@ -580,9 +594,10 @@ def where(
         "where", flop_cost=cost, subscripts=None, shapes=(cond_arr.shape,)
     ):
         if x is None and y is None:
-            result = _np.where(_to_base_ndarray(condition))
+            result = _call_numpy(_np.where, _to_base_ndarray(condition))
         else:
-            result = _np.where(
+            result = _call_numpy(
+                _np.where,
                 _to_base_ndarray(condition),
                 _to_base_ndarray(x),  # type: ignore[arg-type, call-overload]
                 _to_base_ndarray(y),  # type: ignore[arg-type, call-overload]
@@ -593,6 +608,7 @@ def where(
 attach_docstring(where, _np.where, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def tile(A: ArrayLike, reps: int | Sequence[int]) -> FlopscopeArray:
     """Construct array by repeating. Cost: numel(output)."""
     budget = require_budget()
@@ -601,13 +617,14 @@ def tile(A: ArrayLike, reps: int | Sequence[int]) -> FlopscopeArray:
     # Output size = input size * product of reps
     cost = max(a_arr.size * int(_np.prod(reps_tup)), 1)
     with budget.deduct("tile", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.tile(_to_base_ndarray(A), reps)
+        result = _call_numpy(_np.tile, _to_base_ndarray(A), reps)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(tile, _np.tile, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def repeat(
     a: ArrayLike,
     repeats: int | ArrayLike,
@@ -623,7 +640,7 @@ def repeat(
     else:
         cost = max(int(reps.sum()), 1)
     with budget.deduct("repeat", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.repeat(_to_base_ndarray(a), _to_base_ndarray(repeats), axis=axis)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(_np.repeat, _to_base_ndarray(a), _to_base_ndarray(repeats), axis=axis)  # type: ignore[arg-type, call-overload]
     return result
 
 
@@ -641,6 +658,7 @@ def flip(
 attach_docstring(flip, _np.flip, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def roll(
     a: ArrayLike,
     shift: int | Sequence[int],
@@ -651,13 +669,14 @@ def roll(
     a_arr = _np.asarray(a)
     cost = max(a_arr.size, 1)
     with budget.deduct("roll", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.roll(_to_base_ndarray(a), shift, axis=axis)
+        result = _call_numpy(_np.roll, _to_base_ndarray(a), shift, axis=axis)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(roll, _np.roll, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def pad(array: ArrayLike, pad_width: Any, **kwargs: Any) -> FlopscopeArray:
     """Pad an array. Cost: numel(output)."""
     budget = require_budget()
@@ -689,6 +708,7 @@ def tril(m: ArrayLike, k: int = 0) -> FlopscopeArray:
 attach_docstring(tril, _np.tril, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def diagonal(
     a: ArrayLike,
     offset: int = 0,
@@ -708,7 +728,8 @@ def diagonal(
     with budget.deduct(
         "diagonal", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.diagonal(
+        result = _call_numpy(
+            _np.diagonal,
             _to_base_ndarray(a), offset=offset, axis1=axis1, axis2=axis2
         )
     return result  # type: ignore[return-value]
@@ -717,6 +738,7 @@ def diagonal(
 attach_docstring(diagonal, _np.diagonal, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def broadcast_to(
     array: ArrayLike,
     shape: int | Sequence[int],
@@ -727,7 +749,7 @@ def broadcast_to(
     budget = require_budget()
     cost = max(int(_np.prod(output_shape)), 1)
     with budget.deduct("broadcast_to", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.broadcast_to(input_array, output_shape)
+        result = _call_numpy(_np.broadcast_to, input_array, output_shape)
     symmetry = broadcast_group(
         array.symmetry if isinstance(array, SymmetricTensor) else None,
         input_shape=input_array.shape,
@@ -739,6 +761,7 @@ def broadcast_to(
 attach_docstring(broadcast_to, _np.broadcast_to, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def meshgrid(*xi: ArrayLike, **kwargs: Any) -> tuple[FlopscopeArray, ...]:
     """Return coordinate matrices. Cost: numel(output)."""
     budget = require_budget()
@@ -747,7 +770,7 @@ def meshgrid(*xi: ArrayLike, **kwargs: Any) -> tuple[FlopscopeArray, ...]:
     grid_size = int(_np.prod(sizes)) if sizes else 0
     cost = max(grid_size * len(sizes), 1)
     with budget.deduct("meshgrid", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.meshgrid(*[_to_base_ndarray(x) for x in xi], **kwargs)
+        result = _call_numpy(_np.meshgrid, *[_to_base_ndarray(x) for x in xi], **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -770,6 +793,7 @@ def astype(
     return _np.astype(_to_base_ndarray(x), dtype, copy=copy, device=device)  # type: ignore[arg-type, call-overload]
 
 
+@_counted_wrapper
 def asarray(
     a: ArrayLike,
     dtype: DTypeLike | None = None,
@@ -783,13 +807,14 @@ def asarray(
     with budget.deduct(
         "asarray", flop_cost=cost, subscripts=None, shapes=(_probe.shape,)
     ):
-        result = _np.asarray(a, dtype=dtype, **kwargs)
+        result = _call_numpy(_np.asarray, a, dtype=dtype, **kwargs)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(asarray, _np.asarray, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def isnan(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Test element-wise for NaN. Cost: numel(input)."""
     budget = require_budget()
@@ -798,13 +823,14 @@ def isnan(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     with budget.deduct("isnan", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)):
         # Strip flopscope subclasses so the raw NumPy ufunc does not
         # re-dispatch through __array_ufunc__ and recurse.
-        result = _np.isnan(_to_base_ndarray(x), **kwargs)
+        result = _call_numpy(_np.isnan, _to_base_ndarray(x), **kwargs)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(isnan, _np.isnan, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def isfinite(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Test element-wise for finiteness. Cost: numel(input)."""
     budget = require_budget()
@@ -813,20 +839,21 @@ def isfinite(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     with budget.deduct(
         "isfinite", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
     ):
-        result = _np.isfinite(_to_base_ndarray(x), **kwargs)
+        result = _call_numpy(_np.isfinite, _to_base_ndarray(x), **kwargs)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(isfinite, _np.isfinite, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def isinf(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Test element-wise for Inf. Cost: numel(input)."""
     budget = require_budget()
     x_arr = _np.asarray(x)
     cost = x_arr.size
     with budget.deduct("isinf", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)):
-        result = _np.isinf(_to_base_ndarray(x), **kwargs)
+        result = _call_numpy(_np.isinf, _to_base_ndarray(x), **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -837,6 +864,7 @@ attach_docstring(isinf, _np.isinf, "free", "0 FLOPs")
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def append(
     arr: ArrayLike,
     values: ArrayLike,
@@ -848,7 +876,8 @@ def append(
     values_arr = _np.asarray(values)
     cost = values_arr.size  # num appended
     with budget.deduct("append", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.append(
+        result = _call_numpy(
+            _np.append,
             _to_base_ndarray(arr), _to_base_ndarray(values), axis=axis, **kwargs
         )
     return result  # type: ignore[return-value]
@@ -857,6 +886,7 @@ def append(
 attach_docstring(append, _np.append, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def argwhere(a: ArrayLike, *args: Any, **kwargs: Any) -> FlopscopeArray:
     """Find indices of non-zero elements. Cost: numel(input)."""
     budget = require_budget()
@@ -865,13 +895,14 @@ def argwhere(a: ArrayLike, *args: Any, **kwargs: Any) -> FlopscopeArray:
     with budget.deduct(
         "argwhere", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.argwhere(_to_base_ndarray(a), *args, **kwargs)
+        result = _call_numpy(_np.argwhere, _to_base_ndarray(a), *args, **kwargs)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(argwhere, _np.argwhere, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def array_split(ary: ArrayLike, *args: Any, **kwargs: Any) -> list[FlopscopeArray]:
     """Split array into sub-arrays. Cost: numel(input)."""
     budget = require_budget()
@@ -880,13 +911,14 @@ def array_split(ary: ArrayLike, *args: Any, **kwargs: Any) -> list[FlopscopeArra
     with budget.deduct(
         "array_split", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.array_split(_to_base_ndarray(ary), *args, **kwargs)
+        result = _call_numpy(_np.array_split, _to_base_ndarray(ary), *args, **kwargs)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(array_split, _np.array_split, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def asarray_chkfinite(a: ArrayLike, *args: Any, **kwargs: Any) -> FlopscopeArray:
     """Convert to array checking for NaN/Inf. Cost: numel(output)."""
     budget = require_budget()
@@ -938,6 +970,7 @@ def atleast_3d(
 attach_docstring(atleast_3d, _np.atleast_3d, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def base_repr(*args, **kwargs):
     """Return string representation of number. Cost: numel(output)."""
     budget = require_budget()
@@ -951,6 +984,7 @@ def base_repr(*args, **kwargs):
 attach_docstring(base_repr, _np.base_repr, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def binary_repr(*args, **kwargs):
     """Return binary representation of integer. Cost: numel(output)."""
     budget = require_budget()
@@ -964,6 +998,7 @@ def binary_repr(*args, **kwargs):
 attach_docstring(binary_repr, _np.binary_repr, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def block(*args, **kwargs):
     """Assemble array from nested lists. Cost: numel(output)."""
     budget = require_budget()
@@ -977,6 +1012,7 @@ def block(*args, **kwargs):
 attach_docstring(block, _np.block, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def bmat(*args, **kwargs):
     """Build matrix from string/nested sequence. Cost: numel(output)."""
     budget = require_budget()
@@ -997,6 +1033,7 @@ def bmat(*args, **kwargs):
 attach_docstring(bmat, _np.bmat, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def broadcast_arrays(*args: ArrayLike, **kwargs: Any) -> tuple[FlopscopeArray, ...]:
     """Broadcast any number of arrays. Cost: numel(output)."""
     arrays = tuple(_np.asarray(arg) for arg in args)
@@ -1038,6 +1075,7 @@ def can_cast(*args, **kwargs):
 attach_docstring(can_cast, _np.can_cast, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def choose(*args, **kwargs):
     """Construct array from index array. Cost: numel(output)."""
     budget = require_budget()
@@ -1077,6 +1115,7 @@ def common_type(*args, **kwargs):
 attach_docstring(common_type, _np.common_type, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def compress(
     condition: ArrayLike,
     a: ArrayLike,
@@ -1108,6 +1147,7 @@ def compress(
 attach_docstring(compress, _np.compress, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def concat(
     arrays: Sequence[ArrayLike],
     axis: int | None = 0,
@@ -1125,6 +1165,7 @@ def concat(
 attach_docstring(concat, _np.concat, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def copyto(dst, src, casting="same_kind", where=True):
     """Copies values from one array to another. Cost: num elements copied."""
     budget = require_budget()
@@ -1135,7 +1176,8 @@ def copyto(dst, src, casting="same_kind", where=True):
     else:
         cost = src_arr.size
     with budget.deduct("copyto", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.copyto(
+        result = _call_numpy(
+            _np.copyto,
             _to_base_ndarray(dst),
             _to_base_ndarray(src),
             casting=casting,  # type: ignore[arg-type, call-overload]
@@ -1147,6 +1189,7 @@ def copyto(dst, src, casting="same_kind", where=True):
 attach_docstring(copyto, _np.copyto, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def delete(
     arr: ArrayLike,
     obj: Any,
@@ -1182,6 +1225,7 @@ def diag_indices_from(*args, **kwargs):
 attach_docstring(diag_indices_from, _np.diag_indices_from, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def diagflat(v: ArrayLike, k: int = 0) -> FlopscopeArray:
     """Create diagonal array from flattened input. Cost: numel(output)."""
     budget = require_budget()
@@ -1203,6 +1247,7 @@ def diagflat(v: ArrayLike, k: int = 0) -> FlopscopeArray:
 attach_docstring(diagflat, _np.diagflat, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def dsplit(ary: ArrayLike, *args: Any, **kwargs: Any) -> list[FlopscopeArray]:
     """Split array along third axis. Cost: numel(input)."""
     budget = require_budget()
@@ -1211,13 +1256,14 @@ def dsplit(ary: ArrayLike, *args: Any, **kwargs: Any) -> list[FlopscopeArray]:
     with budget.deduct(
         "dsplit", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _np.dsplit(_to_base_ndarray(ary), *args, **kwargs)
+        result = _call_numpy(_np.dsplit, _to_base_ndarray(ary), *args, **kwargs)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(dsplit, _np.dsplit, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def dstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     """Stack arrays along third axis. Cost: numel(output)."""
     budget = require_budget()
@@ -1231,6 +1277,7 @@ def dstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
 attach_docstring(dstack, _np.dstack, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def extract(
     condition: ArrayLike,
     arr: ArrayLike,
@@ -1244,7 +1291,8 @@ def extract(
     with budget.deduct(
         "extract", flop_cost=cost, subscripts=None, shapes=(arr_np.shape,)
     ):
-        result = _np.extract(
+        result = _call_numpy(
+            _np.extract,
             _to_base_ndarray(condition), _to_base_ndarray(arr), *args, **kwargs
         )
     return result  # type: ignore[return-value]
@@ -1253,6 +1301,7 @@ def extract(
 attach_docstring(extract, _np.extract, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def fill_diagonal(
     a: ArrayLike,
     val: Any,
@@ -1268,13 +1317,14 @@ def fill_diagonal(
     ):
         # ``np.fill_diagonal`` mutates ``a`` in-place; ``_to_base_ndarray``
         # is zero-copy so the mutation propagates to the user's array.
-        result = _np.fill_diagonal(_to_base_ndarray(a), val, wrap=wrap, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(_np.fill_diagonal, _to_base_ndarray(a), val, wrap=wrap, **kwargs)  # type: ignore[arg-type, call-overload]
     return result
 
 
 attach_docstring(fill_diagonal, _np.fill_diagonal, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def flatnonzero(a: ArrayLike, *args: Any, **kwargs: Any) -> FlopscopeArray:
     """Return indices of non-zero elements in flattened array. Cost: numel(input)."""
     budget = require_budget()
@@ -1283,7 +1333,7 @@ def flatnonzero(a: ArrayLike, *args: Any, **kwargs: Any) -> FlopscopeArray:
     with budget.deduct(
         "flatnonzero", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.flatnonzero(_to_base_ndarray(a), *args, **kwargs)
+        result = _call_numpy(_np.flatnonzero, _to_base_ndarray(a), *args, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -1308,6 +1358,7 @@ def flipud(*args, **kwargs):
 attach_docstring(flipud, _np.flipud, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def from_dlpack(*args, **kwargs):
     """Create array from DLPack capsule. Cost: numel(output)."""
     budget = require_budget()
@@ -1321,6 +1372,7 @@ def from_dlpack(*args, **kwargs):
 attach_docstring(from_dlpack, _np.from_dlpack, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def frombuffer(
     buffer: Any,
     dtype: DTypeLike = float,
@@ -1339,6 +1391,7 @@ def frombuffer(
 attach_docstring(frombuffer, _np.frombuffer, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def fromfile(*args, **kwargs):
     """Construct array from data in text or binary file. Cost: numel(output)."""
     budget = require_budget()
@@ -1352,6 +1405,7 @@ def fromfile(*args, **kwargs):
 attach_docstring(fromfile, _np.fromfile, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def fromfunction(*args, **kwargs):
     """Construct array by executing function over each coordinate. Cost: numel(output)."""
     budget = require_budget()
@@ -1365,6 +1419,7 @@ def fromfunction(*args, **kwargs):
 attach_docstring(fromfunction, _np.fromfunction, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def fromiter(*args, **kwargs):
     """Create array from iterable object. Cost: numel(output)."""
     budget = require_budget()
@@ -1378,6 +1433,7 @@ def fromiter(*args, **kwargs):
 attach_docstring(fromiter, _np.fromiter, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def fromregex(*args, **kwargs):
     """Construct array from text file using regex. Cost: numel(output)."""
     budget = require_budget()
@@ -1391,6 +1447,7 @@ def fromregex(*args, **kwargs):
 attach_docstring(fromregex, _np.fromregex, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def fromstring(*args, **kwargs):
     """Construct array from string. Cost: numel(output)."""
     budget = require_budget()
@@ -1404,6 +1461,7 @@ def fromstring(*args, **kwargs):
 attach_docstring(fromstring, _np.fromstring, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def indices(*args: Any, **kwargs: Any) -> FlopscopeArray:
     """Return array representing indices of a grid. Cost: numel(output)."""
     budget = require_budget()
@@ -1417,6 +1475,7 @@ def indices(*args: Any, **kwargs: Any) -> FlopscopeArray:
 attach_docstring(indices, _np.indices, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def insert(
     arr: ArrayLike,
     obj: Any,
@@ -1429,7 +1488,8 @@ def insert(
     values_arr = _np.asarray(values)
     cost = values_arr.size  # num inserted
     with budget.deduct("insert", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.insert(
+        result = _call_numpy(
+            _np.insert,
             _to_base_ndarray(arr), obj, _to_base_ndarray(values), axis=axis, **kwargs
         )
     return result  # type: ignore[return-value]
@@ -1496,6 +1556,7 @@ def iterable(*args, **kwargs):
 attach_docstring(iterable, _np.iterable, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def ix_(*args: ArrayLike, **kwargs: Any) -> tuple[FlopscopeArray, ...]:
     """Construct open mesh from multiple sequences. Cost: numel(output)."""
     budget = require_budget()
@@ -1510,6 +1571,7 @@ def ix_(*args: ArrayLike, **kwargs: Any) -> tuple[FlopscopeArray, ...]:
 attach_docstring(ix_, _np.ix_, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def mask_indices(*args, **kwargs):
     """Return indices to access main or off-diagonal of array. Cost: numel(output)."""
     budget = require_budget()
@@ -1565,6 +1627,7 @@ def ndim(*args, **kwargs):
 attach_docstring(ndim, _np.ndim, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def nonzero(a: ArrayLike, *args: Any, **kwargs: Any) -> tuple[FlopscopeArray, ...]:
     """Return indices of non-zero elements. Cost: numel(input)."""
     budget = require_budget()
@@ -1573,13 +1636,14 @@ def nonzero(a: ArrayLike, *args: Any, **kwargs: Any) -> tuple[FlopscopeArray, ..
     with budget.deduct(
         "nonzero", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.nonzero(_to_base_ndarray(a), *args, **kwargs)  # type: ignore[arg-type, call-overload]
+        result = _call_numpy(_np.nonzero, _to_base_ndarray(a), *args, **kwargs)  # type: ignore[arg-type, call-overload]
     return result  # type: ignore[return-value]
 
 
 attach_docstring(nonzero, _np.nonzero, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def packbits(a: ArrayLike, *args: Any, **kwargs: Any) -> FlopscopeArray:
     """Pack binary-valued array into bits. Cost: numel(output)."""
     budget = require_budget()
@@ -1610,6 +1674,7 @@ def permute_dims(*args, **kwargs):
 attach_docstring(permute_dims, _np.permute_dims, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def place(
     arr: ArrayLike,
     mask: ArrayLike,
@@ -1626,7 +1691,8 @@ def place(
     ):
         # ``np.place`` mutates ``arr`` in-place; ``_to_base_ndarray`` is
         # zero-copy so the mutation propagates to the user's array.
-        result = _np.place(
+        result = _call_numpy(
+            _np.place,
             _to_base_ndarray(arr),  # type: ignore[arg-type, call-overload]
             _to_base_ndarray(mask),
             _to_base_ndarray(vals),
@@ -1647,6 +1713,7 @@ def promote_types(*args, **kwargs):
 attach_docstring(promote_types, _np.promote_types, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def put(
     a: ArrayLike,
     ind: ArrayLike,
@@ -1662,7 +1729,8 @@ def put(
         # ``np.put`` mutates ``a`` in-place. ``_to_base_ndarray`` is a
         # zero-copy view, so the mutation propagates to the user's
         # original FlopscopeArray buffer.
-        result = _np.put(
+        result = _call_numpy(
+            _np.put,
             _to_base_ndarray(a),  # type: ignore[arg-type, call-overload]
             _to_base_ndarray(ind),  # type: ignore[arg-type, call-overload]
             _to_base_ndarray(v),
@@ -1675,6 +1743,7 @@ def put(
 attach_docstring(put, _np.put, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def put_along_axis(
     arr: ArrayLike,
     indices: ArrayLike,
@@ -1692,7 +1761,8 @@ def put_along_axis(
     ):
         # ``np.put_along_axis`` mutates ``arr`` in-place; ``_to_base_ndarray``
         # is zero-copy so the mutation propagates to the user's array.
-        result = _np.put_along_axis(
+        result = _call_numpy(
+            _np.put_along_axis,
             _to_base_ndarray(arr),  # type: ignore[arg-type, call-overload]
             _to_base_ndarray(indices),  # type: ignore[arg-type, call-overload]
             _to_base_ndarray(values),
@@ -1706,6 +1776,7 @@ def put_along_axis(
 attach_docstring(put_along_axis, _np.put_along_axis, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def putmask(
     a: ArrayLike,
     mask: ArrayLike,
@@ -1720,7 +1791,8 @@ def putmask(
     with budget.deduct(
         "putmask", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
     ):
-        result = _np.putmask(
+        result = _call_numpy(
+            _np.putmask,
             _to_base_ndarray(a),  # type: ignore[arg-type, call-overload]
             _to_base_ndarray(mask),  # type: ignore[arg-type, call-overload]
             _to_base_ndarray(values),
@@ -1755,6 +1827,7 @@ def require(*args, **kwargs):
 attach_docstring(require, _np.require, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def resize(*args, **kwargs):
     """Return new array with given shape. Cost: numel(output)."""
     budget = require_budget()
@@ -1777,6 +1850,7 @@ def result_type(*args, **kwargs):
 attach_docstring(result_type, _np.result_type, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def rollaxis(*args, **kwargs):
     """Roll specified axis backwards. Cost: numel(output)."""
     budget = require_budget()
@@ -1809,6 +1883,7 @@ def row_stack(*args, **kwargs):
 attach_docstring(row_stack, _np.row_stack, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def select(
     condlist: Sequence[ArrayLike],
     choicelist: Sequence[ArrayLike],
@@ -1819,7 +1894,8 @@ def select(
     # Cost based on the size of the choice arrays
     cost = max((_np.asarray(c).size for c in choicelist), default=1)
     with budget.deduct("select", flop_cost=cost, subscripts=None, shapes=()):
-        result = _np.select(
+        result = _call_numpy(
+            _np.select,
             _to_base_ndarray_tree(condlist),  # type: ignore[arg-type]
             _to_base_ndarray_tree(choicelist),  # type: ignore[arg-type]
             default=default,
@@ -1854,6 +1930,7 @@ def size(*args, **kwargs):
 attach_docstring(size, _np.size, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def take(
     a: ArrayLike,
     indices: ArrayLike,
@@ -1879,6 +1956,7 @@ def take(
 attach_docstring(take, _np.take, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def take_along_axis(
     arr: ArrayLike,
     indices: ArrayLike,
@@ -1924,6 +2002,7 @@ def tril_indices_from(*args, **kwargs):
 attach_docstring(tril_indices_from, _np.tril_indices_from, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def trim_zeros(filt: ArrayLike, trim: str = "fb", **kwargs: Any) -> FlopscopeArray:
     """Trim leading and/or trailing zeros from 1-D array. Cost: num elements trimmed."""
     budget = require_budget()
@@ -1963,6 +2042,7 @@ def typename(*args, **kwargs):
 attach_docstring(typename, _np.typename, "free", "0 FLOPs")
 
 
+@_counted_wrapper
 def unpackbits(a: ArrayLike, *args: Any, **kwargs: Any) -> FlopscopeArray:
     """Unpack elements of uint8 array into binary-valued bit array. Cost: numel(output)."""
     budget = require_budget()
@@ -1994,6 +2074,7 @@ attach_docstring(unravel_index, _np.unravel_index, "free", "0 FLOPs")
 
 if hasattr(_np, "unstack"):
 
+    @_counted_wrapper
     def unstack(x: ArrayLike, *args: Any, **kwargs: Any) -> tuple[FlopscopeArray, ...]:  # pyright: ignore[reportRedeclaration]
         """Split array into sequence of arrays along an axis. Cost: numel(input)."""
         budget = require_budget()
@@ -2002,7 +2083,7 @@ if hasattr(_np, "unstack"):
         with budget.deduct(
             "unstack", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
         ):
-            result = _np.unstack(_to_base_ndarray(x), *args, **kwargs)
+            result = _call_numpy(_np.unstack, _to_base_ndarray(x), *args, **kwargs)
         return result  # type: ignore[return-value]
 
     attach_docstring(unstack, _np.unstack, "free", "0 FLOPs")

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -15,6 +15,7 @@ from typing import Any
 import numpy as _np
 from numpy.typing import ArrayLike, DTypeLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray, _to_base_ndarray_tree
 from flopscope._perm_group import SymmetryGroup
@@ -27,7 +28,6 @@ from flopscope._symmetry_utils import (
     wrap_with_symmetry,
     wrap_with_trusted_symmetry,
 )
-from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._validation import require_budget
 from flopscope.errors import SymmetryError, UnsupportedFunctionError
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as _np
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._config import get_setting as _get_setting
 from flopscope._docstrings import attach_docstring
 from flopscope._flops import (
@@ -47,7 +48,6 @@ from flopscope._symmetry_utils import (
     restrict_group_to_axes,
     unique_elements_for_shape,
 )
-from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._validation import maybe_check_nan_inf, require_budget
 from flopscope.errors import (
     CostFallbackWarning,

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -47,6 +47,7 @@ from flopscope._symmetry_utils import (
     restrict_group_to_axes,
     unique_elements_for_shape,
 )
+from flopscope._budget import _call_numpy
 from flopscope._validation import maybe_check_nan_inf, require_budget
 from flopscope.errors import (
     CostFallbackWarning,
@@ -220,10 +221,12 @@ def _call_with_optional_out(np_func, *args, out=None, supports_out=False, **kwar
             kwargs[k] = _to_base_ndarray_tree(v)
     out_stripped = _to_base_ndarray(out) if out is not None else None
     if out is None:
-        return np_func(*args, **kwargs)
+        return _call_numpy(np_func, *args, **kwargs)
     if supports_out:
-        return np_func(*args, out=out_stripped, **kwargs)
-    result = np_func(*args, **kwargs)
+        return _call_numpy(np_func, *args, out=out_stripped, **kwargs)
+    result = _call_numpy(np_func, *args, **kwargs)
+    # Fallback copy when np_func doesn't natively support out=. This is
+    # flopscope's overhead, NOT routed through _call_numpy.
     _np.copyto(out_stripped, _np.asarray(result), casting="unsafe")  # type: ignore[arg-type]
     return out
 
@@ -248,7 +251,7 @@ def _call_with_optional_multi_out(np_func, *args, out=None, nout, **kwargs):
         elif isinstance(v, (tuple, list)):
             kwargs[k] = _to_base_ndarray_tree(v)
     if out is None:
-        return np_func(*args, **kwargs)
+        return _call_numpy(np_func, *args, **kwargs)
     if not isinstance(out, tuple) or len(out) != nout:
         length_repr = len(out) if hasattr(out, "__len__") else "?"
         raise TypeError(
@@ -257,7 +260,7 @@ def _call_with_optional_multi_out(np_func, *args, out=None, nout, **kwargs):
             f"{type(out).__name__} of length {length_repr}"
         )
     stripped = tuple(_to_base_ndarray(o) if o is not None else None for o in out)
-    result = np_func(*args, out=stripped, **kwargs)
+    result = _call_numpy(np_func, *args, out=stripped, **kwargs)
     # Numpy returns a tuple of the stripped buffers (or fresh allocations
     # for None slots). Replace each non-None slot with the caller's
     # original to preserve object identity.

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -47,7 +47,7 @@ from flopscope._symmetry_utils import (
     restrict_group_to_axes,
     unique_elements_for_shape,
 )
-from flopscope._budget import _call_numpy
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._validation import maybe_check_nan_inf, require_budget
 from flopscope.errors import (
     CostFallbackWarning,
@@ -338,9 +338,11 @@ def _pointwise_symmetry(operands, output_shape):
     return output_symmetry, aligned_groups
 
 
+@_counted_wrapper
 def _counted_unary(np_func, op_name: str):
     supports_out = _supports_out_argument(np_func)
 
+    @_counted_wrapper
     def wrapper(
         x: ArrayLike, out: FlopscopeArray | None = None, **kwargs: Any
     ) -> FlopscopeArray:
@@ -371,6 +373,7 @@ def _counted_unary(np_func, op_name: str):
     return wrapper
 
 
+@_counted_wrapper
 def _counted_unary_multi(np_func, op_name: str):
     """Factory for unary functions that return multiple arrays (modf, frexp).
 
@@ -381,6 +384,7 @@ def _counted_unary_multi(np_func, op_name: str):
     """
     nout = getattr(np_func, "nout", 2)
 
+    @_counted_wrapper
     def wrapper(
         x: ArrayLike,
         out: tuple[FlopscopeArray, FlopscopeArray] | None = None,
@@ -411,9 +415,11 @@ def _counted_unary_multi(np_func, op_name: str):
     return wrapper
 
 
+@_counted_wrapper
 def _counted_binary(np_func, op_name: str):
     supports_out = _supports_out_argument(np_func)
 
+    @_counted_wrapper
     def wrapper(
         x: ArrayLike, y: ArrayLike, out: FlopscopeArray | None = None, **kwargs: Any
     ) -> FlopscopeArray:
@@ -486,6 +492,7 @@ def _counted_binary(np_func, op_name: str):
     return wrapper
 
 
+@_counted_wrapper
 def _counted_binary_multi(np_func, op_name: str):
     """Factory for binary functions that return multiple arrays (divmod).
 
@@ -497,6 +504,7 @@ def _counted_binary_multi(np_func, op_name: str):
     """
     nout = getattr(np_func, "nout", 2)
 
+    @_counted_wrapper
     def wrapper(
         x: ArrayLike,
         y: ArrayLike,
@@ -575,6 +583,7 @@ def _counted_binary_multi(np_func, op_name: str):
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
     """Cost-tracked ``ufunc.outer(a, b)`` for any binary ufunc.
 
@@ -630,6 +639,7 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
     return _wrap_result(result, out=out, symmetry=out_sym)
 
 
+@_counted_wrapper
 def _counted_ufunc_reduce_generic(
     ufunc, a, *, axis=0, out=None, keepdims=False, **kwargs
 ):
@@ -668,6 +678,7 @@ def _counted_ufunc_reduce_generic(
     return _wrap_result(result, out=out, symmetry=out_sym)
 
 
+@_counted_wrapper
 def _counted_ufunc_accumulate_generic(ufunc, a, *, axis=0, out=None, **kwargs):
     """Cost-tracked fallback for ``ufunc.accumulate`` of arbitrary binary ufuncs.
 
@@ -704,6 +715,7 @@ def _counted_ufunc_accumulate_generic(ufunc, a, *, axis=0, out=None, **kwargs):
     return _wrap_result(result, out=out, symmetry=out_sym)
 
 
+@_counted_wrapper
 def _counted_ufunc_reduceat(ufunc, a, indices, *, axis=0, out=None, **kwargs):
     """Cost-tracked ``ufunc.reduceat(a, indices, axis=...)``.
 
@@ -739,6 +751,7 @@ def _counted_ufunc_reduceat(ufunc, a, indices, *, axis=0, out=None, **kwargs):
     return _wrap_result(result, out=out, symmetry=None)
 
 
+@_counted_wrapper
 def _counted_ufunc_at(ufunc, a, indices, *args, **kwargs):
     """Cost-tracked ``ufunc.at(a, indices[, values])`` (in-place fancy index).
 
@@ -798,6 +811,7 @@ def _counted_ufunc_at(ufunc, a, indices, *args, **kwargs):
     return None  # numpy's ufunc.at returns None (mutation is the side effect)
 
 
+@_counted_wrapper
 def _counted_reduction(
     np_func, op_name: str, cost_multiplier: int = 1, extra_output: bool = False
 ):
@@ -832,6 +846,7 @@ def _counted_reduction(
         else None
     )
 
+    @_counted_wrapper
     def wrapper(
         a: ArrayLike, axis: int | None = None, *args: Any, **kwargs: Any
     ) -> FlopscopeArray:
@@ -992,6 +1007,7 @@ arctan = _counted_unary(_np.arctan, "arctan")
 arctanh = _counted_unary(_np.arctanh, "arctanh")
 
 
+@_counted_wrapper
 def around(
     a: ArrayLike, decimals: int = 0, out: FlopscopeArray | None = None
 ) -> FlopscopeArray | Any:
@@ -1076,6 +1092,7 @@ reciprocal = _counted_unary(_np.reciprocal, "reciprocal")
 rint = _counted_unary(_np.rint, "rint")
 
 
+@_counted_wrapper
 def round(
     a: ArrayLike, decimals: int = 0, out: FlopscopeArray | None = None
 ) -> FlopscopeArray | Any:
@@ -1112,6 +1129,7 @@ sinc = _counted_unary(_np.sinc, "sinc")
 sinh = _counted_unary(_np.sinh, "sinh")
 
 
+@_counted_wrapper
 def sort_complex(a: ArrayLike) -> FlopscopeArray:
     """Counted version of np.sort_complex. Cost: n*ceil(log2(n))."""
     import math
@@ -1125,7 +1143,7 @@ def sort_complex(a: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "sort_complex", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.sort_complex(_to_base_ndarray(a))
+        result = _call_numpy(_np.sort_complex, _to_base_ndarray(a))
     return result  # type: ignore[return-value]  # wrapped at fnp.sort_complex import time
 
 
@@ -1139,6 +1157,7 @@ frexp = _counted_unary_multi(_np.frexp, "frexp")
 
 
 # isclose is binary (takes 2 args) but classified as unary in registry
+@_counted_wrapper
 def isclose(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> FlopscopeArray | bool:
     """Counted version of np.isclose. Cost = numel(output) FLOPs."""
     budget = require_budget()
@@ -1158,7 +1177,7 @@ def isclose(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> FlopscopeArray | bool:
     with budget.deduct(
         "isclose", flop_cost=cost, subscripts=None, shapes=(a_arr.shape, b_arr.shape)
     ):
-        result = _np.isclose(_to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
+        result = _call_numpy(_np.isclose, _to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
     if a_is_scalar and b_is_scalar and _np.ndim(result) == 0:
         return bool(result)
     return _wrap_result(result, symmetry=out_symmetry)  # type: ignore[return-value]
@@ -1224,6 +1243,7 @@ true_divide = _counted_binary(_np.true_divide, "true_divide")
 
 if hasattr(_np, "vecdot"):
 
+    @_counted_wrapper
     def vecdot(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> FlopscopeArray:  # pyright: ignore[reportRedeclaration]
         """Counted version of np.vecdot.
 
@@ -1252,7 +1272,8 @@ if hasattr(_np, "vecdot"):
         with budget.deduct(
             "vecdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.vecdot(
+            result = _call_numpy(
+                _np.vecdot,
                 _to_base_ndarray(a),
                 _to_base_ndarray(b),
                 out=out_stripped,
@@ -1268,6 +1289,7 @@ else:
 
 if hasattr(_np, "matvec"):
 
+    @_counted_wrapper
     def matvec(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> FlopscopeArray:  # pyright: ignore[reportRedeclaration]
         """Counted version of np.matvec.
 
@@ -1292,7 +1314,8 @@ if hasattr(_np, "matvec"):
         with budget.deduct(
             "matvec", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.matvec(
+            result = _call_numpy(
+                _np.matvec,
                 _to_base_ndarray(a),
                 _to_base_ndarray(b),
                 out=out_stripped,
@@ -1308,6 +1331,7 @@ else:
 
 if hasattr(_np, "vecmat"):
 
+    @_counted_wrapper
     def vecmat(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> FlopscopeArray:  # pyright: ignore[reportRedeclaration]
         """Counted version of np.vecmat.
 
@@ -1332,7 +1356,8 @@ if hasattr(_np, "vecmat"):
         with budget.deduct(
             "vecmat", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
         ):
-            result = _np.vecmat(
+            result = _call_numpy(
+                _np.vecmat,
                 _to_base_ndarray(a),
                 _to_base_ndarray(b),
                 out=out_stripped,
@@ -1355,6 +1380,7 @@ divmod = _counted_binary_multi(_np.divmod, "divmod")
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def clip(
     a: ArrayLike, *args: Any, out: FlopscopeArray | None = None, **kwargs: Any
 ) -> FlopscopeArray:
@@ -1485,6 +1511,7 @@ if hasattr(_np, "ptp"):
     ptp = _counted_reduction(_np.ptp, "ptp")
 else:
 
+    @_counted_wrapper
     def ptp(a: ArrayLike, axis: int | None = None, **kwargs: Any) -> FlopscopeArray:
         """Peak-to-peak range. Cost = numel(input) FLOPs."""
         budget = require_budget()
@@ -1493,8 +1520,8 @@ else:
         cost = reduction_cost(a.shape, axis)
         with budget.deduct("ptp", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
             stripped = _to_base_ndarray(a)
-            result = _np.max(stripped, axis=axis, **kwargs) - _np.min(
-                stripped, axis=axis, **kwargs
+            result = _call_numpy(_np.max, stripped, axis=axis, **kwargs) - _call_numpy(
+                _np.min, stripped, axis=axis, **kwargs
             )
         return result  # type: ignore[return-value]  # wrapped at fnp.ptp import time
 
@@ -1506,6 +1533,7 @@ else:
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def dot(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     """Counted version of np.dot."""
     budget = require_budget()
@@ -1546,7 +1574,7 @@ def dot(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     ):
         # Strip flopscope subclasses so the raw NumPy call does not re-dispatch
         # through __array_ufunc__ (matmul is a ufunc) / __array_function__.
-        result = _np.dot(_to_base_ndarray(a), _to_base_ndarray(b))
+        result = _call_numpy(_np.dot, _to_base_ndarray(a), _to_base_ndarray(b))
     maybe_check_nan_inf(result, "dot")
     return _asflopscope(result) if inputs_were_whest else result  # type: ignore[return-value]
 
@@ -1554,6 +1582,7 @@ def dot(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
 attach_docstring(dot, _np.dot, "counted_custom", "depends on operand dimensions")
 
 
+@_counted_wrapper
 def matmul(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     """Counted version of np.matmul."""
     budget = require_budget()
@@ -1588,7 +1617,7 @@ def matmul(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
         "matmul", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
         with _np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-            result = _np.matmul(_to_base_ndarray(a), _to_base_ndarray(b))
+            result = _call_numpy(_np.matmul, _to_base_ndarray(a), _to_base_ndarray(b))
     maybe_check_nan_inf(result, "matmul")
     return _asflopscope(result) if inputs_were_whest else result  # type: ignore[return-value]
 
@@ -1601,6 +1630,7 @@ attach_docstring(matmul, _np.matmul, "counted_custom", "depends on operand dimen
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def inner(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     """Counted version of np.inner."""
     budget = require_budget()
@@ -1616,13 +1646,14 @@ def inner(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "inner", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.inner(_to_base_ndarray(a), _to_base_ndarray(b))
+        result = _call_numpy(_np.inner, _to_base_ndarray(a), _to_base_ndarray(b))
     return result  # type: ignore[return-value]  # wrapped at fnp.inner import time
 
 
 attach_docstring(inner, _np.inner, "counted_custom", "product of matching dims")
 
 
+@_counted_wrapper
 def outer(
     a: ArrayLike, b: ArrayLike, out: FlopscopeArray | None = None
 ) -> FlopscopeArray:
@@ -1641,7 +1672,8 @@ def outer(
     with budget.deduct(
         "outer", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.outer(
+        result = _call_numpy(
+            _np.outer,
             _to_base_ndarray(a),
             _to_base_ndarray(b),
             out=None if isinstance(out, SymmetricTensor) else out,
@@ -1692,6 +1724,7 @@ def _surviving_symmetry_after_contraction(group, surviving_axes):
     return restrict_group_to_axes(group, axes=wanted)
 
 
+@_counted_wrapper
 def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
     """Counted version of ``np.tensordot``.
 
@@ -1759,7 +1792,7 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
     with budget.deduct(
         "tensordot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.tensordot(_to_base_ndarray(a), _to_base_ndarray(b), axes=axes)
+        result = _call_numpy(_np.tensordot, _to_base_ndarray(a), _to_base_ndarray(b), axes=axes)
     if out_sym is not None:
         return _wrap_result(result, symmetry=out_sym)  # type: ignore[return-value]
     return result  # type: ignore[return-value]  # wrapped at fnp.tensordot import time
@@ -1768,6 +1801,7 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
 attach_docstring(tensordot, _np.tensordot, "counted_custom", "product of all dims")
 
 
+@_counted_wrapper
 def vdot(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     """Counted version of np.vdot."""
     budget = require_budget()
@@ -1779,13 +1813,14 @@ def vdot(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "vdot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.vdot(_to_base_ndarray(a), _to_base_ndarray(b))
+        result = _call_numpy(_np.vdot, _to_base_ndarray(a), _to_base_ndarray(b))
     return result  # type: ignore[return-value]  # wrapped at fnp.vdot import time
 
 
 attach_docstring(vdot, _np.vdot, "counted_custom", "size of input FLOPs")
 
 
+@_counted_wrapper
 def kron(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     """Counted version of np.kron."""
     budget = require_budget()
@@ -1798,13 +1833,14 @@ def kron(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "kron", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _np.kron(_to_base_ndarray(a), _to_base_ndarray(b))
+        result = _call_numpy(_np.kron, _to_base_ndarray(a), _to_base_ndarray(b))
     return result  # type: ignore[return-value]  # wrapped at fnp.kron import time
 
 
 attach_docstring(kron, _np.kron, "counted_custom", "output size FLOPs")
 
 
+@_counted_wrapper
 def cross(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Counted version of np.cross."""
     budget = require_budget()
@@ -1830,6 +1866,7 @@ attach_docstring(cross, _np.cross, "counted_custom", "output_size * 3 FLOPs")
 cross.__signature__ = _inspect.signature(_np.cross)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def diff(a: ArrayLike, n: int = 1, axis: int = -1, **kwargs: Any) -> FlopscopeArray:
     """Counted version of np.diff."""
     budget = require_budget()
@@ -1847,7 +1884,7 @@ def diff(a: ArrayLike, n: int = 1, axis: int = -1, **kwargs: Any) -> FlopscopeAr
         subscripts=None,
         shapes=(a.shape,),
     ):
-        result = _np.diff(_to_base_ndarray(a), n=n, axis=axis, **kwargs)
+        result = _call_numpy(_np.diff, _to_base_ndarray(a), n=n, axis=axis, **kwargs)
     return result  # type: ignore[return-value]  # wrapped at fnp.diff import time
 
 
@@ -1855,6 +1892,7 @@ attach_docstring(diff, _np.diff, "counted_custom", "numel(output) FLOPs")
 diff.__signature__ = _inspect.signature(_np.diff)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def gradient(
     f: ArrayLike, *varargs: ArrayLike, **kwargs: Any
 ) -> FlopscopeArray | list[FlopscopeArray]:
@@ -1865,7 +1903,8 @@ def gradient(
     with budget.deduct(
         "gradient", flop_cost=f.size, subscripts=None, shapes=(f.shape,)
     ):
-        result = _np.gradient(
+        result = _call_numpy(
+            _np.gradient,
             _to_base_ndarray(f),
             *[_to_base_ndarray(v) for v in varargs],
             **kwargs,
@@ -1877,6 +1916,7 @@ attach_docstring(gradient, _np.gradient, "counted_custom", "numel(input) FLOPs")
 gradient.__signature__ = _inspect.signature(_np.gradient)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def ediff1d(ary: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Counted version of np.ediff1d."""
     budget = require_budget()
@@ -1902,7 +1942,7 @@ def ediff1d(ary: ArrayLike, **kwargs: Any) -> FlopscopeArray:
             k: _to_base_ndarray(v) if isinstance(v, _np.ndarray) else v
             for k, v in kwargs.items()
         }
-        result = _np.ediff1d(_to_base_ndarray(ary), **stripped_kwargs)
+        result = _call_numpy(_np.ediff1d, _to_base_ndarray(ary), **stripped_kwargs)
     return result  # type: ignore[return-value]  # wrapped at fnp.ediff1d import time
 
 
@@ -1910,6 +1950,7 @@ attach_docstring(ediff1d, _np.ediff1d, "counted_custom", "numel(output) FLOPs")
 ediff1d.__signature__ = _inspect.signature(_np.ediff1d)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def convolve(a: ArrayLike, v: ArrayLike, mode: str = "full") -> FlopscopeArray:
     """Counted version of np.convolve."""
     budget = require_budget()
@@ -1924,13 +1965,14 @@ def convolve(a: ArrayLike, v: ArrayLike, mode: str = "full") -> FlopscopeArray:
         subscripts=None,
         shapes=(a.shape, v.shape),
     ):
-        result = _np.convolve(_to_base_ndarray(a), _to_base_ndarray(v), mode=mode)  # type: ignore[arg-type]
+        result = _call_numpy(_np.convolve, _to_base_ndarray(a), _to_base_ndarray(v), mode=mode)  # type: ignore[arg-type]
     return result  # type: ignore[return-value]  # wrapped at fnp.convolve import time
 
 
 attach_docstring(convolve, _np.convolve, "counted_custom", "n * m FLOPs")
 
 
+@_counted_wrapper
 def correlate(a: ArrayLike, v: ArrayLike, mode: str = "valid") -> FlopscopeArray:
     """Counted version of np.correlate."""
     budget = require_budget()
@@ -1945,7 +1987,7 @@ def correlate(a: ArrayLike, v: ArrayLike, mode: str = "valid") -> FlopscopeArray
         subscripts=None,
         shapes=(a.shape, v.shape),
     ):
-        result = _np.correlate(_to_base_ndarray(a), _to_base_ndarray(v), mode=mode)  # type: ignore[arg-type]
+        result = _call_numpy(_np.correlate, _to_base_ndarray(a), _to_base_ndarray(v), mode=mode)  # type: ignore[arg-type]
     return result  # type: ignore[return-value]  # wrapped at fnp.correlate import time
 
 
@@ -1971,6 +2013,7 @@ def _cov_cost(x, y=None):
     return _builtins.max(2 * f * f * s, 1)
 
 
+@_counted_wrapper
 def corrcoef(x: ArrayLike, y: ArrayLike | None = None, **kwargs: Any) -> FlopscopeArray:
     """Counted version of np.corrcoef. Cost: 2 * f^2 * s FLOPs."""
     budget = require_budget()
@@ -1978,7 +2021,8 @@ def corrcoef(x: ArrayLike, y: ArrayLike | None = None, **kwargs: Any) -> Flopsco
         x = _np.asarray(x)
     cost = _cov_cost(x, y)
     with budget.deduct("corrcoef", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-        result = _np.corrcoef(
+        result = _call_numpy(
+            _np.corrcoef,
             _to_base_ndarray(x),
             y=_to_base_ndarray(y) if y is not None else None,  # type: ignore[arg-type]
             **kwargs,
@@ -1990,6 +2034,7 @@ attach_docstring(corrcoef, _np.corrcoef, "counted_custom", r"$2 f^2 s$ FLOPs")
 corrcoef.__signature__ = _inspect.signature(_np.corrcoef)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def cov(m: ArrayLike, y: ArrayLike | None = None, **kwargs: Any) -> FlopscopeArray:
     """Counted version of np.cov. Cost: 2 * f^2 * s FLOPs."""
     budget = require_budget()
@@ -1997,7 +2042,8 @@ def cov(m: ArrayLike, y: ArrayLike | None = None, **kwargs: Any) -> FlopscopeArr
         m = _np.asarray(m)
     cost = _cov_cost(m, y)
     with budget.deduct("cov", flop_cost=cost, subscripts=None, shapes=(m.shape,)):
-        result = _np.cov(
+        result = _call_numpy(
+            _np.cov,
             _to_base_ndarray(m),
             y=_to_base_ndarray(y) if y is not None else None,  # type: ignore[arg-type]
             **kwargs,
@@ -2009,6 +2055,7 @@ attach_docstring(cov, _np.cov, "counted_custom", r"$2 f^2 s$ FLOPs")
 cov.__signature__ = _inspect.signature(_np.cov)  # pyright: ignore[reportFunctionMemberAccess]
 
 
+@_counted_wrapper
 def trapezoid(
     y: ArrayLike, x: ArrayLike | None = None, dx: float = 1.0, axis: int = -1
 ) -> FlopscopeArray:
@@ -2019,7 +2066,8 @@ def trapezoid(
     with budget.deduct(
         "trapezoid", flop_cost=y.size, subscripts=None, shapes=(y.shape,)
     ):
-        result = _np.trapezoid(
+        result = _call_numpy(
+            _np.trapezoid,
             _to_base_ndarray(y),
             x=_to_base_ndarray(x) if x is not None else None,  # type: ignore[arg-type]
             dx=dx,
@@ -2033,6 +2081,7 @@ attach_docstring(trapezoid, _np.trapezoid, "counted_custom", "numel(input) FLOPs
 
 if hasattr(_np, "trapz"):
 
+    @_counted_wrapper
     def trapz(  # pyright: ignore[reportRedeclaration]
         y: ArrayLike, x: ArrayLike | None = None, dx: float = 1.0, axis: int = -1
     ) -> FlopscopeArray:
@@ -2043,7 +2092,8 @@ if hasattr(_np, "trapz"):
         with budget.deduct(
             "trapz", flop_cost=y.size, subscripts=None, shapes=(y.shape,)
         ):
-            result = _np.trapz(
+            result = _call_numpy(
+                _np.trapz,
                 _to_base_ndarray(y),
                 x=_to_base_ndarray(x) if x is not None else None,
                 dx=dx,
@@ -2061,6 +2111,7 @@ else:
         )
 
 
+@_counted_wrapper
 def interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Counted version of np.interp. Cost: n * ceil(log2(len(xp))) FLOPs."""
     budget = require_budget()
@@ -2073,7 +2124,8 @@ def interp(x: ArrayLike, xp: ArrayLike, fp: ArrayLike, **kwargs: Any) -> Flopsco
     with budget.deduct(
         "interp", flop_cost=cost, subscripts=None, shapes=(x.shape, xp_arr.shape)
     ):
-        result = _np.interp(
+        result = _call_numpy(
+            _np.interp,
             _to_base_ndarray(x),
             _to_base_ndarray(xp),  # type: ignore[arg-type]
             _to_base_ndarray(fp),  # type: ignore[arg-type]

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -1177,7 +1177,9 @@ def isclose(a: ArrayLike, b: ArrayLike, **kwargs: Any) -> FlopscopeArray | bool:
     with budget.deduct(
         "isclose", flop_cost=cost, subscripts=None, shapes=(a_arr.shape, b_arr.shape)
     ):
-        result = _call_numpy(_np.isclose, _to_base_ndarray(a), _to_base_ndarray(b), **kwargs)
+        result = _call_numpy(
+            _np.isclose, _to_base_ndarray(a), _to_base_ndarray(b), **kwargs
+        )
     if a_is_scalar and b_is_scalar and _np.ndim(result) == 0:
         return bool(result)
     return _wrap_result(result, symmetry=out_symmetry)  # type: ignore[return-value]
@@ -1792,7 +1794,9 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
     with budget.deduct(
         "tensordot", flop_cost=cost, subscripts=None, shapes=(a.shape, b.shape)
     ):
-        result = _call_numpy(_np.tensordot, _to_base_ndarray(a), _to_base_ndarray(b), axes=axes)
+        result = _call_numpy(
+            _np.tensordot, _to_base_ndarray(a), _to_base_ndarray(b), axes=axes
+        )
     if out_sym is not None:
         return _wrap_result(result, symmetry=out_sym)  # type: ignore[return-value]
     return result  # type: ignore[return-value]  # wrapped at fnp.tensordot import time
@@ -1965,7 +1969,9 @@ def convolve(a: ArrayLike, v: ArrayLike, mode: str = "full") -> FlopscopeArray:
         subscripts=None,
         shapes=(a.shape, v.shape),
     ):
-        result = _call_numpy(_np.convolve, _to_base_ndarray(a), _to_base_ndarray(v), mode=mode)  # type: ignore[arg-type]
+        result = _call_numpy(
+            _np.convolve, _to_base_ndarray(a), _to_base_ndarray(v), mode=mode
+        )  # type: ignore[arg-type]
     return result  # type: ignore[return-value]  # wrapped at fnp.convolve import time
 
 
@@ -1987,7 +1993,9 @@ def correlate(a: ArrayLike, v: ArrayLike, mode: str = "valid") -> FlopscopeArray
         subscripts=None,
         shapes=(a.shape, v.shape),
     ):
-        result = _call_numpy(_np.correlate, _to_base_ndarray(a), _to_base_ndarray(v), mode=mode)  # type: ignore[arg-type]
+        result = _call_numpy(
+            _np.correlate, _to_base_ndarray(a), _to_base_ndarray(v), mode=mode
+        )  # type: ignore[arg-type]
     return result  # type: ignore[return-value]  # wrapped at fnp.correlate import time
 
 

--- a/src/flopscope/_polynomial.py
+++ b/src/flopscope/_polynomial.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as _np
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray
 from flopscope._validation import require_budget
@@ -72,6 +73,7 @@ def roots_cost(n: int) -> int:
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def polyval(p: ArrayLike, x: ArrayLike) -> FlopscopeArray:
     """Evaluate a polynomial at given points. Wraps ``numpy.polyval``.
 
@@ -88,7 +90,7 @@ def polyval(p: ArrayLike, x: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "polyval", flop_cost=cost, subscripts=None, shapes=(p.shape, x.shape)
     ):
-        result = _np.polyval(p, x)
+        result = _call_numpy(_np.polyval, p, x)
     return result  # type: ignore[return-value]
 
 
@@ -97,6 +99,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def polyadd(a1: ArrayLike, a2: ArrayLike) -> FlopscopeArray:
     """Add two polynomials. Wraps ``numpy.polyadd``."""
     budget = require_budget()
@@ -108,13 +111,14 @@ def polyadd(a1: ArrayLike, a2: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "polyadd", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.polyadd(a1, a2)
+        result = _call_numpy(_np.polyadd, a1, a2)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(polyadd, _np.polyadd, "counted_custom", "max(n1, n2) FLOPs")
 
 
+@_counted_wrapper
 def polysub(a1: ArrayLike, a2: ArrayLike) -> FlopscopeArray:
     """Subtract two polynomials. Wraps ``numpy.polysub``."""
     budget = require_budget()
@@ -126,13 +130,14 @@ def polysub(a1: ArrayLike, a2: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "polysub", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.polysub(a1, a2)
+        result = _call_numpy(_np.polysub, a1, a2)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(polysub, _np.polysub, "counted_custom", "max(n1, n2) FLOPs")
 
 
+@_counted_wrapper
 def polyder(p: ArrayLike, m: int = 1) -> FlopscopeArray:
     """Differentiate a polynomial. Wraps ``numpy.polyder``."""
     budget = require_budget()
@@ -140,13 +145,14 @@ def polyder(p: ArrayLike, m: int = 1) -> FlopscopeArray:
     n = len(p)
     cost = polyder_cost(n)
     with budget.deduct("polyder", flop_cost=cost, subscripts=None, shapes=(p.shape,)):
-        result = _np.polyder(p, m=m)
+        result = _call_numpy(_np.polyder, p, m=m)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(polyder, _np.polyder, "counted_custom", "n FLOPs (n = len(coeffs))")
 
 
+@_counted_wrapper
 def polyint(p: ArrayLike, m: int = 1, k: ArrayLike | None = None) -> FlopscopeArray:
     """Integrate a polynomial. Wraps ``numpy.polyint``."""
     budget = require_budget()
@@ -155,15 +161,16 @@ def polyint(p: ArrayLike, m: int = 1, k: ArrayLike | None = None) -> FlopscopeAr
     cost = polyint_cost(n)
     with budget.deduct("polyint", flop_cost=cost, subscripts=None, shapes=(p.shape,)):
         if k is None:
-            result = _np.polyint(p, m=m)
+            result = _call_numpy(_np.polyint, p, m=m)
         else:
-            result = _np.polyint(p, m=m, k=k)  # type: ignore[arg-type]
+            result = _call_numpy(_np.polyint, p, m=m, k=k)  # type: ignore[arg-type]
     return result  # type: ignore[return-value]
 
 
 attach_docstring(polyint, _np.polyint, "counted_custom", "n FLOPs (n = len(coeffs))")
 
 
+@_counted_wrapper
 def polymul(a1: ArrayLike, a2: ArrayLike) -> FlopscopeArray:
     """Multiply polynomials. Wraps ``numpy.polymul``."""
     budget = require_budget()
@@ -175,13 +182,14 @@ def polymul(a1: ArrayLike, a2: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "polymul", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.polymul(a1, a2)
+        result = _call_numpy(_np.polymul, a1, a2)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(polymul, _np.polymul, "counted_custom", "n1 * n2 FLOPs")
 
 
+@_counted_wrapper
 def polydiv(u: ArrayLike, v: ArrayLike) -> tuple[FlopscopeArray, FlopscopeArray]:
     """Divide one polynomial by another. Wraps ``numpy.polydiv``."""
     budget = require_budget()
@@ -193,13 +201,14 @@ def polydiv(u: ArrayLike, v: ArrayLike) -> tuple[FlopscopeArray, FlopscopeArray]
     with budget.deduct(
         "polydiv", flop_cost=cost, subscripts=None, shapes=(u.shape, v.shape)
     ):
-        result = _np.polydiv(u, v)
+        result = _call_numpy(_np.polydiv, u, v)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(polydiv, _np.polydiv, "counted_custom", "n1 * n2 FLOPs")
 
 
+@_counted_wrapper
 def polyfit(
     x: ArrayLike,
     y: ArrayLike,
@@ -212,7 +221,7 @@ def polyfit(
     m = len(x)
     cost = polyfit_cost(m, deg)
     with budget.deduct("polyfit", flop_cost=cost, subscripts=None, shapes=(x.shape,)):
-        result = _np.polyfit(x, y, deg, **kwargs)  # type: ignore[arg-type]
+        result = _call_numpy(_np.polyfit, x, y, deg, **kwargs)  # type: ignore[arg-type]
     return result  # type: ignore[return-value]
 
 
@@ -220,6 +229,7 @@ attach_docstring(polyfit, _np.polyfit, "counted_custom", "2 * m * (deg+1)^2 FLOP
 polyfit.__signature__ = _inspect.signature(_np.polyfit)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def poly(seq_of_zeros: ArrayLike) -> FlopscopeArray:
     """Return polynomial coefficients from roots. Wraps ``numpy.poly``."""
     budget = require_budget()
@@ -231,13 +241,14 @@ def poly(seq_of_zeros: ArrayLike) -> FlopscopeArray:
         n = len(seq)
     cost = poly_cost(n)
     with budget.deduct("poly", flop_cost=cost, subscripts=None, shapes=(seq.shape,)):
-        result = _np.poly(seq_of_zeros)
+        result = _call_numpy(_np.poly, seq_of_zeros)
     return result  # type: ignore[return-value]
 
 
 attach_docstring(poly, _np.poly, "counted_custom", "n^2 FLOPs")
 
 
+@_counted_wrapper
 def roots(p: ArrayLike) -> FlopscopeArray:
     """Return the roots of a polynomial with given coefficients. Wraps ``numpy.roots``."""
     budget = require_budget()
@@ -245,7 +256,7 @@ def roots(p: ArrayLike) -> FlopscopeArray:
     n = len(p) - 1  # degree = number of roots
     cost = roots_cost(n)
     with budget.deduct("roots", flop_cost=cost, subscripts=None, shapes=(p.shape,)):
-        result = _np.roots(p)
+        result = _call_numpy(_np.roots, p)
     return result  # type: ignore[return-value]
 
 

--- a/src/flopscope/_sorting_ops.py
+++ b/src/flopscope/_sorting_ops.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as _np
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._flops import search_cost, sort_cost
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray, _to_base_ndarray_tree
@@ -45,6 +46,7 @@ def _sort_cost_nd(a: _np.ndarray, axis: int) -> int:
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def sort(
     a: ArrayLike,
     axis: int | None = -1,
@@ -64,7 +66,7 @@ def sort(
         ax = axis % a.ndim
         cost = _sort_cost_nd(a, ax)
     with budget.deduct("sort", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.sort(_to_base_ndarray(a), axis=axis, **kwargs)
+        result = _call_numpy(_np.sort, _to_base_ndarray(a), axis=axis, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -72,6 +74,7 @@ attach_docstring(sort, _np.sort, "counted_custom", "n*ceil(log2(n)) FLOPs per sl
 sort.__signature__ = _inspect.signature(_np.sort)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def argsort(
     a: ArrayLike,
     axis: int | None = -1,
@@ -89,7 +92,7 @@ def argsort(
         ax = axis % a.ndim
         cost = _sort_cost_nd(a, ax)
     with budget.deduct("argsort", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.argsort(_to_base_ndarray(a), axis=axis, **kwargs)
+        result = _call_numpy(_np.argsort, _to_base_ndarray(a), axis=axis, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -99,6 +102,7 @@ attach_docstring(
 argsort.__signature__ = _inspect.signature(_np.argsort)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def lexsort(keys: Sequence[ArrayLike], axis: int = -1) -> FlopscopeArray:
     """Counted version of ``numpy.lexsort``.
 
@@ -117,13 +121,14 @@ def lexsort(keys: Sequence[ArrayLike], axis: int = -1) -> FlopscopeArray:
         cost = max(k * sort_cost(n), 1)
     shapes = tuple(_np.asarray(key).shape for key in keys_list)
     with budget.deduct("lexsort", flop_cost=cost, subscripts=None, shapes=shapes):
-        result = _np.lexsort(_to_base_ndarray_tree(keys_list), axis=axis)
+        result = _call_numpy(_np.lexsort, _to_base_ndarray_tree(keys_list), axis=axis)
     return result
 
 
 attach_docstring(lexsort, _np.lexsort, "counted_custom", "k*n*ceil(log2(n)) FLOPs")
 
 
+@_counted_wrapper
 def partition(
     a: ArrayLike,
     kth: int | Sequence[int],
@@ -148,7 +153,7 @@ def partition(
         num_slices = numel // n if n > 0 else 1
         cost = max(num_slices * n * kth_count, 1)
     with budget.deduct("partition", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.partition(_to_base_ndarray(a), kth, axis=axis, **kwargs)
+        result = _call_numpy(_np.partition, _to_base_ndarray(a), kth, axis=axis, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -158,6 +163,7 @@ attach_docstring(
 partition.__signature__ = _inspect.signature(_np.partition)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def argpartition(
     a: ArrayLike,
     kth: int | Sequence[int],
@@ -184,7 +190,7 @@ def argpartition(
     with budget.deduct(
         "argpartition", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.argpartition(_to_base_ndarray(a), kth, axis=axis, **kwargs)
+        result = _call_numpy(_np.argpartition, _to_base_ndarray(a), kth, axis=axis, **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -202,6 +208,7 @@ argpartition.__signature__ = _inspect.signature(_np.argpartition)  # type: ignor
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def searchsorted(
     a: ArrayLike,
     v: ArrayLike,
@@ -224,7 +231,7 @@ def searchsorted(
         subscripts=None,
         shapes=(a.shape, v_arr.shape),
     ):
-        result = _np.searchsorted(_to_base_ndarray(a), _to_base_ndarray(v), **kwargs)
+        result = _call_numpy(_np.searchsorted, _to_base_ndarray(a), _to_base_ndarray(v), **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -237,6 +244,7 @@ attach_docstring(
 searchsorted.__signature__ = _inspect.signature(_np.searchsorted)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def digitize(
     x: ArrayLike,
     bins: ArrayLike,
@@ -257,7 +265,7 @@ def digitize(
         subscripts=None,
         shapes=(x_arr.shape, bins_arr.shape),
     ):
-        result = _np.digitize(_to_base_ndarray(x), _to_base_ndarray(bins), **kwargs)  # type: ignore[arg-type]
+        result = _call_numpy(_np.digitize, _to_base_ndarray(x), _to_base_ndarray(bins), **kwargs)  # type: ignore[arg-type]
     return result  # type: ignore[return-value]
 
 
@@ -283,6 +291,7 @@ def _unique_cost(ar):
     return sort_cost(n)
 
 
+@_counted_wrapper
 def unique(ar: ArrayLike, **kwargs: Any) -> FlopscopeArray | tuple[FlopscopeArray, ...]:
     """Counted version of ``numpy.unique``. Cost: n*ceil(log2(n)) FLOPs.
 
@@ -296,7 +305,7 @@ def unique(ar: ArrayLike, **kwargs: Any) -> FlopscopeArray | tuple[FlopscopeArra
     with budget.deduct(
         "unique", flop_cost=cost, subscripts=None, shapes=(ar_arr.shape,)
     ):
-        result = _np.unique(ar_arr, **kwargs)
+        result = _call_numpy(_np.unique, ar_arr, **kwargs)
 
     # Shim: restore sort guarantee for string / complex dtypes on numpy 2.3+.
     # Only active for the default signature (no auxiliary arrays requested).
@@ -317,6 +326,7 @@ attach_docstring(unique, _np.unique, "counted_custom", "n*ceil(log2(n)) FLOPs")
 unique.__signature__ = _inspect.signature(_np.unique)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def unique_all(x: ArrayLike, /) -> Any:
     """Counted version of ``numpy.unique_all``. Cost: n*ceil(log2(n)) FLOPs."""
     budget = require_budget()
@@ -325,13 +335,14 @@ def unique_all(x: ArrayLike, /) -> Any:
     with budget.deduct(
         "unique_all", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
     ):
-        result = _np.unique_all(x_arr)
+        result = _call_numpy(_np.unique_all, x_arr)
     return result
 
 
 attach_docstring(unique_all, _np.unique_all, "counted_custom", "n*ceil(log2(n)) FLOPs")
 
 
+@_counted_wrapper
 def unique_counts(x: ArrayLike, /) -> Any:
     """Counted version of ``numpy.unique_counts``. Cost: n*ceil(log2(n)) FLOPs."""
     budget = require_budget()
@@ -340,7 +351,7 @@ def unique_counts(x: ArrayLike, /) -> Any:
     with budget.deduct(
         "unique_counts", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
     ):
-        result = _np.unique_counts(x_arr)
+        result = _call_numpy(_np.unique_counts, x_arr)
     return result
 
 
@@ -349,6 +360,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def unique_inverse(x: ArrayLike, /) -> Any:
     """Counted version of ``numpy.unique_inverse``. Cost: n*ceil(log2(n)) FLOPs."""
     budget = require_budget()
@@ -357,7 +369,7 @@ def unique_inverse(x: ArrayLike, /) -> Any:
     with budget.deduct(
         "unique_inverse", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
     ):
-        result = _np.unique_inverse(x_arr)
+        result = _call_numpy(_np.unique_inverse, x_arr)
     return result
 
 
@@ -366,6 +378,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def unique_values(x: ArrayLike, /) -> FlopscopeArray:
     """Counted version of ``numpy.unique_values``. Cost: n*ceil(log2(n)) FLOPs."""
     budget = require_budget()
@@ -374,7 +387,7 @@ def unique_values(x: ArrayLike, /) -> FlopscopeArray:
     with budget.deduct(
         "unique_values", flop_cost=cost, subscripts=None, shapes=(x_arr.shape,)
     ):
-        result = _np.unique_values(x_arr)
+        result = _call_numpy(_np.unique_values, x_arr)
     return result  # type: ignore[return-value]
 
 
@@ -398,6 +411,7 @@ def _set_cost(ar1, ar2):
 
 if hasattr(_np, "in1d"):
 
+    @_counted_wrapper
     def in1d(ar1: ArrayLike, ar2: ArrayLike, **kwargs: Any) -> FlopscopeArray:  # pyright: ignore[reportRedeclaration]
         """Counted version of ``numpy.in1d``. Cost: (n+m)*ceil(log2(n+m)) FLOPs."""
         budget = require_budget()
@@ -407,7 +421,7 @@ if hasattr(_np, "in1d"):
         with budget.deduct(
             "in1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
         ):
-            result = _np.in1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+            result = _call_numpy(_np.in1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
         return result  # type: ignore[return-value]
 
     attach_docstring(in1d, _np.in1d, "counted_custom", "(n+m)*ceil(log2(n+m)) FLOPs")
@@ -419,6 +433,7 @@ else:
         raise UnsupportedFunctionError("in1d", max_version="2.4", replacement="isin")
 
 
+@_counted_wrapper
 def isin(
     element: ArrayLike,
     test_elements: ArrayLike,
@@ -432,8 +447,8 @@ def isin(
     with budget.deduct(
         "isin", flop_cost=cost, subscripts=None, shapes=(el.shape, te.shape)
     ):
-        result = _np.isin(
-            _to_base_ndarray(element), _to_base_ndarray(test_elements), **kwargs
+        result = _call_numpy(
+            _np.isin, _to_base_ndarray(element), _to_base_ndarray(test_elements), **kwargs
         )
     return result  # type: ignore[return-value]
 
@@ -442,6 +457,7 @@ attach_docstring(isin, _np.isin, "counted_custom", "(n+m)*ceil(log2(n+m)) FLOPs"
 isin.__signature__ = _inspect.signature(_np.isin)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def intersect1d(
     ar1: ArrayLike,
     ar2: ArrayLike,
@@ -455,7 +471,7 @@ def intersect1d(
     with budget.deduct(
         "intersect1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.intersect1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+        result = _call_numpy(_np.intersect1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -465,6 +481,7 @@ attach_docstring(
 intersect1d.__signature__ = _inspect.signature(_np.intersect1d)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def union1d(ar1: ArrayLike, ar2: ArrayLike) -> FlopscopeArray:
     """Counted version of ``numpy.union1d``. Cost: (n+m)*ceil(log2(n+m)) FLOPs."""
     budget = require_budget()
@@ -474,13 +491,14 @@ def union1d(ar1: ArrayLike, ar2: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "union1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.union1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2))
+        result = _call_numpy(_np.union1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2))
     return result  # type: ignore[return-value]
 
 
 attach_docstring(union1d, _np.union1d, "counted_custom", "(n+m)*ceil(log2(n+m)) FLOPs")
 
 
+@_counted_wrapper
 def setdiff1d(
     ar1: ArrayLike,
     ar2: ArrayLike,
@@ -494,7 +512,7 @@ def setdiff1d(
     with budget.deduct(
         "setdiff1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.setdiff1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+        result = _call_numpy(_np.setdiff1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
     return result  # type: ignore[return-value]
 
 
@@ -504,6 +522,7 @@ attach_docstring(
 setdiff1d.__signature__ = _inspect.signature(_np.setdiff1d)  # type: ignore[attr-defined]
 
 
+@_counted_wrapper
 def setxor1d(
     ar1: ArrayLike,
     ar2: ArrayLike,
@@ -517,7 +536,7 @@ def setxor1d(
     with budget.deduct(
         "setxor1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _np.setxor1d(_to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+        result = _call_numpy(_np.setxor1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
     return result  # type: ignore[return-value]
 
 

--- a/src/flopscope/_sorting_ops.py
+++ b/src/flopscope/_sorting_ops.py
@@ -153,7 +153,9 @@ def partition(
         num_slices = numel // n if n > 0 else 1
         cost = max(num_slices * n * kth_count, 1)
     with budget.deduct("partition", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.partition, _to_base_ndarray(a), kth, axis=axis, **kwargs)
+        result = _call_numpy(
+            _np.partition, _to_base_ndarray(a), kth, axis=axis, **kwargs
+        )
     return result  # type: ignore[return-value]
 
 
@@ -190,7 +192,9 @@ def argpartition(
     with budget.deduct(
         "argpartition", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _call_numpy(_np.argpartition, _to_base_ndarray(a), kth, axis=axis, **kwargs)
+        result = _call_numpy(
+            _np.argpartition, _to_base_ndarray(a), kth, axis=axis, **kwargs
+        )
     return result  # type: ignore[return-value]
 
 
@@ -231,7 +235,9 @@ def searchsorted(
         subscripts=None,
         shapes=(a.shape, v_arr.shape),
     ):
-        result = _call_numpy(_np.searchsorted, _to_base_ndarray(a), _to_base_ndarray(v), **kwargs)
+        result = _call_numpy(
+            _np.searchsorted, _to_base_ndarray(a), _to_base_ndarray(v), **kwargs
+        )
     return result  # type: ignore[return-value]
 
 
@@ -265,7 +271,9 @@ def digitize(
         subscripts=None,
         shapes=(x_arr.shape, bins_arr.shape),
     ):
-        result = _call_numpy(_np.digitize, _to_base_ndarray(x), _to_base_ndarray(bins), **kwargs)  # type: ignore[arg-type]
+        result = _call_numpy(
+            _np.digitize, _to_base_ndarray(x), _to_base_ndarray(bins), **kwargs
+        )  # type: ignore[arg-type]
     return result  # type: ignore[return-value]
 
 
@@ -421,7 +429,9 @@ if hasattr(_np, "in1d"):
         with budget.deduct(
             "in1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
         ):
-            result = _call_numpy(_np.in1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+            result = _call_numpy(
+                _np.in1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs
+            )
         return result  # type: ignore[return-value]
 
     attach_docstring(in1d, _np.in1d, "counted_custom", "(n+m)*ceil(log2(n+m)) FLOPs")
@@ -448,7 +458,10 @@ def isin(
         "isin", flop_cost=cost, subscripts=None, shapes=(el.shape, te.shape)
     ):
         result = _call_numpy(
-            _np.isin, _to_base_ndarray(element), _to_base_ndarray(test_elements), **kwargs
+            _np.isin,
+            _to_base_ndarray(element),
+            _to_base_ndarray(test_elements),
+            **kwargs,
         )
     return result  # type: ignore[return-value]
 
@@ -471,7 +484,9 @@ def intersect1d(
     with budget.deduct(
         "intersect1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _call_numpy(_np.intersect1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+        result = _call_numpy(
+            _np.intersect1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs
+        )
     return result  # type: ignore[return-value]
 
 
@@ -512,7 +527,9 @@ def setdiff1d(
     with budget.deduct(
         "setdiff1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _call_numpy(_np.setdiff1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+        result = _call_numpy(
+            _np.setdiff1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs
+        )
     return result  # type: ignore[return-value]
 
 
@@ -536,7 +553,9 @@ def setxor1d(
     with budget.deduct(
         "setxor1d", flop_cost=cost, subscripts=None, shapes=(a1.shape, a2.shape)
     ):
-        result = _call_numpy(_np.setxor1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs)
+        result = _call_numpy(
+            _np.setxor1d, _to_base_ndarray(ar1), _to_base_ndarray(ar2), **kwargs
+        )
     return result  # type: ignore[return-value]
 
 

--- a/src/flopscope/_unwrap.py
+++ b/src/flopscope/_unwrap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as _np
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._validation import require_budget
@@ -34,6 +35,7 @@ def unwrap_cost(shape: tuple[int, ...]) -> int:
     return max(numel, 1)
 
 
+@_counted_wrapper
 def unwrap(
     p: ArrayLike,
     discont: float | None = None,
@@ -49,7 +51,7 @@ def unwrap(
     if discont is not None:
         kwargs["discont"] = discont
     with budget.deduct("unwrap", flop_cost=cost, subscripts=None, shapes=(p.shape,)):
-        result = _np.unwrap(_to_base_ndarray(p), **kwargs)
+        result = _call_numpy(_np.unwrap, _to_base_ndarray(p), **kwargs)
     return result  # type: ignore[return-value]
 
 

--- a/src/flopscope/_window.py
+++ b/src/flopscope/_window.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import numpy as _np
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._cost_model import FMA_COST
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray
@@ -31,11 +32,12 @@ def bartlett_cost(n: int) -> int:
     return max(n, 1)
 
 
+@_counted_wrapper
 def bartlett(M: int) -> FlopscopeArray:
     budget = require_budget()
     cost = bartlett_cost(M)
     with budget.deduct("bartlett", flop_cost=cost, subscripts=None, shapes=((M,),)):
-        result = _np.bartlett(M)
+        result = _call_numpy(_np.bartlett, M)
     return result  # type: ignore[return-value]
 
 
@@ -62,11 +64,12 @@ def blackman_cost(n: int) -> int:
     return max(3 * n, 1)
 
 
+@_counted_wrapper
 def blackman(M: int) -> FlopscopeArray:
     budget = require_budget()
     cost = blackman_cost(M)
     with budget.deduct("blackman", flop_cost=cost, subscripts=None, shapes=((M,),)):
-        result = _np.blackman(M)
+        result = _call_numpy(_np.blackman, M)
     return result  # type: ignore[return-value]
 
 
@@ -93,11 +96,12 @@ def hamming_cost(n: int) -> int:
     return max(FMA_COST * n, 1)
 
 
+@_counted_wrapper
 def hamming(M: int) -> FlopscopeArray:
     budget = require_budget()
     cost = hamming_cost(M)
     with budget.deduct("hamming", flop_cost=cost, subscripts=None, shapes=((M,),)):
-        result = _np.hamming(M)
+        result = _call_numpy(_np.hamming, M)
     return result  # type: ignore[return-value]
 
 
@@ -124,11 +128,12 @@ def hanning_cost(n: int) -> int:
     return max(FMA_COST * n, 1)
 
 
+@_counted_wrapper
 def hanning(M: int) -> FlopscopeArray:
     budget = require_budget()
     cost = hanning_cost(M)
     with budget.deduct("hanning", flop_cost=cost, subscripts=None, shapes=((M,),)):
-        result = _np.hanning(M)
+        result = _call_numpy(_np.hanning, M)
     return result  # type: ignore[return-value]
 
 
@@ -155,11 +160,12 @@ def kaiser_cost(n: int) -> int:
     return max(3 * n, 1)
 
 
+@_counted_wrapper
 def kaiser(M: int, beta: float) -> FlopscopeArray:
     budget = require_budget()
     cost = kaiser_cost(M)
     with budget.deduct("kaiser", flop_cost=cost, subscripts=None, shapes=((M,),)):
-        result = _np.kaiser(M, beta)
+        result = _call_numpy(_np.kaiser, M, beta)
     return result  # type: ignore[return-value]
 
 

--- a/src/flopscope/numpy/fft/_transforms.py
+++ b/src/flopscope/numpy/fft/_transforms.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 import numpy as _np
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._validation import require_budget
@@ -166,6 +167,7 @@ def _batch_count_nd(a: _np.ndarray, axes: tuple[int, ...] | None) -> int:
 
 
 # 1-D transforms
+@_counted_wrapper
 def fft(
     a: ArrayLike,
     n: int | None = None,
@@ -180,7 +182,7 @@ def fft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.fft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fft(
+        result = _call_numpy(_np.fft.fft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -195,6 +197,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def ifft(
     a: ArrayLike,
     n: int | None = None,
@@ -209,7 +212,7 @@ def ifft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.ifft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifft(
+        result = _call_numpy(_np.fft.ifft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -224,6 +227,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def rfft(
     a: ArrayLike,
     n: int | None = None,
@@ -238,7 +242,7 @@ def rfft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.rfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfft(
+        result = _call_numpy(_np.fft.rfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -253,6 +257,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def irfft(
     a: ArrayLike,
     n: int | None = None,
@@ -267,7 +272,7 @@ def irfft(
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.irfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.irfft(
+        result = _call_numpy(_np.fft.irfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -283,6 +288,7 @@ attach_docstring(
 
 
 # 2-D transforms
+@_counted_wrapper
 def fft2(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -301,7 +307,7 @@ def fft2(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.fft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fft2(
+        result = _call_numpy(_np.fft.fft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -319,6 +325,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def ifft2(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -337,7 +344,7 @@ def ifft2(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.ifft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifft2(
+        result = _call_numpy(_np.fft.ifft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -355,6 +362,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def rfft2(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -373,7 +381,7 @@ def rfft2(
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.rfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfft2(
+        result = _call_numpy(_np.fft.rfft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -391,6 +399,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def irfft2(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -414,7 +423,7 @@ def irfft2(
     with budget.deduct(
         "fft.irfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.fft.irfft2(
+        result = _call_numpy(_np.fft.irfft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -433,6 +442,7 @@ attach_docstring(
 
 
 # N-D transforms
+@_counted_wrapper
 def fftn(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -452,7 +462,7 @@ def fftn(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.fftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.fftn(
+        result = _call_numpy(_np.fft.fftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -470,6 +480,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def ifftn(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -489,7 +500,7 @@ def ifftn(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.ifftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ifftn(
+        result = _call_numpy(_np.fft.ifftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -507,6 +518,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def rfftn(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -526,7 +538,7 @@ def rfftn(
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.rfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.rfftn(
+        result = _call_numpy(_np.fft.rfftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -544,6 +556,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def irfftn(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -577,7 +590,7 @@ def irfftn(
     with budget.deduct(
         "fft.irfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.fft.irfftn(
+        result = _call_numpy(_np.fft.irfftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -596,6 +609,7 @@ attach_docstring(
 
 
 # Hermitian transforms
+@_counted_wrapper
 def hfft(
     a: ArrayLike,
     n: int | None = None,
@@ -610,7 +624,7 @@ def hfft(
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.hfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.hfft(
+        result = _call_numpy(_np.fft.hfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -628,6 +642,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def ihfft(
     a: ArrayLike,
     n: int | None = None,
@@ -642,7 +657,7 @@ def ihfft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.ihfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.fft.ihfft(
+        result = _call_numpy(_np.fft.ihfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,

--- a/src/flopscope/numpy/fft/_transforms.py
+++ b/src/flopscope/numpy/fft/_transforms.py
@@ -182,7 +182,8 @@ def fft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.fft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.fft,
+        result = _call_numpy(
+            _np.fft.fft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -212,7 +213,8 @@ def ifft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
     with budget.deduct("fft.ifft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.ifft,
+        result = _call_numpy(
+            _np.fft.ifft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -242,7 +244,8 @@ def rfft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.rfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.rfft,
+        result = _call_numpy(
+            _np.fft.rfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -272,7 +275,8 @@ def irfft(
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
     with budget.deduct("fft.irfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.irfft,
+        result = _call_numpy(
+            _np.fft.irfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -307,7 +311,8 @@ def fft2(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.fft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.fft2,
+        result = _call_numpy(
+            _np.fft.fft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -344,7 +349,8 @@ def ifft2(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.ifft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.ifft2,
+        result = _call_numpy(
+            _np.fft.ifft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -381,7 +387,8 @@ def rfft2(
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.rfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.rfft2,
+        result = _call_numpy(
+            _np.fft.rfft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -423,7 +430,8 @@ def irfft2(
     with budget.deduct(
         "fft.irfft2", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _call_numpy(_np.fft.irfft2,
+        result = _call_numpy(
+            _np.fft.irfft2,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -462,7 +470,8 @@ def fftn(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.fftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.fftn,
+        result = _call_numpy(
+            _np.fft.fftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -500,7 +509,8 @@ def ifftn(
         )
     cost = _batch_count_nd(a, axes) * fftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.ifftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.ifftn,
+        result = _call_numpy(
+            _np.fft.ifftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -538,7 +548,8 @@ def rfftn(
         )
     cost = _batch_count_nd(a, axes) * rfftn_cost(s_for_cost)  # type: ignore[reportArgumentType]
     with budget.deduct("fft.rfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.rfftn,
+        result = _call_numpy(
+            _np.fft.rfftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -590,7 +601,8 @@ def irfftn(
     with budget.deduct(
         "fft.irfftn", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _call_numpy(_np.fft.irfftn,
+        result = _call_numpy(
+            _np.fft.irfftn,
             _to_base_ndarray(a),
             s=s,
             axes=axes,
@@ -624,7 +636,8 @@ def hfft(
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.hfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.hfft,
+        result = _call_numpy(
+            _np.fft.hfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,
@@ -657,7 +670,8 @@ def ihfft(
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
     with budget.deduct("fft.ihfft", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _call_numpy(_np.fft.ihfft,
+        result = _call_numpy(
+            _np.fft.ihfft,
             _to_base_ndarray(a),
             n=n,
             axis=axis,

--- a/src/flopscope/numpy/linalg/_aliases.py
+++ b/src/flopscope/numpy/linalg/_aliases.py
@@ -50,7 +50,9 @@ def cross(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1) -> FlopscopeArray:
         subscripts=None,
         shapes=(x1_arr.shape, x2_arr.shape),
     ):
-        result = _call_numpy(_np.linalg.cross, _to_base_ndarray(x1), _to_base_ndarray(x2), axis=axis)  # type: ignore[reportCallIssue]
+        result = _call_numpy(
+            _np.linalg.cross, _to_base_ndarray(x1), _to_base_ndarray(x2), axis=axis
+        )  # type: ignore[reportCallIssue]
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]

--- a/src/flopscope/numpy/linalg/_aliases.py
+++ b/src/flopscope/numpy/linalg/_aliases.py
@@ -13,6 +13,7 @@ import numpy as _np
 from numpy.typing import ArrayLike
 
 import flopscope.numpy as _me
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray
 
@@ -27,6 +28,7 @@ attach_docstring(
 )
 
 
+@_counted_wrapper
 def cross(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1) -> FlopscopeArray:
     """Cross product (linalg namespace). Uses np.linalg.cross for strict validation."""
     import builtins as _builtins
@@ -48,7 +50,7 @@ def cross(x1: ArrayLike, x2: ArrayLike, /, *, axis: int = -1) -> FlopscopeArray:
         subscripts=None,
         shapes=(x1_arr.shape, x2_arr.shape),
     ):
-        result = _np.linalg.cross(_to_base_ndarray(x1), _to_base_ndarray(x2), axis=axis)  # type: ignore[reportCallIssue]
+        result = _call_numpy(_np.linalg.cross, _to_base_ndarray(x1), _to_base_ndarray(x2), axis=axis)  # type: ignore[reportCallIssue]
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]

--- a/src/flopscope/numpy/linalg/_compound.py
+++ b/src/flopscope/numpy/linalg/_compound.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 import numpy as _np
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._cost_model import FMA_COST
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray, _asflopscope, _to_base_ndarray
@@ -63,6 +64,7 @@ def multi_dot_cost(shapes: Sequence[Sequence[int]]) -> int:
     return max(int(cost_table[0][n - 1]), 1)
 
 
+@_counted_wrapper
 def multi_dot(
     arrays: Sequence[ArrayLike], *, out: ArrayLike | None = None
 ) -> FlopscopeArray:
@@ -76,7 +78,8 @@ def multi_dot(
     with budget.deduct(
         "linalg.multi_dot", flop_cost=cost, subscripts=None, shapes=tuple(shapes)
     ):
-        result = _np.linalg.multi_dot(
+        result = _call_numpy(
+            _np.linalg.multi_dot,
             [_to_base_ndarray(a) for a in arrays],
             out=out_stripped,  # type: ignore[reportArgumentType]
         )
@@ -120,6 +123,7 @@ def matrix_power_cost(n: int, k: int) -> int:
     return max(num_ops * n**3, 1)
 
 
+@_counted_wrapper
 def matrix_power(a: ArrayLike, n: int) -> FlopscopeArray:
     """Matrix power with FLOP counting."""
     budget = require_budget()
@@ -132,7 +136,7 @@ def matrix_power(a: ArrayLike, n: int) -> FlopscopeArray:
     with budget.deduct(
         "linalg.matrix_power", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.matrix_power(_to_base_ndarray(a), n)
+        result = _call_numpy(_np.linalg.matrix_power, _to_base_ndarray(a), n)
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]

--- a/src/flopscope/numpy/linalg/_decompositions.py
+++ b/src/flopscope/numpy/linalg/_decompositions.py
@@ -11,6 +11,7 @@ import numpy as _np
 from numpy.linalg._linalg import EighResult, EigResult, QRResult
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray, _asflopscope, _to_base_ndarray
 from flopscope._validation import require_budget
@@ -37,6 +38,7 @@ def cholesky_cost(n: int) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def cholesky(a: ArrayLike, /, *, upper: bool = False) -> FlopscopeArray:
     """Cholesky decomposition with FLOP counting."""
     budget = require_budget()
@@ -49,7 +51,7 @@ def cholesky(a: ArrayLike, /, *, upper: bool = False) -> FlopscopeArray:
     with budget.deduct(
         "linalg.cholesky", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.cholesky(_to_base_ndarray(a), upper=upper)
+        result = _call_numpy(_np.linalg.cholesky, _to_base_ndarray(a), upper=upper)
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -80,6 +82,7 @@ def qr_cost(m: int, n: int) -> int:
     return max(m * n * min(m, n), 1)
 
 
+@_counted_wrapper
 def qr(
     a: ArrayLike, mode: str = "reduced"
 ) -> tuple[FlopscopeArray, FlopscopeArray] | FlopscopeArray:
@@ -102,7 +105,7 @@ def qr(
     batch = _batch_size(a.shape)
     cost = qr_cost(m, n) * batch if not _has_zero_dim(a.shape) else 0
     with budget.deduct("linalg.qr", flop_cost=cost, subscripts=None, shapes=(a.shape,)):
-        result = _np.linalg.qr(_to_base_ndarray(a), mode=mode)  # type: ignore[reportCallIssue]
+        result = _call_numpy(_np.linalg.qr, _to_base_ndarray(a), mode=mode)  # type: ignore[reportCallIssue]
     if mode in ("reduced", "complete"):
         q, r = result  # type: ignore[reportGeneralTypeIssues]
         if inputs_were_whest:
@@ -144,6 +147,7 @@ def eig_cost(n: int) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def eig(a: ArrayLike) -> tuple[FlopscopeArray, FlopscopeArray]:
     """Eigendecomposition with FLOP counting."""
     budget = require_budget()
@@ -156,7 +160,7 @@ def eig(a: ArrayLike) -> tuple[FlopscopeArray, FlopscopeArray]:
     with budget.deduct(
         "linalg.eig", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eig(_to_base_ndarray(a))
+        result = _call_numpy(_np.linalg.eig, _to_base_ndarray(a))
     if inputs_were_whest:
         return EigResult(  # type: ignore[reportReturnType]
             _asflopscope(result.eigenvalues), _asflopscope(result.eigenvectors)
@@ -187,6 +191,7 @@ def eigh_cost(n: int) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def eigh(a: ArrayLike, UPLO: str = "L") -> tuple[FlopscopeArray, FlopscopeArray]:
     """Symmetric eigendecomposition with FLOP counting."""
     budget = require_budget()
@@ -199,7 +204,7 @@ def eigh(a: ArrayLike, UPLO: str = "L") -> tuple[FlopscopeArray, FlopscopeArray]
     with budget.deduct(
         "linalg.eigh", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eigh(_to_base_ndarray(a), UPLO=UPLO)  # type: ignore[reportCallIssue]
+        result = _call_numpy(_np.linalg.eigh, _to_base_ndarray(a), UPLO=UPLO)  # type: ignore[reportCallIssue]
     if inputs_were_whest:
         return EighResult(  # type: ignore[reportReturnType]
             _asflopscope(result.eigenvalues), _asflopscope(result.eigenvectors)
@@ -230,6 +235,7 @@ def eigvals_cost(n: int) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def eigvals(a: ArrayLike) -> FlopscopeArray:
     """Eigenvalues (nonsymmetric) with FLOP counting."""
     budget = require_budget()
@@ -242,7 +248,7 @@ def eigvals(a: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "linalg.eigvals", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eigvals(_to_base_ndarray(a))
+        result = _call_numpy(_np.linalg.eigvals, _to_base_ndarray(a))
     if inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -271,6 +277,7 @@ def eigvalsh_cost(n: int) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def eigvalsh(a: ArrayLike, UPLO: str = "L") -> FlopscopeArray:
     """Eigenvalues (symmetric) with FLOP counting."""
     budget = require_budget()
@@ -283,7 +290,7 @@ def eigvalsh(a: ArrayLike, UPLO: str = "L") -> FlopscopeArray:
     with budget.deduct(
         "linalg.eigvalsh", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.eigvalsh(_to_base_ndarray(a), UPLO=UPLO)  # type: ignore[reportCallIssue]
+        result = _call_numpy(_np.linalg.eigvalsh, _to_base_ndarray(a), UPLO=UPLO)  # type: ignore[reportCallIssue]
     if inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -318,6 +325,7 @@ def svdvals_cost(m: int, n: int, k: int | None = None) -> int:
     return max(m * n * k, 1)
 
 
+@_counted_wrapper
 def svdvals(x: ArrayLike, /, *, k: int | None = None) -> FlopscopeArray:
     """Singular values with FLOP counting."""
     budget = require_budget()
@@ -334,7 +342,7 @@ def svdvals(x: ArrayLike, /, *, k: int | None = None) -> FlopscopeArray:
     with budget.deduct(
         "linalg.svdvals", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.svdvals(_to_base_ndarray(x))
+        result = _call_numpy(_np.linalg.svdvals, _to_base_ndarray(x))
     if k < min(m, n):
         result = result[..., :k]
     if inputs_were_whest:

--- a/src/flopscope/numpy/linalg/_properties.py
+++ b/src/flopscope/numpy/linalg/_properties.py
@@ -9,6 +9,7 @@ import numpy as _np
 from numpy.linalg._linalg import SlogdetResult
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray, _asflopscope, _to_base_ndarray
 from flopscope._symmetric import SymmetricTensor
@@ -36,6 +37,7 @@ def trace_cost(n: int) -> int:
     return max(n, 1)
 
 
+@_counted_wrapper
 def trace(x: ArrayLike, /, *, offset: int = 0, dtype: Any = None) -> FlopscopeArray:
     """Matrix trace with FLOP counting (numpy 2.0 linalg.trace signature)."""
     budget = require_budget()
@@ -52,7 +54,7 @@ def trace(x: ArrayLike, /, *, offset: int = 0, dtype: Any = None) -> FlopscopeAr
     with budget.deduct(
         "linalg.trace", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.trace(_to_base_ndarray(x), offset=offset, dtype=dtype)
+        result = _call_numpy(_np.linalg.trace, _to_base_ndarray(x), offset=offset, dtype=dtype)
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -83,6 +85,7 @@ def det_cost(n: int, symmetric: bool = False) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def det(a: ArrayLike) -> FlopscopeArray:
     """Determinant with FLOP counting."""
     budget = require_budget()
@@ -98,7 +101,7 @@ def det(a: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "linalg.det", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.det(_to_base_ndarray(a))
+        result = _call_numpy(_np.linalg.det, _to_base_ndarray(a))
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -129,6 +132,7 @@ def slogdet_cost(n: int, symmetric: bool = False) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def slogdet(a: ArrayLike) -> SlogdetResult:
     """Sign and log-determinant with FLOP counting."""
     budget = require_budget()
@@ -146,7 +150,7 @@ def slogdet(a: ArrayLike) -> SlogdetResult:
     with budget.deduct(
         "linalg.slogdet", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.slogdet(_to_base_ndarray(a))
+        result = _call_numpy(_np.linalg.slogdet, _to_base_ndarray(a))
     if inputs_were_whest:
         return SlogdetResult(
             _asflopscope(result.sign)
@@ -205,6 +209,7 @@ def norm_cost(shape: tuple, ord=None) -> int:
         return numel
 
 
+@_counted_wrapper
 def norm(
     x: ArrayLike,
     ord: Any = None,
@@ -241,8 +246,8 @@ def norm(
     with budget.deduct(
         "linalg.norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.norm(
-            _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
+        result = _call_numpy(
+            _np.linalg.norm, _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
         )
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
@@ -282,6 +287,7 @@ def vector_norm_cost(shape: tuple, ord=None) -> int:
     return numel
 
 
+@_counted_wrapper
 def vector_norm(
     x: ArrayLike,
     ord: Any = 2,
@@ -304,8 +310,8 @@ def vector_norm(
     with budget.deduct(
         "linalg.vector_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.vector_norm(
-            _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
+        result = _call_numpy(
+            _np.linalg.vector_norm, _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
         )
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
@@ -351,6 +357,7 @@ def matrix_norm_cost(shape: tuple, ord=None) -> int:
     return numel
 
 
+@_counted_wrapper
 def matrix_norm(
     x: ArrayLike, ord: Any = "fro", keepdims: bool = False
 ) -> FlopscopeArray:
@@ -363,7 +370,7 @@ def matrix_norm(
     with budget.deduct(
         "linalg.matrix_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _np.linalg.matrix_norm(_to_base_ndarray(x), ord=ord, keepdims=keepdims)  # type: ignore[reportCallIssue]
+        result = _call_numpy(_np.linalg.matrix_norm, _to_base_ndarray(x), ord=ord, keepdims=keepdims)  # type: ignore[reportCallIssue]
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -405,6 +412,7 @@ def cond_cost(m: int, n: int, p=None) -> int:
     return max(k**3 + m * n, 1)
 
 
+@_counted_wrapper
 def cond(x: ArrayLike, p: Any = None) -> FlopscopeArray:
     """Condition number with FLOP counting."""
     budget = require_budget()
@@ -425,21 +433,21 @@ def cond(x: ArrayLike, p: Any = None) -> FlopscopeArray:
             # propagates per-matrix rather than SVD failing the whole batch.
             batch_shape = x.shape[:-2]
             flat = _to_base_ndarray(x).reshape(-1, x.shape[-2], x.shape[-1])
-            out = _np.empty(flat.shape[0], dtype=_np.float64)
+            out = _call_numpy(_np.empty, flat.shape[0], dtype=_np.float64)
             for i in range(flat.shape[0]):
                 try:
-                    out[i] = _np.linalg.cond(flat[i], p=p)
+                    out[i] = _call_numpy(_np.linalg.cond, flat[i], p=p)
                 except _np.linalg.LinAlgError:
                     out[i] = _np.nan
             result = out.reshape(batch_shape)
         elif has_nan:
             # Single matrix with NaN: SVD may fail; return NaN instead.
             try:
-                result = _np.linalg.cond(_to_base_ndarray(x), p=p)
+                result = _call_numpy(_np.linalg.cond, _to_base_ndarray(x), p=p)
             except _np.linalg.LinAlgError:
-                result = _np.float64(_np.nan)
+                result = _call_numpy(_np.float64, _np.nan)
         else:
-            result = _np.linalg.cond(_to_base_ndarray(x), p=p)
+            result = _call_numpy(_np.linalg.cond, _to_base_ndarray(x), p=p)
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -475,6 +483,7 @@ def matrix_rank_cost(m: int, n: int) -> int:
     return max(m * n * min(m, n), 1)
 
 
+@_counted_wrapper
 def matrix_rank(
     A: ArrayLike,
     tol: float | None = None,
@@ -503,7 +512,7 @@ def matrix_rank(
     with budget.deduct(
         "linalg.matrix_rank", flop_cost=cost, subscripts=None, shapes=(A.shape,)
     ):
-        result = _np.linalg.matrix_rank(_to_base_ndarray(A), **kwargs)
+        result = _call_numpy(_np.linalg.matrix_rank, _to_base_ndarray(A), **kwargs)
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]

--- a/src/flopscope/numpy/linalg/_properties.py
+++ b/src/flopscope/numpy/linalg/_properties.py
@@ -54,7 +54,9 @@ def trace(x: ArrayLike, /, *, offset: int = 0, dtype: Any = None) -> FlopscopeAr
     with budget.deduct(
         "linalg.trace", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _call_numpy(_np.linalg.trace, _to_base_ndarray(x), offset=offset, dtype=dtype)
+        result = _call_numpy(
+            _np.linalg.trace, _to_base_ndarray(x), offset=offset, dtype=dtype
+        )
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -311,7 +313,11 @@ def vector_norm(
         "linalg.vector_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
         result = _call_numpy(
-            _np.linalg.vector_norm, _to_base_ndarray(x), ord=ord, axis=axis, keepdims=keepdims
+            _np.linalg.vector_norm,
+            _to_base_ndarray(x),
+            ord=ord,
+            axis=axis,
+            keepdims=keepdims,
         )
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
@@ -370,7 +376,9 @@ def matrix_norm(
     with budget.deduct(
         "linalg.matrix_norm", flop_cost=cost, subscripts=None, shapes=(x.shape,)
     ):
-        result = _call_numpy(_np.linalg.matrix_norm, _to_base_ndarray(x), ord=ord, keepdims=keepdims)  # type: ignore[reportCallIssue]
+        result = _call_numpy(
+            _np.linalg.matrix_norm, _to_base_ndarray(x), ord=ord, keepdims=keepdims
+        )  # type: ignore[reportCallIssue]
     if isinstance(result, _np.ndarray) and inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]

--- a/src/flopscope/numpy/linalg/_solvers.py
+++ b/src/flopscope/numpy/linalg/_solvers.py
@@ -197,7 +197,9 @@ def lstsq(
     with budget.deduct(
         "linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _call_numpy(_np.linalg.lstsq, _to_base_ndarray(a), _to_base_ndarray(b), rcond=rcond)  # type: ignore[reportCallIssue]
+        result = _call_numpy(
+            _np.linalg.lstsq, _to_base_ndarray(a), _to_base_ndarray(b), rcond=rcond
+        )  # type: ignore[reportCallIssue]
     if b_was_whest:
         return tuple(  # type: ignore[reportReturnType]
             _asflopscope(r) if isinstance(r, _np.ndarray) else r for r in result

--- a/src/flopscope/numpy/linalg/_solvers.py
+++ b/src/flopscope/numpy/linalg/_solvers.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as _np
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._ndarray import FlopscopeArray, _asflopscope, _to_base_ndarray
 from flopscope._symmetric import SymmetricTensor, as_symmetric
@@ -54,6 +55,7 @@ def solve_cost(n: int, nrhs: int = 1, symmetric: bool = False) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def solve(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     """Solve linear system ``a @ x = b`` with FLOP counting.
 
@@ -77,7 +79,7 @@ def solve(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "linalg.solve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.solve(_to_base_ndarray(a), _to_base_ndarray(b))
+        result = _call_numpy(_np.linalg.solve, _to_base_ndarray(a), _to_base_ndarray(b))
     if b_was_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -111,6 +113,7 @@ def inv_cost(n: int, symmetric: bool = False) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def inv(a: ArrayLike) -> FlopscopeArray:
     """Matrix inverse with FLOP counting."""
     budget = require_budget()
@@ -127,7 +130,7 @@ def inv(a: ArrayLike) -> FlopscopeArray:
     with budget.deduct(
         "linalg.inv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.inv(_to_base_ndarray(a))
+        result = _call_numpy(_np.linalg.inv, _to_base_ndarray(a))
     if is_symmetric:
         try:
             result = as_symmetric(result, symmetry=input_symmetry)
@@ -168,6 +171,7 @@ def lstsq_cost(m: int, n: int) -> int:
     return max(m * n * min(m, n), 1)
 
 
+@_counted_wrapper
 def lstsq(
     a: ArrayLike, b: ArrayLike, rcond: float | None = None
 ) -> tuple[FlopscopeArray, FlopscopeArray, int, FlopscopeArray]:
@@ -193,7 +197,7 @@ def lstsq(
     with budget.deduct(
         "linalg.lstsq", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.lstsq(_to_base_ndarray(a), _to_base_ndarray(b), rcond=rcond)  # type: ignore[reportCallIssue]
+        result = _call_numpy(_np.linalg.lstsq, _to_base_ndarray(a), _to_base_ndarray(b), rcond=rcond)  # type: ignore[reportCallIssue]
     if b_was_whest:
         return tuple(  # type: ignore[reportReturnType]
             _asflopscope(r) if isinstance(r, _np.ndarray) else r for r in result
@@ -228,6 +232,7 @@ def pinv_cost(m: int, n: int) -> int:
     return max(m * n * min(m, n), 1)
 
 
+@_counted_wrapper
 def pinv(
     a: ArrayLike,
     rcond: float | None = None,
@@ -251,7 +256,7 @@ def pinv(
     with budget.deduct(
         "linalg.pinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.pinv(_to_base_ndarray(a), **kwargs)
+        result = _call_numpy(_np.linalg.pinv, _to_base_ndarray(a), **kwargs)
     if inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]
@@ -289,6 +294,7 @@ def tensorsolve_cost(a_shape: tuple, ind: int | None = None) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def tensorsolve(a: ArrayLike, b: ArrayLike, axes: Any = None) -> FlopscopeArray:
     """Tensor solve with FLOP counting."""
     budget = require_budget()
@@ -299,7 +305,8 @@ def tensorsolve(a: ArrayLike, b: ArrayLike, axes: Any = None) -> FlopscopeArray:
     with budget.deduct(
         "linalg.tensorsolve", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.tensorsolve(
+        result = _call_numpy(
+            _np.linalg.tensorsolve,
             _to_base_ndarray(a),
             _to_base_ndarray(b),  # type: ignore[arg-type]
             axes=axes,
@@ -342,6 +349,7 @@ def tensorinv_cost(a_shape: tuple, ind: int = 2) -> int:
     return max(n**3, 1)
 
 
+@_counted_wrapper
 def tensorinv(a: ArrayLike, ind: int = 2) -> FlopscopeArray:
     """Tensor inverse with FLOP counting."""
     budget = require_budget()
@@ -352,7 +360,7 @@ def tensorinv(a: ArrayLike, ind: int = 2) -> FlopscopeArray:
     with budget.deduct(
         "linalg.tensorinv", flop_cost=cost, subscripts=None, shapes=(a.shape,)
     ):
-        result = _np.linalg.tensorinv(_to_base_ndarray(a), ind=ind)
+        result = _call_numpy(_np.linalg.tensorinv, _to_base_ndarray(a), ind=ind)
     if inputs_were_whest:
         return _asflopscope(result)  # type: ignore[reportReturnType]
     return result  # type: ignore[reportReturnType]

--- a/src/flopscope/numpy/linalg/_svd.py
+++ b/src/flopscope/numpy/linalg/_svd.py
@@ -91,7 +91,10 @@ def svd(
             # When k is specified, always use economy decomposition then slice.
             fm = full_matrices if k is None else False
             U, S, Vt = _call_numpy(
-                _np.linalg.svd, _to_base_ndarray(a), full_matrices=fm, hermitian=hermitian
+                _np.linalg.svd,
+                _to_base_ndarray(a),
+                full_matrices=fm,
+                hermitian=hermitian,
             )
             if k is not None:
                 S = S[..., :k]
@@ -100,7 +103,10 @@ def svd(
             maybe_check_nan_inf(S, "linalg.svd")
         else:
             S = _call_numpy(
-                _np.linalg.svd, _to_base_ndarray(a), compute_uv=False, hermitian=hermitian
+                _np.linalg.svd,
+                _to_base_ndarray(a),
+                compute_uv=False,
+                hermitian=hermitian,
             )
             if k is not None:
                 S = S[..., :k]

--- a/src/flopscope/numpy/linalg/_svd.py
+++ b/src/flopscope/numpy/linalg/_svd.py
@@ -6,6 +6,7 @@ import numpy as _np
 from numpy.linalg._linalg import SVDResult
 from numpy.typing import ArrayLike
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._flops import svd_cost
 from flopscope._ndarray import FlopscopeArray, _asflopscope, _to_base_ndarray
 from flopscope._validation import maybe_check_nan_inf, require_budget
@@ -26,6 +27,7 @@ def _has_zero_dim(shape):
     return len(shape) >= 2 and (shape[-2] == 0 or shape[-1] == 0)
 
 
+@_counted_wrapper
 def svd(
     a: ArrayLike,
     full_matrices: bool = True,
@@ -88,8 +90,8 @@ def svd(
         if compute_uv:
             # When k is specified, always use economy decomposition then slice.
             fm = full_matrices if k is None else False
-            U, S, Vt = _np.linalg.svd(
-                _to_base_ndarray(a), full_matrices=fm, hermitian=hermitian
+            U, S, Vt = _call_numpy(
+                _np.linalg.svd, _to_base_ndarray(a), full_matrices=fm, hermitian=hermitian
             )
             if k is not None:
                 S = S[..., :k]
@@ -97,8 +99,8 @@ def svd(
                 Vt = Vt[..., :k, :]
             maybe_check_nan_inf(S, "linalg.svd")
         else:
-            S = _np.linalg.svd(
-                _to_base_ndarray(a), compute_uv=False, hermitian=hermitian
+            S = _call_numpy(
+                _np.linalg.svd, _to_base_ndarray(a), compute_uv=False, hermitian=hermitian
             )
             if k is not None:
                 S = S[..., :k]

--- a/src/flopscope/numpy/random/__init__.py
+++ b/src/flopscope/numpy/random/__init__.py
@@ -22,6 +22,7 @@ import numpy as _np
 import numpy.random as _npr
 from numpy.random import Generator, RandomState, SeedSequence
 
+from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._flops import _ceil_log2, sort_cost  # noqa: F401
 from flopscope._ndarray import FlopscopeArray
 from flopscope._perm_group import SymmetryGroup
@@ -48,6 +49,7 @@ def _output_size(*dims, size=None):
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def _counted_sampler(
     np_func: Callable[..., Any],
     op_name: str,
@@ -59,6 +61,7 @@ def _counted_sampler(
     as either a positional or keyword argument.
     """
 
+    @_counted_wrapper
     def wrapper(*args, **kwargs):
         budget = require_budget()
         result = np_func(*args, **kwargs)
@@ -84,12 +87,14 @@ def _counted_sampler(
     return wrapper
 
 
+@_counted_wrapper
 def _counted_dims_sampler(
     np_func: Callable[..., Any],
     op_name: str,
 ) -> Callable[..., Any]:
     """Factory for rand/randn that take *dims instead of size=."""
 
+    @_counted_wrapper
     def wrapper(*dims):
         budget = require_budget()
         n = int(_np.prod(dims)) if dims else 1
@@ -252,18 +257,20 @@ dirichlet = _counted_sampler(_npr.dirichlet, "random.dirichlet")
 randint = _counted_sampler(_npr.randint, "random.randint")
 
 
+@_counted_wrapper
 def _counted_size_only_sampler(
     np_func: Callable[..., Any],
     op_name: str,
 ) -> Callable[..., Any]:
     """Factory for samplers where the only arg is ``size`` (positional or kw)."""
 
+    @_counted_wrapper
     def wrapper(size=None):
         budget = require_budget()
         n = _output_size(size=size)
         cost = _builtins.max(n, 1)
         with budget.deduct(op_name, flop_cost=cost, subscripts=None, shapes=((n,),)):
-            result = np_func(size=size)
+            result = _call_numpy(np_func, size=size)
         return result
 
     wrapper.__name__ = op_name
@@ -289,6 +296,7 @@ sample = _counted_size_only_sampler(_npr.sample, "random.sample")
 # ---------------------------------------------------------------------------
 
 
+@_counted_wrapper
 def permutation(x):
     """Counted version of ``numpy.random.permutation``.
 
@@ -300,10 +308,11 @@ def permutation(x):
     with budget.deduct(
         "random.permutation", flop_cost=cost, subscripts=None, shapes=((n,),)
     ):
-        result = _npr.permutation(x)
+        result = _call_numpy(_npr.permutation, x)
     return result
 
 
+@_counted_wrapper
 def shuffle(x):
     """Counted version of ``numpy.random.shuffle``.
 
@@ -318,9 +327,10 @@ def shuffle(x):
     with budget.deduct(
         "random.shuffle", flop_cost=cost, subscripts=None, shapes=((n,),)
     ):
-        _npr.shuffle(x)
+        _call_numpy(_npr.shuffle, x)
 
 
+@_counted_wrapper
 def choice(a, size=None, replace=True, p=None):
     """Counted version of ``numpy.random.choice``.
 
@@ -339,13 +349,13 @@ def choice(a, size=None, replace=True, p=None):
         with budget.deduct(
             "random.choice", flop_cost=cost, subscripts=None, shapes=((out_size,),)
         ):
-            result = _npr.choice(a, size=size, replace=replace, p=p)
+            result = _call_numpy(_npr.choice, a, size=size, replace=replace, p=p)
     else:
         cost = sort_cost(n)
         with budget.deduct(
             "random.choice", flop_cost=cost, subscripts=None, shapes=((n,),)
         ):
-            result = _npr.choice(a, size=size, replace=replace, p=p)
+            result = _call_numpy(_npr.choice, a, size=size, replace=replace, p=p)
     # Preserve identity when picking a scalar from an object-dtype array:
     # numpy returns the exact object stored in the input, and user code
     # (e.g. `choice(object_array) is original_object`) relies on that.
@@ -361,6 +371,7 @@ def choice(a, size=None, replace=True, p=None):
     return result
 
 
+@_counted_wrapper
 def symmetric(
     shape: int | Sequence[int],
     symmetry: SymmetryGroup,
@@ -504,6 +515,7 @@ def symmetric(
         return symmetrize(sample, symmetry=symmetry)
 
 
+@_counted_wrapper
 def bytes(length):
     """Counted version of ``numpy.random.bytes``.
 
@@ -514,7 +526,7 @@ def bytes(length):
     with budget.deduct(
         "random.bytes", flop_cost=cost, subscripts=None, shapes=((length,),)
     ):
-        result = _npr.bytes(length)
+        result = _call_numpy(_npr.bytes, length)
     return result
 
 

--- a/src/flopscope/stats/_base.py
+++ b/src/flopscope/stats/_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as _np
 
+from flopscope._budget import _counted_wrapper
 from flopscope._ndarray import _asflopscope
 from flopscope._validation import require_budget
 
@@ -33,6 +34,7 @@ class ContinuousDistribution:
     def name(self) -> str:
         return self._name
 
+    @_counted_wrapper
     def _deduct_and_call(self, method: str, cost_per_elem: int, x, *args, **kwargs):
         """Deduct FLOPs then call the pure-numpy implementation.
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -598,3 +598,22 @@ def test_budget_context_flopscope_overhead_time_property():
 
     b._total_flopscope_overhead_time = 1.5
     assert b.flopscope_overhead_time == 1.5
+
+
+def test_timing_summary_subtracts_overhead():
+    from flopscope._budget import _timing_summary
+
+    wall, tracked, overhead, untracked = _timing_summary(10.0, 4.0, 3.0)
+    assert wall == 10.0
+    assert tracked == 4.0
+    assert overhead == 3.0
+    assert untracked == 3.0
+
+    wall, tracked, overhead, untracked = _timing_summary(None, 4.0, 3.0)
+    assert wall is None
+    assert tracked == 4.0
+    assert overhead == 3.0
+    assert untracked is None
+
+    wall, tracked, overhead, untracked = _timing_summary(10.0, 7.0, 3.0 + 1e-13)
+    assert untracked == 0.0

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -786,3 +786,189 @@ def test_factory_wrapper_tracked_time_is_numpy_only():
     # Generous bounds for noisy timing
     assert flopscope_tracked < pure_numpy_wall * 3.0
     assert flopscope_tracked > pure_numpy_wall * 0.3
+
+
+def test_decomposition_invariant_after_single_op():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        _ = flopscope.numpy.add(
+            flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
+        )
+    d = b.summary_dict()
+    total = (
+        d["tracked_time_s"]
+        + d["flopscope_overhead_time_s"]
+        + d["untracked_time_s"]
+    )
+    assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
+
+
+def test_decomposition_invariant_under_mixed_workload():
+    import time as _time
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        a = flopscope.numpy.ones((50, 50))
+        _ = flopscope.numpy.matmul(a, a)
+        _ = flopscope.numpy.linalg.inv(a + flopscope.numpy.eye(50))
+        _ = flopscope.numpy.fft.fft(flopscope.numpy.ones((128,)))
+        _ = flopscope.numpy.sort(flopscope.numpy.ones((100,)))
+        _time.sleep(0.005)  # genuinely untracked
+    d = b.summary_dict()
+    total = (
+        d["tracked_time_s"]
+        + d["flopscope_overhead_time_s"]
+        + d["untracked_time_s"]
+    )
+    assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
+    # The sleep should land in untracked, not overhead
+    assert d["untracked_time_s"] >= 0.004
+
+
+def test_per_op_overhead_recorded():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        _ = flopscope.numpy.add(
+            flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
+        )
+    op = b.op_log[-1]
+    assert op.flopscope_overhead is not None
+    assert op.flopscope_overhead >= 0
+
+
+def test_per_op_overhead_sums_to_global_no_namespace():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        for _ in range(5):
+            _ = flopscope.numpy.add(
+                flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
+            )
+    per_op_total = sum(
+        op.flopscope_overhead or 0.0 for op in b.op_log
+    )
+    # OpRecord.flopscope_overhead captures overhead attributed to each op that
+    # created an OpRecord.  Zero-FLOP ops (e.g. ones) still add to the global
+    # counter without creating an OpRecord, so per_op_total <= global overhead.
+    # We verify that the per-op sum is positive and does not exceed the global.
+    assert per_op_total > 0
+    assert per_op_total <= b.flopscope_overhead_time + 1e-9
+
+
+def test_per_namespace_overhead_breakdown():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        with flopscope.namespace("ns1"):
+            _ = flopscope.numpy.add(
+                flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
+            )
+        with flopscope.namespace("ns2"):
+            _ = flopscope.numpy.multiply(
+                flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
+            )
+    d = b.summary_dict(by_namespace=True)
+    assert d["by_namespace"]["ns1"]["flopscope_overhead_time_s"] > 0
+    assert d["by_namespace"]["ns2"]["flopscope_overhead_time_s"] > 0
+
+
+def test_overhead_recorded_on_budget_exhausted():
+    import flopscope
+    from flopscope.errors import BudgetExhaustedError
+
+    with flopscope.BudgetContext(flop_budget=10, quiet=True) as b:
+        with pytest.raises(BudgetExhaustedError):
+            _ = flopscope.numpy.matmul(
+                flopscope.numpy.ones((100, 100)),
+                flopscope.numpy.ones((100, 100)),
+            )
+    assert b.flopscope_overhead_time > 0
+
+
+def test_overhead_recorded_on_numpy_call_exception():
+    import numpy as np
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        # Singular matrix raises LinAlgError inside the numpy call
+        singular = flopscope.numpy.zeros((3, 3))
+        with pytest.raises(np.linalg.LinAlgError):
+            _ = flopscope.numpy.linalg.inv(singular)
+    # Decorator's try/finally captured the wrapper time
+    assert b.flopscope_overhead_time > 0
+
+
+def test_nested_wrapper_no_double_count():
+    """Calling a wrapped op transitively (e.g., einsum internally calling
+    np.tensordot through opt_einsum) does not double-count overhead."""
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        # einsum's _execute_pairwise dispatches to multiple inner ops
+        _ = flopscope.numpy.einsum(
+            "ij,jk,kl->il",
+            flopscope.numpy.ones((4, 4)),
+            flopscope.numpy.ones((4, 4)),
+            flopscope.numpy.ones((4, 4)),
+        )
+    d = b.summary_dict()
+    total = (
+        d["tracked_time_s"]
+        + d["flopscope_overhead_time_s"]
+        + d["untracked_time_s"]
+    )
+    assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
+
+
+def test_check_nan_inf_opt_in_attributes_to_overhead():
+    """Toggling check_nan_inf=True should grow flopscope overhead.
+
+    Each call pays an extra np.any(np.isnan | np.isinf) scan — pure overhead.
+    We measure the per-call overhead delta directly to avoid cross-run noise.
+    """
+    import flopscope
+
+    N_CALLS = 200
+    ARRAY_SIZE = 100_000  # large enough for np.any scan to be measurable
+
+    # Warmup to ensure modules are loaded before timing
+    for _ in range(3):
+        with flopscope.BudgetContext(flop_budget=int(1e15), quiet=True):
+            _ = flopscope.numpy.add(
+                flopscope.numpy.ones((ARRAY_SIZE,)),
+                flopscope.numpy.ones((ARRAY_SIZE,)),
+            )
+
+    flopscope.configure(check_nan_inf=False)
+    with flopscope.BudgetContext(flop_budget=int(1e15), quiet=True) as b_off:
+        for _ in range(N_CALLS):
+            _ = flopscope.numpy.add(
+                flopscope.numpy.ones((ARRAY_SIZE,)),
+                flopscope.numpy.ones((ARRAY_SIZE,)),
+            )
+
+    flopscope.configure(check_nan_inf=True)
+    try:
+        with flopscope.BudgetContext(flop_budget=int(1e15), quiet=True) as b_on:
+            for _ in range(N_CALLS):
+                _ = flopscope.numpy.add(
+                    flopscope.numpy.ones((ARRAY_SIZE,)),
+                    flopscope.numpy.ones((ARRAY_SIZE,)),
+                )
+    finally:
+        flopscope.configure(check_nan_inf=False)
+
+    overhead_off = b_off.flopscope_overhead_time
+    overhead_on = b_on.flopscope_overhead_time
+
+    # check_nan_inf=True must add measurable overhead. We verify per-call
+    # overhead grew by at least 5 µs per call (a very conservative lower bound
+    # for np.any on a 100k-element array) to tolerate timing noise.
+    per_call_delta = (overhead_on - overhead_off) / N_CALLS
+    assert per_call_delta > 5e-6, (
+        f"Expected per-call overhead to grow by >5µs with check_nan_inf=True; "
+        f"got {per_call_delta*1e6:.2f}µs "
+        f"(overhead_on={overhead_on:.4f}s, overhead_off={overhead_off:.4f}s)"
+    )

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -758,3 +758,30 @@ def test_per_namespace_summary_includes_flopscope_overhead():
     assert "flopscope_overhead_time_s" in d["by_namespace"]["ns"]
     assert d["by_namespace"][None]["flopscope_overhead_time_s"] >= 0
     assert d["by_namespace"]["ns"]["flopscope_overhead_time_s"] >= 0
+
+
+def test_factory_wrapper_tracked_time_is_numpy_only():
+    import time as _time
+    import numpy as np
+    import flopscope
+
+    plain_a = np.ones((10000,))
+    plain_b = np.ones((10000,))
+
+    # Pure numpy timing
+    t0 = _time.perf_counter()
+    for _ in range(1000):
+        np.add(plain_a, plain_b)
+    pure_numpy_wall = (_time.perf_counter() - t0) / 1000
+
+    # Flopscope timing
+    fnp_a = flopscope.numpy.asarray(plain_a)
+    fnp_b = flopscope.numpy.asarray(plain_b)
+    with flopscope.BudgetContext(flop_budget=int(1e15), quiet=True) as b:
+        for _ in range(1000):
+            flopscope.numpy.add(fnp_a, fnp_b)
+    flopscope_tracked = b.total_tracked_time / 1000
+
+    # Generous bounds for noisy timing
+    assert flopscope_tracked < pure_numpy_wall * 3.0
+    assert flopscope_tracked > pure_numpy_wall * 0.3

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -588,3 +588,13 @@ def test_budget_context_initializes_overhead_state():
     assert b._total_flopscope_overhead_time == 0.0
     assert b._recorded_overhead_time == 0.0
     assert b._current_op_timer is None
+
+
+def test_budget_context_flopscope_overhead_time_property():
+    import flopscope
+
+    b = flopscope.BudgetContext(flop_budget=int(1e9))
+    assert b.flopscope_overhead_time == 0.0
+
+    b._total_flopscope_overhead_time = 1.5
+    assert b.flopscope_overhead_time == 1.5

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -975,3 +975,32 @@ def test_check_nan_inf_opt_in_attributes_to_overhead():
         f"got {per_call_delta * 1e6:.2f}µs "
         f"(overhead_on={overhead_on:.4f}s, overhead_off={overhead_off:.4f}s)"
     )
+
+
+def test_untracked_time_property_agrees_with_summary_dict():
+    """Regression: BudgetContext.untracked_time property must match
+    summary_dict()['untracked_time_s']. Prior to the fix, the property
+    returned `wall - tracked` (pre-#76 semantics) while summary_dict
+    returned `wall - tracked - overhead` — the two disagreed by exactly
+    flopscope_overhead_time.
+    """
+    import flopscope
+    import flopscope.numpy as fnp
+
+    ctx = flopscope.BudgetContext(flop_budget=int(1e12), quiet=True)
+    with ctx:
+        # Generate enough wrapper overhead that the bug would be visible
+        a = fnp.eye(64)
+        for _ in range(20):
+            a = a @ a + a
+
+    prop_value = ctx.untracked_time
+    summary_value = ctx.summary_dict()["untracked_time_s"]
+    assert prop_value is not None
+    assert summary_value is not None
+    assert prop_value == pytest.approx(summary_value, abs=1e-9)
+    # Also verify both equal the documented identity.
+    expected = (
+        ctx.wall_time_s - ctx.total_tracked_time - ctx.flopscope_overhead_time  # type: ignore[operator]
+    )
+    assert prop_value == pytest.approx(max(expected, 0.0), abs=1e-9)

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -496,7 +496,10 @@ def test_budget_context_summary_dict_live_and_closed():
         assert live["wall_time_s"] is not None
         assert live["tracked_time_s"] >= 0.01
         assert live["untracked_time_s"] == pytest.approx(
-            live["wall_time_s"] - live["tracked_time_s"], abs=1e-6
+            live["wall_time_s"]
+            - live["tracked_time_s"]
+            - live["flopscope_overhead_time_s"],
+            abs=1e-6,
         )
         assert live["operations"]["add"]["calls"] == 1
         assert live["operations"]["add"]["duration"] >= 0.01
@@ -505,7 +508,10 @@ def test_budget_context_summary_dict_live_and_closed():
     assert closed["wall_time_s"] is not None
     assert closed["tracked_time_s"] >= 0.01
     assert closed["untracked_time_s"] == pytest.approx(
-        closed["wall_time_s"] - closed["tracked_time_s"], abs=1e-6
+        closed["wall_time_s"]
+        - closed["tracked_time_s"]
+        - closed["flopscope_overhead_time_s"],
+        abs=1e-6,
     )
 
 
@@ -524,7 +530,10 @@ def test_budget_summary_dict_shows_live_timing_for_active_context():
         assert live["wall_time_s"] >= 0.01
         assert live["tracked_time_s"] >= 0.0
         assert live["untracked_time_s"] == pytest.approx(
-            live["wall_time_s"] - live["tracked_time_s"], abs=1e-6
+            live["wall_time_s"]
+            - live["tracked_time_s"]
+            - live["flopscope_overhead_time_s"],
+            abs=1e-6,
         )
 
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -579,3 +579,12 @@ def test_oprecord_has_flopscope_overhead_field():
         flop_cost=3, cumulative=3, flopscope_overhead=0.001,
     )
     assert rec2.flopscope_overhead == 0.001
+
+
+def test_budget_context_initializes_overhead_state():
+    import flopscope
+
+    b = flopscope.BudgetContext(flop_budget=int(1e9))
+    assert b._total_flopscope_overhead_time == 0.0
+    assert b._recorded_overhead_time == 0.0
+    assert b._current_op_timer is None

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -670,7 +670,7 @@ def test_call_numpy_returns_fn_result_and_records_duration():
                 self._np_duration = 0.0
 
         fake = _FakeTimer()
-        b._current_op_timer = fake
+        b._current_op_timer = fake  # type: ignore[assignment]
         try:
             _call_numpy(_time.sleep, 0.01)
         finally:

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -580,14 +580,21 @@ def test_oprecord_has_flopscope_overhead_field():
     import flopscope
 
     rec = flopscope.OpRecord(
-        op_name="add", subscripts=None, shapes=((3,),),
-        flop_cost=3, cumulative=3,
+        op_name="add",
+        subscripts=None,
+        shapes=((3,),),
+        flop_cost=3,
+        cumulative=3,
     )
     assert rec.flopscope_overhead is None
 
     rec2 = flopscope.OpRecord(
-        op_name="add", subscripts=None, shapes=((3,),),
-        flop_cost=3, cumulative=3, flopscope_overhead=0.001,
+        op_name="add",
+        subscripts=None,
+        shapes=((3,),),
+        flop_cost=3,
+        cumulative=3,
+        flopscope_overhead=0.001,
     )
     assert rec2.flopscope_overhead == 0.001
 
@@ -661,6 +668,7 @@ def test_call_numpy_returns_fn_result_and_records_duration():
         class _FakeTimer:
             def __init__(self):
                 self._np_duration = 0.0
+
         fake = _FakeTimer()
         b._current_op_timer = fake
         try:
@@ -803,11 +811,7 @@ def test_decomposition_invariant_after_single_op():
             flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
         )
     d = b.summary_dict()
-    total = (
-        d["tracked_time_s"]
-        + d["flopscope_overhead_time_s"]
-        + d["untracked_time_s"]
-    )
+    total = d["tracked_time_s"] + d["flopscope_overhead_time_s"] + d["untracked_time_s"]
     assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
 
 
@@ -824,11 +828,7 @@ def test_decomposition_invariant_under_mixed_workload():
         _ = flopscope.numpy.sort(flopscope.numpy.ones((100,)))
         _time.sleep(0.005)  # genuinely untracked
     d = b.summary_dict()
-    total = (
-        d["tracked_time_s"]
-        + d["flopscope_overhead_time_s"]
-        + d["untracked_time_s"]
-    )
+    total = d["tracked_time_s"] + d["flopscope_overhead_time_s"] + d["untracked_time_s"]
     assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
     # The sleep should land in untracked, not overhead
     assert d["untracked_time_s"] >= 0.004
@@ -854,9 +854,7 @@ def test_per_op_overhead_sums_to_global_no_namespace():
             _ = flopscope.numpy.add(
                 flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
             )
-    per_op_total = sum(
-        op.flopscope_overhead or 0.0 for op in b.op_log
-    )
+    per_op_total = sum(op.flopscope_overhead or 0.0 for op in b.op_log)
     # OpRecord.flopscope_overhead captures overhead attributed to each op that
     # created an OpRecord.  Zero-FLOP ops (e.g. ones) still add to the global
     # counter without creating an OpRecord, so per_op_total <= global overhead.
@@ -923,11 +921,7 @@ def test_nested_wrapper_no_double_count():
             flopscope.numpy.ones((4, 4)),
         )
     d = b.summary_dict()
-    total = (
-        d["tracked_time_s"]
-        + d["flopscope_overhead_time_s"]
-        + d["untracked_time_s"]
-    )
+    total = d["tracked_time_s"] + d["flopscope_overhead_time_s"] + d["untracked_time_s"]
     assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
 
 
@@ -978,6 +972,6 @@ def test_check_nan_inf_opt_in_attributes_to_overhead():
     per_call_delta = (overhead_on - overhead_off) / N_CALLS
     assert per_call_delta > 5e-6, (
         f"Expected per-call overhead to grow by >5µs with check_nan_inf=True; "
-        f"got {per_call_delta*1e6:.2f}µs "
+        f"got {per_call_delta * 1e6:.2f}µs "
         f"(overhead_on={overhead_on:.4f}s, overhead_off={overhead_off:.4f}s)"
     )

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -563,3 +563,19 @@ def test_budget_context_summary_dict_by_namespace_uses_exact_op_namespace():
     assert data["by_namespace"]["predict..raw.precompute"]["flops_used"] == 25
     assert data["by_namespace"]["predict..raw.precompute"]["calls"] == 1
     assert "flop_budget" not in data["by_namespace"]["predict..raw.precompute"]
+
+
+def test_oprecord_has_flopscope_overhead_field():
+    import flopscope
+
+    rec = flopscope.OpRecord(
+        op_name="add", subscripts=None, shapes=((3,),),
+        flop_cost=3, cumulative=3,
+    )
+    assert rec.flopscope_overhead is None
+
+    rec2 = flopscope.OpRecord(
+        op_name="add", subscripts=None, shapes=((3,),),
+        flop_cost=3, cumulative=3, flopscope_overhead=0.001,
+    )
+    assert rec2.flopscope_overhead == 0.001

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -731,3 +731,14 @@ def test_deduct_self_charges_body_to_overhead_and_oprecord():
         # And the OpRecord should reflect it
         assert b.op_log[-1].flopscope_overhead is not None
         assert b.op_log[-1].flopscope_overhead > 0
+
+
+def test_namespace_scope_charges_push_pop_to_overhead():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        baseline = b.flopscope_overhead_time
+        with flopscope.namespace("ns"):
+            pass
+        # Push + pop are tiny but non-zero
+        assert b.flopscope_overhead_time > baseline

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -664,3 +664,35 @@ def test_call_numpy_returns_fn_result_and_records_duration():
         finally:
             b._current_op_timer = None
         assert fake._np_duration >= 0.01
+
+
+def test_counted_wrapper_records_overhead():
+    import time as _time
+    import flopscope
+    from flopscope._budget import _counted_wrapper
+
+    @_counted_wrapper
+    def fake_wrapper(x):
+        # Pure preamble (no deduct, no numpy) — all time is overhead
+        _time.sleep(0.01)
+        return x + 1
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        result = fake_wrapper(5)
+    assert result == 6
+    assert b.flopscope_overhead_time >= 0.01
+
+
+def test_counted_wrapper_handles_exceptions():
+    import flopscope
+    from flopscope._budget import _counted_wrapper
+
+    @_counted_wrapper
+    def boom():
+        raise ValueError("nope")
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        with pytest.raises(ValueError):
+            boom()
+    # Overhead recorded despite the exception
+    assert b.flopscope_overhead_time > 0

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -742,3 +742,19 @@ def test_namespace_scope_charges_push_pop_to_overhead():
             pass
         # Push + pop are tiny but non-zero
         assert b.flopscope_overhead_time > baseline
+
+
+def test_per_namespace_summary_includes_flopscope_overhead():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        with b.deduct("x", flop_cost=1, subscripts=None, shapes=()):
+            pass
+        with flopscope.namespace("ns"):
+            with b.deduct("y", flop_cost=1, subscripts=None, shapes=()):
+                pass
+    d = b.summary_dict(by_namespace=True)
+    assert "flopscope_overhead_time_s" in d["by_namespace"][None]
+    assert "flopscope_overhead_time_s" in d["by_namespace"]["ns"]
+    assert d["by_namespace"][None]["flopscope_overhead_time_s"] >= 0
+    assert d["by_namespace"]["ns"]["flopscope_overhead_time_s"] >= 0

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -717,3 +717,17 @@ def test_optimer_splits_block_into_tracked_and_overhead():
     # in-block overhead = block - tracked, includes the two 0.005 sleeps
     assert op.flopscope_overhead is not None
     assert op.flopscope_overhead >= 0.008
+
+
+def test_deduct_self_charges_body_to_overhead_and_oprecord():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        baseline = b.flopscope_overhead_time
+        # Call deduct directly without entering the timer
+        timer = b.deduct("x", flop_cost=1, subscripts=None, shapes=())
+        # The deduct body itself should have charged some overhead
+        assert b.flopscope_overhead_time > baseline
+        # And the OpRecord should reflect it
+        assert b.op_log[-1].flopscope_overhead is not None
+        assert b.op_log[-1].flopscope_overhead > 0

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -639,3 +639,28 @@ def test_summary_dict_includes_flopscope_overhead_time_s():
     assert "flopscope_overhead_time_s" in d
     assert d["flopscope_overhead_time_s"] is not None
     assert d["flopscope_overhead_time_s"] >= 0
+
+
+def test_call_numpy_returns_fn_result_and_records_duration():
+    import time as _time
+    import numpy as np
+    import flopscope
+    from flopscope._budget import _call_numpy
+
+    # Without an active timer, _call_numpy is a no-op timing-wise (just calls fn)
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        result = _call_numpy(np.add, np.ones((3,)), np.ones((3,)))
+        assert isinstance(result, np.ndarray)
+        assert result.tolist() == [2.0, 2.0, 2.0]
+
+        # With a fake "timer" object that has _np_duration, the duration is reported
+        class _FakeTimer:
+            def __init__(self):
+                self._np_duration = 0.0
+        fake = _FakeTimer()
+        b._current_op_timer = fake
+        try:
+            _call_numpy(_time.sleep, 0.01)
+        finally:
+            b._current_op_timer = None
+        assert fake._np_duration >= 0.01

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -484,6 +484,7 @@ def test_budget_summary_dict_includes_op_duration():
 
 def test_budget_context_summary_dict_live_and_closed():
     import time
+
     from flopscope._budget import _call_numpy
 
     budget = BudgetContext(flop_budget=100, quiet=True)
@@ -644,7 +645,9 @@ def test_summary_dict_includes_flopscope_overhead_time_s():
 
 def test_call_numpy_returns_fn_result_and_records_duration():
     import time as _time
+
     import numpy as np
+
     import flopscope
     from flopscope._budget import _call_numpy
 
@@ -669,6 +672,7 @@ def test_call_numpy_returns_fn_result_and_records_duration():
 
 def test_counted_wrapper_records_overhead():
     import time as _time
+
     import flopscope
     from flopscope._budget import _counted_wrapper
 
@@ -701,6 +705,7 @@ def test_counted_wrapper_handles_exceptions():
 
 def test_optimer_splits_block_into_tracked_and_overhead():
     import time as _time
+
     import flopscope
     from flopscope._budget import _call_numpy
 
@@ -763,7 +768,9 @@ def test_per_namespace_summary_includes_flopscope_overhead():
 
 def test_factory_wrapper_tracked_time_is_numpy_only():
     import time as _time
+
     import numpy as np
+
     import flopscope
 
     plain_a = np.ones((10000,))
@@ -806,6 +813,7 @@ def test_decomposition_invariant_after_single_op():
 
 def test_decomposition_invariant_under_mixed_workload():
     import time as _time
+
     import flopscope
 
     with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
@@ -889,6 +897,7 @@ def test_overhead_recorded_on_budget_exhausted():
 
 def test_overhead_recorded_on_numpy_call_exception():
     import numpy as np
+
     import flopscope
 
     with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -710,9 +710,10 @@ def test_optimer_splits_block_into_tracked_and_overhead():
             _call_numpy(_time.sleep, 0.01)  # tracked
             _time.sleep(0.005)  # more in-block overhead
     op = b.op_log[-1]
-    # tracked = ONLY the _call_numpy duration
+    # tracked = ONLY the _call_numpy duration. OS scheduling can oversleep
+    # significantly, so use a generous upper bound.
     assert op.duration is not None
-    assert 0.009 <= op.duration <= 0.020  # ~0.01 with timing slop
+    assert op.duration >= 0.009
     assert b.total_tracked_time == op.duration
     # in-block overhead = block - tracked, includes the two 0.005 sleeps
     assert op.flopscope_overhead is not None

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -617,3 +617,16 @@ def test_timing_summary_subtracts_overhead():
 
     wall, tracked, overhead, untracked = _timing_summary(10.0, 7.0, 3.0 + 1e-13)
     assert untracked == 0.0
+
+
+def test_summary_dict_includes_flopscope_overhead_time_s():
+    import flopscope
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        _ = flopscope.numpy.add(
+            flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
+        )
+    d = b.summary_dict()
+    assert "flopscope_overhead_time_s" in d
+    assert d["flopscope_overhead_time_s"] is not None
+    assert d["flopscope_overhead_time_s"] >= 0

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -484,11 +484,12 @@ def test_budget_summary_dict_includes_op_duration():
 
 def test_budget_context_summary_dict_live_and_closed():
     import time
+    from flopscope._budget import _call_numpy
 
     budget = BudgetContext(flop_budget=100, quiet=True)
     with budget:
         with budget.deduct("add", flop_cost=10, subscripts=None, shapes=()):
-            time.sleep(0.01)
+            _call_numpy(time.sleep, 0.01)  # tracked via _call_numpy
         live = budget.summary_dict()
         assert live["flop_budget"] == 100
         assert live["flops_used"] == 10
@@ -696,3 +697,23 @@ def test_counted_wrapper_handles_exceptions():
             boom()
     # Overhead recorded despite the exception
     assert b.flopscope_overhead_time > 0
+
+
+def test_optimer_splits_block_into_tracked_and_overhead():
+    import time as _time
+    import flopscope
+    from flopscope._budget import _call_numpy
+
+    with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
+        with b.deduct("x", flop_cost=1, subscripts=None, shapes=()):
+            _time.sleep(0.005)  # in-block overhead (no _call_numpy)
+            _call_numpy(_time.sleep, 0.01)  # tracked
+            _time.sleep(0.005)  # more in-block overhead
+    op = b.op_log[-1]
+    # tracked = ONLY the _call_numpy duration
+    assert op.duration is not None
+    assert 0.009 <= op.duration <= 0.020  # ~0.01 with timing slop
+    assert b.total_tracked_time == op.duration
+    # in-block overhead = block - tracked, includes the two 0.005 sleeps
+    assert op.flopscope_overhead is not None
+    assert op.flopscope_overhead >= 0.008

--- a/tests/test_overhead_coverage.py
+++ b/tests/test_overhead_coverage.py
@@ -71,6 +71,10 @@ _ALLOWED_CALLERS = {
     "_call_with_optional_out",
     "_call_with_optional_multi_out",
     "_execute_pairwise",
+    # Pure-Python context managers / non-compute helpers — allowed inside
+    # `with budget.deduct(...):` blocks because they don't represent the
+    # numpy compute being timed:
+    "errstate",  # numpy.errstate() — fp-error context manager
 }
 
 

--- a/tests/test_overhead_coverage.py
+++ b/tests/test_overhead_coverage.py
@@ -1,0 +1,129 @@
+"""AST-walk lint tests enforcing flopscope_overhead instrumentation coverage.
+
+Two tests:
+  - test_every_wrapper_with_budget_deduct_is_decorated: every function whose
+    body calls budget.deduct(...) must carry @_counted_wrapper.
+  - test_every_direct_numpy_call_in_wrapper_uses_call_numpy: every direct
+    np.X(...) (or _np.X(...) etc.) call inside a `with budget.deduct(...):`
+    block must go through _call_numpy(np_fn, ...).
+
+Both tests fail initially. They will pass after Tasks 17-31 of the
+flopscope_overhead migration plan land.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "flopscope"
+
+
+def _functions_with_budget_deduct(path: Path) -> list[ast.FunctionDef]:
+    """Return every FunctionDef in `path` whose body contains a call to
+    ``budget.deduct(...)`` (any name, but resolves to a `deduct` attr call)."""
+    tree = ast.parse(path.read_text())
+    out: list[ast.FunctionDef] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == "deduct"
+            ):
+                out.append(node)
+                break
+    return out
+
+
+def _has_counted_wrapper_decorator(fn: ast.FunctionDef) -> bool:
+    for dec in fn.decorator_list:
+        if isinstance(dec, ast.Name) and dec.id == "_counted_wrapper":
+            return True
+        if isinstance(dec, ast.Attribute) and dec.attr == "_counted_wrapper":
+            return True
+    return False
+
+
+def test_every_wrapper_with_budget_deduct_is_decorated():
+    """Every function whose body calls budget.deduct(...) must carry
+    @_counted_wrapper. Exceptions: BudgetContext.deduct itself, _call_numpy."""
+    missing: list[str] = []
+    for path in SRC_ROOT.rglob("*.py"):
+        if path.name.startswith("test_"):
+            continue
+        for fn in _functions_with_budget_deduct(path):
+            if fn.name in ("deduct", "_call_numpy"):
+                continue
+            if not _has_counted_wrapper_decorator(fn):
+                rel = path.relative_to(SRC_ROOT.parent.parent)
+                missing.append(f"{rel}:{fn.lineno} {fn.name}")
+    assert not missing, (
+        "Wrappers calling budget.deduct(...) without @_counted_wrapper:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+_NUMPY_MODULE_NAMES = {"_np", "np", "_npr"}
+_ALLOWED_CALLERS = {
+    "_call_numpy",
+    "_call_with_optional_out",
+    "_call_with_optional_multi_out",
+    "_execute_pairwise",
+}
+
+
+def _direct_numpy_calls_inside_with_deduct(path: Path) -> list[tuple[int, str]]:
+    """Find ``_np.X(...)`` style calls inside ``with budget.deduct(...):`` blocks
+    that aren't routed through ``_call_numpy``. Returns [(lineno, func_repr)]."""
+    tree = ast.parse(path.read_text())
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        # Is at least one of the with-items a budget.deduct(...) call?
+        is_deduct_block = any(
+            isinstance(item.context_expr, ast.Call)
+            and isinstance(item.context_expr.func, ast.Attribute)
+            and item.context_expr.func.attr == "deduct"
+            for item in node.items
+        )
+        if not is_deduct_block:
+            continue
+        # Walk the body, find Call nodes whose func resolves to a numpy module.
+        body_module = ast.Module(body=node.body, type_ignores=[])
+        for sub in ast.walk(body_module):
+            if not isinstance(sub, ast.Call):
+                continue
+            f = sub.func
+            # Allow the listed helpers.
+            if isinstance(f, ast.Name) and f.id in _ALLOWED_CALLERS:
+                continue
+            if isinstance(f, ast.Attribute) and f.attr in _ALLOWED_CALLERS:
+                continue
+            # Walk the attribute chain to find the leftmost Name; flag if it's
+            # a numpy-module alias.
+            root = f
+            while isinstance(root, ast.Attribute):
+                root = root.value
+            if isinstance(root, ast.Name) and root.id in _NUMPY_MODULE_NAMES:
+                out.append((sub.lineno, ast.unparse(f)))
+    return out
+
+
+def test_every_direct_numpy_call_in_wrapper_uses_call_numpy():
+    """Every numpy invocation inside `with budget.deduct(...):` must go through
+    `_call_numpy(np_fn, ...)` so its wall time is correctly attributed to
+    tracked_time. Direct `_np.X(...)` is rejected."""
+    bad: list[str] = []
+    for path in SRC_ROOT.rglob("*.py"):
+        if path.name.startswith("test_"):
+            continue
+        for lineno, repr_ in _direct_numpy_calls_inside_with_deduct(path):
+            rel = path.relative_to(SRC_ROOT.parent.parent)
+            bad.append(f"{rel}:{lineno}  {repr_}(...)")
+    assert not bad, (
+        "Direct numpy calls inside `with budget.deduct(...):` not using "
+        "_call_numpy:\n  " + "\n  ".join(bad)
+    )

--- a/tests/test_overhead_coverage.py
+++ b/tests/test_overhead_coverage.py
@@ -10,6 +10,7 @@ Two tests:
 Both tests fail initially. They will pass after Tasks 17-31 of the
 flopscope_overhead migration plan land.
 """
+
 from __future__ import annotations
 
 import ast

--- a/website/content/docs/getting-started/competition.mdx
+++ b/website/content/docs/getting-started/competition.mdx
@@ -119,7 +119,7 @@ Key things to look for:
 - **Budget / Used / Remaining:** the top rows show the explicit competition budget, current spend, and remaining headroom
 - **By namespace:** `solver` is the root prefix, and nested scopes show up as dotted paths like `solver.precompute`. Use `budget.summary(by_namespace=True)` for the current context or `flops.budget_summary(by_namespace=True)` for the accumulated session/global view
 - **By operation:** this toy pass is dominated by the single `einsum`; `exp` and `sum` are tiny by comparison
-- **Wall / tracked / untracked time:** wall time is total elapsed time for the context, tracked time is time spent inside counted NumPy calls, and untracked time is everything else in the context (`wall_time - tracked_time`)
+- **Wall / tracked / flopscope overhead / untracked time:** wall time is total elapsed time for the context. Tracked time is time spent inside the inner NumPy calls being counted. Flopscope overhead is time spent in flopscope's own dispatch code (wrapper preambles, FLOP cost computation, view-casts, post-call wrapping, `maybe_check_nan_inf` when opted in). Untracked time is genuinely everything else (user Python between ops, sleeps, GC pauses). The decomposition is exact: `wall_time = tracked_time + flopscope_overhead_time + untracked_time`
 - **Flat default:** the default summary stays flat unless you opt into `by_namespace=True`
 
 For programmatic access, use `flops.budget_summary_dict()`:

--- a/website/content/docs/guides/budget-planning.mdx
+++ b/website/content/docs/guides/budget-planning.mdx
@@ -126,11 +126,14 @@ print(budget.summary())
 ```
 
 When the time limit is exceeded, Flopscope raises `TimeExhaustedError` at the next
-operation boundary. The summary exposes three timing views:
+operation boundary. The summary exposes four timing views that decompose wall time exactly:
 
 - `wall_time_s`: total elapsed time for the context
-- `tracked_time_s`: time spent inside counted NumPy calls
-- `untracked_time_s`: everything else in the context (`wall_time_s - tracked_time_s`)
+- `tracked_time_s`: time spent inside the inner NumPy calls being counted
+- `flopscope_overhead_time_s`: time spent in flopscope's own dispatch code (wrapper preambles, FLOP cost computation, view-casts, post-call wrapping, `maybe_check_nan_inf` when opted in via `flopscope.configure(check_nan_inf=True)`)
+- `untracked_time_s`: genuinely everything else (user Python between ops, `time.sleep`, GC pauses, un-instrumented numpy)
+
+The identity `wall_time_s = tracked_time_s + flopscope_overhead_time_s + untracked_time_s` holds within numerical tolerance.
 
 Use `budget.summary()` when you want the current context's timings, and
 `flops.budget_summary()` when you want the accumulated session/global view.


### PR DESCRIPTION
# Track flopscope's own dispatch overhead as a separate `BudgetContext` field

Closes #76.

## Summary

`BudgetContext` previously exposed two timing fields, `tracked_time` and `untracked_time`. Empirically, ~95% of `untracked_time` was flopscope's own dispatch code (wrapper preambles, `deduct()` body, `_OpTimer` bookkeeping, postambles, view-casts), invisible to downstream consumers like whestbench that penalize `untracked_time` as a participant-overhead proxy.

This PR adds a third, **measured** bucket — `flopscope_overhead_time_s` — and tightens `tracked_time_s` to reflect ONLY the inner numpy call wall time. The new identity is:

```
wall_time_s = tracked_time_s            (inner numpy call wall time)
            + flopscope_overhead_time_s (NEW — every flopscope frame)
            + untracked_time_s          (redefined — genuinely "neither")
```

The user-visible promise: if you write the same code in plain numpy, `tracked_time_s` should broadly match the numpy wall time.

## Empirical results (cov-prop estimator, width=256, depth=8, N=60)

| Bucket | Time | % of wall |
|---|---:|---:|
| Wall | 233 ms | 100% |
| Tracked (inner numpy compute) | 151 ms | 64.9% |
| Flopscope overhead (NEW) | 45 ms | 19.2% |
| Untracked (genuinely user Python) | 37 ms | 15.9% |

Decomposition invariant holds **exactly** (residual: 0.0 µs). Tracked-vs-pure-numpy parity check on a small-matmul workload: `tracked / pure_numpy_wall = 1.245` (within the 0.3–3.0 acceptance bound).

## API additions

**`BudgetContext`**:
- `flopscope_overhead_time` property — measured wall-clock seconds spent inside flopscope's own dispatch code.
- `summary_dict()["flopscope_overhead_time_s"]` — top-level bucket.
- `summary_dict(by_namespace=True)["by_namespace"][ns]["flopscope_overhead_time_s"]` — per-namespace bucket.

**`OpRecord`**:
- `flopscope_overhead: float | None` — per-op overhead in seconds.

## Breaking changes (documented in `CHANGELOG.md`)

1. **`untracked_time` redefined**: was `wall - tracked`, now `wall - tracked - flopscope_overhead`. Consumers who want the old "all unattributed" value can compute `flopscope_overhead_time + untracked_time`.
2. **`tracked_time` semantics tightened**: now reflects only the inner numpy call wall time. View-casts, copyto fallbacks, and dispatch logic inside the `with budget.deduct(...):` block are now attributed to `flopscope_overhead_time` instead of `tracked_time`. Existing consumers should see `tracked_time` decrease slightly and `flopscope_overhead_time` pick up the difference.
3. **`flopscope.configure(check_nan_inf=True)`** — opt-in scan time is now attributed to `flopscope_overhead_time` instead of `untracked_time`.

The only known external consumer is whestbench (via `flopscope-server/_session.py`), which treats `untracked_time` as a penalty proxy — the new semantics are strictly better for that use case (framework cost is no longer charged to participants).

## Implementation

Three coordinated mechanisms in `src/flopscope/_budget.py`:

**1. `_call_numpy(fn, *args, **kwargs)` helper.** Times only the inner numpy invocation and reports duration to the active `_OpTimer` via `budget._current_op_timer`. All numpy calls inside counted-op wrappers MUST go through this helper.

**2. `_OpTimer` reformulated.** The block-duration is split into:
- `_np_duration` (sum of `_call_numpy` reports) → `tracked_time`
- `block_duration - _np_duration` (view-casts, copyto, dispatch) → `flopscope_overhead_time`

`_OpTimer` no longer adds block-duration to `tracked_time` directly.

**3. `@_counted_wrapper` decorator.** Brackets each wrapper and bills its non-numpy non-nested time to `flopscope_overhead_time` using:
```
wrapper_own_overhead = wall - tracked_delta - overhead_delta
```
The `overhead_delta` term handles nested wrapper calls naturally (no re-entrancy guard needed), and per-op attribution distributes equally across ops created in the wrapper.

Additionally:
- `BudgetContext.deduct()` self-charges its body time (FLOP arithmetic, OpRecord append, deadline check) to both the global counter and the OpRecord, including exception paths.
- `_NamespaceScope.__enter__/__exit__` charge push/pop time to the global counter.
- `_call_with_optional_out` and `_call_with_optional_multi_out` route inner numpy calls through `_call_numpy`.

## Migration

214 wrappers across 18 files received the `@_counted_wrapper` decorator and (where the wrapper called numpy directly) the `_call_numpy(np_fn, ...)` substitution:

| Module | Wrappers |
|---|---:|
| `_pointwise.py` | 33 (10 factories + 23 custom) |
| `_einsum.py` | 2 |
| `_free_ops.py` | 68 |
| `_counting_ops.py` | 12 |
| `_sorting_ops.py` | 17 |
| `_window.py` | 5 |
| `_polynomial.py` | 10 |
| `_unwrap.py` | 1 |
| `numpy/linalg/*` | 25 (across 6 files) |
| `numpy/fft/_transforms.py` | 14 |
| `numpy/random/__init__.py` | 8 |
| `stats/_base.py` | 1 |

Internal helpers (`_call_with_optional_out`, `_call_with_optional_multi_out`) auto-cover their callers — factory wrappers don't need per-site `_call_numpy` substitution.

## Tests

- **Lint coverage** (`tests/test_overhead_coverage.py`): two AST-walk tests enforce that every wrapper calling `budget.deduct(...)` has `@_counted_wrapper`, and every direct numpy call inside a `with budget.deduct(...):` block goes through `_call_numpy` (`_np.errstate` allowlisted as a context manager). Both pass.
- **Decomposition invariant** (`test_decomposition_invariant_after_single_op`, `test_decomposition_invariant_under_mixed_workload`): `wall ≈ tracked + overhead + untracked` to within 1e-6.
- **Per-op + per-namespace**: `OpRecord.flopscope_overhead` populated, summed per-namespace bucket, sums to global counter (within zero-FLOP-op caveat).
- **Exception paths**: overhead recorded on `BudgetExhaustedError` (raised inside `deduct()`) and on numpy-side `LinAlgError` (raised inside `_call_numpy`).
- **Nested wrapper**: einsum's pairwise contraction (which dispatches to multiple inner numpy ops) doesn't double-count overhead.
- **`check_nan_inf` opt-in**: toggling on increases overhead, leaves tracked roughly unchanged.
- **Tracked-vs-pure-numpy parity** (`test_factory_wrapper_tracked_time_is_numpy_only`): `tracked` within 0.3×–3.0× of pure numpy wall on a 1000-call `np.add` workload.

Full suite: 3182 tests pass. The 4 errors in `test_stats_*` are pre-existing missing-scipy import errors, unrelated.

## Typing

The new `_call_numpy` helper is untyped, matching the existing `_call_with_optional_out` convention. No impact on the 22 documented whestbench-side pyright errors from PR #78's stub-tightening cleanup. Internal helpers in `flopscope/` use untyped dispatch; public type contracts are preserved by explicit annotations on wrapper signatures and `_asflopscope` return casts.

## Display

`flopscope.summary()` now includes a "Flopscope overhead" row in both plain-text and Rich renderings, between "Tracked time" and "Untracked time":

```
  Wall time:           0.031s
  Tracked time:        0.000s  (0.0%)
  Flopscope overhead:  0.021s  (67.7%)
  Untracked time:      0.010s  (32.3%)
```

## Out of scope (deferred)

- **Eliminating `_OpTimer` allocation per op** (issue #76 Section 3, optional bullet #2): folding `deduct`'s body into `_OpTimer.__enter__` to avoid the per-op allocation. Independent optimization, separate PR.
- **Counting-only mode** (issue #22): orthogonal — that issue lets users opt *out* of overhead; this one lets them *measure* it.
- **Einsum cache short-circuits** (issue #26): once landed, will reduce the largest single contributor to `flopscope_overhead_time` (the `einsum_cost` → `contract_path` planning cost). The new field will continue to measure it correctly.

## Test plan

- [x] Full test suite passes (3182 tests, modulo 4 pre-existing scipy import errors and 1 known-flaky thread test under xdist parallelism).
- [x] Lint coverage tests pass — every wrapper instrumented.
- [x] Decomposition invariant holds exactly (0.0 µs residual on cov-prop benchmark).
- [x] CHANGELOG entry.
- [x] Smoke-test display output.
- [ ] Verify whestbench (`flopscope-server`) integration still works after re-pin (downstream task).