### PR TITLE
Bracket BudgetContext lifecycle and harden namespace scope (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
   casts, copyto fallbacks, dispatch logic) is now attributed to
   `flopscope_overhead_time`.
 
+- `BudgetContext.wall_time_s` now spans `__init__` start through the end of
+  `__exit__` (was `__enter__` start through start of `__exit__` body). For an
+  empty `with BudgetContext(): pass` the value grows by ~3 µs (was ~0.4 µs,
+  now ~2.7 µs); real workloads see noise-level changes. The pre-`__enter__`
+  slice (`__init__` body + banner print) and the post-`__exit__` body slice
+  (accumulator-record, active-budget restore) are now attributed to
+  `flopscope_overhead_time` rather than falling out of any bucket. Issue #82.
+
 ### Added
 
 - `BudgetContext.flopscope_overhead_time` property — measured wall-clock time
@@ -28,3 +36,7 @@
 
 - `flopscope.configure(check_nan_inf=True)` — opt-in scan time is now attributed
   to `flopscope_overhead_time` instead of `untracked_time`.
+
+- `_NamespaceScope.__enter__/__exit__` brackets now use `try/finally` so that
+  push/pop time is billed to `flopscope_overhead_time` even when the underlying
+  `_push_namespace`/`_pop_namespace` raises. Issue #82.

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -196,16 +196,20 @@ class _NamespaceScope:
         self._segment = segment
 
     def __enter__(self) -> BudgetContext:
-        t0 = time.perf_counter()
-        self._budget._push_namespace(self._segment)
-        self._budget._total_flopscope_overhead_time += time.perf_counter() - t0
-        return self._budget
+        fs_t0 = time.perf_counter()
+        try:
+            self._budget._push_namespace(self._segment)
+            return self._budget
+        finally:
+            self._budget._total_flopscope_overhead_time += time.perf_counter() - fs_t0
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
-        t0 = time.perf_counter()
-        self._budget._pop_namespace(self._segment)
-        self._budget._total_flopscope_overhead_time += time.perf_counter() - t0
-        return False
+        fs_t0 = time.perf_counter()
+        try:
+            self._budget._pop_namespace(self._segment)
+            return False
+        finally:
+            self._budget._total_flopscope_overhead_time += time.perf_counter() - fs_t0
 
 
 def _validate_namespace_segment(name: str) -> str:
@@ -361,6 +365,11 @@ class BudgetContext:
         namespace: str | None = None,
         wall_time_limit_s: float | None = None,
     ):
+        # Capture creation time as the very first thing so any work done in
+        # __init__ (validation, list/dict allocation) is included in the
+        # eventual wall_time_s span, billed to flopscope_overhead_time. See
+        # issue #82.
+        self._creation_time = time.perf_counter()
         if flop_budget <= 0:
             raise ValueError(f"flop_budget must be > 0, got {flop_budget}")
         self._flop_budget = flop_budget
@@ -377,6 +386,7 @@ class BudgetContext:
         self._wall_time_s: float | None = None
         self._total_tracked_time: float = 0.0
         self._total_flopscope_overhead_time: float = 0.0
+        self._pre_enter_overhead: float = 0.0
         self._current_op_timer: _OpTimer | None = None
         self._recorded_flops_used = 0
         self._recorded_op_count = 0
@@ -420,6 +430,18 @@ class BudgetContext:
 
     @property
     def wall_time_s(self) -> float | None:
+        """Total wall-clock seconds spanned by the context.
+
+        Measured from ``__init__`` start to the end of ``__exit__`` (after the
+        accumulator-record and active-budget restoration work). ``None`` until
+        ``__exit__`` has run.
+
+        The decomposition ``wall_time_s == tracked_time + flopscope_overhead_time
+        + untracked_time`` holds within numerical tolerance. The pre-``__enter__``
+        slice (``__init__`` body + banner print) and the post-``__exit__`` body
+        slice (accumulator-record, active-budget restore) are both attributed
+        to ``flopscope_overhead_time``.
+        """
         return self._wall_time_s
 
     @property
@@ -629,11 +651,8 @@ class BudgetContext:
             raise RuntimeError("Cannot nest BudgetContexts")
         self._previous_budget = current  # save (may be global default or None)
         _thread_local.active_budget = self
-        self._start_time = time.perf_counter()
         self._wall_time_s = None
         self._deadline = None
-        if self._wall_time_limit_s is not None:
-            self._deadline = self._start_time + self._wall_time_limit_s
         if not self._quiet:
             import sys
 
@@ -647,13 +666,32 @@ class BudgetContext:
             if self._wall_time_limit_s is not None:
                 banner += f" | time limit: {self._wall_time_limit_s:.1f}s"
             print(banner, file=sys.stderr)
