### PR TITLE
fix(docs): correct broken op-page links in random guide

### DIFF
--- a/website/content/docs/guides/random.mdx
+++ b/website/content/docs/guides/random.mdx
@@ -202,7 +202,9 @@ The pattern works because `rng.uniform(...)` and `fnp.stats.norm.ppf(...)` are b
 
 ## Related
 
-- [`fnp.random.default_rng`](/docs/api/ops/random.default_rng/) — canonical entry point
-- [`fnp.random.RandomState`](/docs/api/ops/random.RandomState/) — legacy class
+- [`fnp.random.default_rng`](/docs/api/numpy/random/default-rng/) — canonical entry point (op page)
 - [Migrate from NumPy](/docs/guides/migrate-from-numpy/) — broader migration guide
 - [Issue #18](https://github.com/AIcrowd/flopscope/issues/18) — design rationale and history
+
+(`fnp.random.RandomState` is a class constructor, not a registered op — its
+sampler methods have individual op pages under `/docs/api/numpy/random/`.)


### PR DESCRIPTION
## Summary

CI on `main` has been red since PR #85 merged because the deploy-only link audit found 2 broken internal targets in the new `random.mdx` guide. This PR fixes them.

## What was broken

| Link in guide | Why broken |
|---|---|
| `/docs/api/ops/random.default_rng/` | Op pages aren't routed under `/docs/api/ops/<slug>/`. Their actual URL is `detail_href` from ops.json: `/docs/api/numpy/random/default-rng/`. The dots also don't appear in slugs. |
| `/docs/api/ops/random.RandomState/` | `random.RandomState` is a class constructor, not a registered op — there's no per-class page. Only its sampler methods have op pages. |

## The fix

- Repoint `default_rng` to its actual `detail_href`: `/docs/api/numpy/random/default-rng/`.
- Drop the `RandomState` link; replace with a one-line note pointing readers at the per-method pages under `/docs/api/numpy/random/`.

## Verification

Local link audit before and after:

```
Before:  brokenCount: 2  (the two links above)
After:   brokenCount: 0
```

Run locally with:

```bash
cd website && npm run build && npm run check:deploy-links
```

CI should turn green on the next run. No code changes — single MDX file edit.