+        # Mark wall start AFTER all enter setup (including the banner print).
+        # The slice from _creation_time → _start_time is pre-enter overhead;
+        # __exit__ adds it to flopscope_overhead_time. See issue #82.
+        self._start_time = time.perf_counter()
+        self._pre_enter_overhead = self._start_time - self._creation_time
+        if self._wall_time_limit_s is not None:
+            self._deadline = self._start_time + self._wall_time_limit_s
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        # body_end snapshots the user-code window (start_time → here). Then
+        # we do the post-exit accumulator work and snapshot post_exit_end.
+        # wall_time_s spans creation → post_exit_end, and the pre-enter +
+        # post-exit slices are billed to flopscope_overhead_time. See #82.
+        body_end = time.perf_counter()
         if self._start_time is not None:
-            self._wall_time_s = time.perf_counter() - self._start_time
-        _accumulator.record(self)
-        _thread_local.active_budget = self._previous_budget  # restore previous
+            _accumulator.record(self)
+            _thread_local.active_budget = self._previous_budget
+            post_exit_end = time.perf_counter()
+            self._wall_time_s = post_exit_end - self._creation_time
+            self._total_flopscope_overhead_time += self._pre_enter_overhead + (
+                post_exit_end - body_end
+            )
+        else:
+            # Defensive: __exit__ called without __enter__.
+            _thread_local.active_budget = self._previous_budget
         return None
 
     def __call__(self, func):

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1004,3 +1004,98 @@ def test_untracked_time_property_agrees_with_summary_dict():
         ctx.wall_time_s - ctx.total_tracked_time - ctx.flopscope_overhead_time  # type: ignore[operator]
     )
     assert prop_value == pytest.approx(max(expected, 0.0), abs=1e-9)
+
+
+def test_budget_context_init_and_exit_billed_as_overhead():
+    """Empty BudgetContext: pre-enter and post-exit work are flopscope_overhead,
+    not untracked. The Python ``with`` protocol itself adds ~1-2 µs of strictly-
+    user-controlled time between ``__enter__`` returning and ``__exit__`` being
+    called; that legitimately lands in untracked. The bulk should be overhead.
+    Issue #82.
+    """
+    import flopscope as flops
+
+    ctx = flops.BudgetContext(flop_budget=int(1e12), quiet=True)
+    with ctx:
+        pass
+
+    assert ctx.wall_time_s is not None
+    assert ctx.wall_time_s > 0
+    assert ctx.total_tracked_time == 0.0
+    # Most of the wall should be overhead. Allow a few µs of untracked for the
+    # Python ``with`` protocol's enter→exit gap.
+    assert ctx.flopscope_overhead_time > 0
+    assert ctx.flopscope_overhead_time >= ctx.untracked_time, (  # type: ignore[operator]
+        f"overhead ({ctx.flopscope_overhead_time}) "
+        f"should dominate untracked ({ctx.untracked_time})"
+    )
+    assert ctx.untracked_time < 5e-6, (  # type: ignore[operator]
+        f"empty BudgetContext leaked >5µs into untracked: {ctx.untracked_time}"
+    )
+    # Decomposition invariant.
+    assert (
+        abs(
+            ctx.wall_time_s
+            - ctx.total_tracked_time
+            - ctx.flopscope_overhead_time
+            - ctx.untracked_time  # type: ignore[operator]
+        )
+        < 1e-9
+    )
+
+
+def test_namespace_scope_billed_as_overhead_amplified():
+    """1000 namespace enter/exit pairs add measurable overhead, not untracked.
+    Issue #82.
+    """
+    import flopscope as flops
+
+    ctx = flops.BudgetContext(flop_budget=int(1e12), quiet=True)
+    with ctx:
+        overhead_before = ctx.flopscope_overhead_time
+        for _ in range(1000):
+            with flops.namespace("foo"):
+                pass
+        overhead_after = ctx.flopscope_overhead_time
+
+    delta = overhead_after - overhead_before
+    # 1000 pairs × O(100ns) each → at least 100 μs of overhead growth.
+    assert delta > 1e-4, f"namespace overhead not billed: delta={delta}"
+    # Decomposition invariant still holds after exit.
+    assert (
+        abs(
+            ctx.wall_time_s  # type: ignore[operator]
+            - ctx.total_tracked_time
+            - ctx.flopscope_overhead_time
+            - ctx.untracked_time  # type: ignore[operator]
+        )
+        < 1e-9
+    )
+
+
+def test_namespace_scope_exit_exception_still_charges_overhead(monkeypatch):
+    """If _pop_namespace raises, the __exit__ try/finally still bills overhead.
+    Issue #82.
+    """
+    import flopscope as flops
+
+    ctx = flops.BudgetContext(flop_budget=int(1e12), quiet=True)
+    original = type(ctx)._pop_namespace
+    raised = {"flag": False}
+
+    def boom(self, expected):
+        raised["flag"] = True
+        raise RuntimeError("synthetic pop failure")
+
+    with ctx:
+        overhead_before = ctx.flopscope_overhead_time
+        monkeypatch.setattr(type(ctx), "_pop_namespace", boom)
+        with pytest.raises(RuntimeError, match="synthetic pop failure"):
+            with flops.namespace("foo"):
+                pass
+        # Restore so the outer with-block exits cleanly. Manually pop the
+        # orphaned "foo" so the namespace stack is consistent.
+        monkeypatch.setattr(type(ctx), "_pop_namespace", original)
+        ctx._namespace_stack.pop()
+    assert raised["flag"]
+    assert ctx.flopscope_overhead_time > overhead_before


### PR DESCRIPTION
# Bracket BudgetContext lifecycle and harden namespace scope for `flopscope_overhead_time`

Closes #82. Follow-up to #80 (which closed #76).

## Summary

PR #80 introduced `flopscope_overhead_time` and decorated every counted-op wrapper with `@_counted_wrapper`. Two paths still leaked time outside the new bucket:

1. `BudgetContext` lifecycle — `__init__` body ran *before* `_start_time` was captured, and the post-`_wall_time_s` portion of `__exit__` ran *after* the wall snapshot. Neither was in any bucket.
2. `_NamespaceScope.__enter__/__exit__` — already bracketed in #80, but only on the success path. If `_push_namespace`/`_pop_namespace` raised, the bracket time was lost.

This PR closes both leaks.

## Empirical results

Average over 1000 empty `with BudgetContext(): pass` calls:

| Bucket | Time (µs) | % of wall |
|---|---:|---:|
| Wall | 4.45 | 100% |
| Tracked | 0.00 | 0% (no ops) |
| Flopscope overhead | **4.22** | **95%** |
| Untracked | 0.23 | 5% |

Decomposition residual: **0.0000 µs**. The 5% untracked is the Python `with`-statement protocol gap between `__enter__` returning and `__exit__` being called — strictly user-controlled and correctly classified.

Before this PR, the same workload reported `wall_time_s ≈ 0.4 µs` (only the inner enter→exit window) with the rest of the lifecycle invisible to any bucket.

## Implementation

### Fix 1 — `BudgetContext` lifecycle ([_budget.py:356-392](src/flopscope/_budget.py:356), [_budget.py:632-690](src/flopscope/_budget.py:632))

- `__init__`: capture `self._creation_time = time.perf_counter()` as the first statement, before any other work. Initialize `self._pre_enter_overhead = 0.0`.
- `__enter__`: reorder so the banner print happens *before* `_start_time` is captured. Compute `_pre_enter_overhead = _start_time - _creation_time` — this slice (init body + banner) becomes flopscope overhead.
- `__exit__`: capture `body_end` snapshot at entry, do the existing post-exit work (accumulator-record, active-budget restore), then capture `post_exit_end`. Redefine `_wall_time_s = post_exit_end - _creation_time`. Add `_pre_enter_overhead + (post_exit_end - body_end)` to `_total_flopscope_overhead_time`.

The decomposition `wall = tracked + overhead + untracked` continues to hold. The only behavioral change visible to consumers is that `wall_time_s` grows by ~3 µs per context — below measurement noise for any real workload.

### Fix 2 — `_NamespaceScope` exception robustness ([_budget.py:198-216](src/flopscope/_budget.py:198))

The existing brackets work for the success path. Wrapping with `try/finally` ensures the time is billed even when `_push_namespace`/`_pop_namespace` raises (e.g., the `RuntimeError` from a corrupted namespace stack).

## Tests

Three new tests in [tests/test_budget.py](tests/test_budget.py):

- `test_budget_context_init_and_exit_billed_as_overhead` — empty context: most of `wall_time_s` lands in `flopscope_overhead_time`, untracked < 5 µs (the Python with-protocol gap).
- `test_namespace_scope_billed_as_overhead_amplified` — 1000 namespace enter/exit pairs add measurable overhead growth (>100 µs).
- `test_namespace_scope_exit_exception_still_charges_overhead` — monkeypatches `_pop_namespace` to raise, verifies the `try/finally` still bills the bracket.

Existing tests (decomposition invariant, per-op, per-namespace, etc.) continue to pass with no changes.

## Documentation

- New docstring on `BudgetContext.wall_time_s` describing the lifecycle span.
- CHANGELOG `## Unreleased` extended with two entries: BREAKING (`wall_time_s` semantic change) and Changed (`_NamespaceScope` try/finally).

## Out of scope

`summary_dict()` reads (~0.69 µs) and property reads (~0.07 µs) noted in issue #82 are consumer-side, after `__exit__` has run — they cannot be retroactively billed to `flopscope_overhead_time`. Issue #82 acknowledges this; skipped here.

## Test plan

- [x] `uv run pytest tests/test_budget.py tests/test_overhead_coverage.py tests/test_budget_accumulator.py` — 79 passed.
- [x] `uv run pytest --doctest-modules src/flopscope/_budget.py` — 5 passed.
- [x] Decomposition invariant residual = 0.0000 µs on 1000-context empirical run.
- [x] Pre-push hooks pass (lint, typecheck, test, website docs build).