### PR TITLE
[codex] Rename flopscope timing fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,12 @@ with flops.BudgetContext(flop_budget=10**8, wall_time_limit_s=5.0) as budget:
 
     print(budget.summary())   # current context summary
 
-flops.budget_summary()           # session/global summary
+flops.budget_summary()           # accumulated session/global summary
 ```
 
 ```
-
-`wall_time_limit_s` starts when the context is entered and is checked before
-and after each counted NumPy call. If the limit is exceeded, flopscope raises
-`TimeExhaustedError` with the operation name, elapsed time, and configured
-limit. Use `budget.summary()` for the current context and
-`flops.budget_summary()` when you want the accumulated session/global view.
 flopscope FLOP Budget Summary
-=========================
+=============================
   Total budget:     100,000,000
   Used:                 984,321  (1.0%)
   Remaining:         99,015,679  (99.0%)
@@ -159,6 +153,11 @@ flopscope FLOP Budget Summary
     einsum                327,680  ( 33.3%)  [5 calls]
     maximum                 1,024  (  0.1%)  [4 calls]
     sqrt                        1  (  0.0%)  [1 call]
+
+  Total Wall Time:     ...s
+  Flopscope Backend:   ...s  (...%)
+  Flopscope Overhead:  ...s  (...%)
+  Residual Wall Time:  ...s  (...%)
 ```
 
 ### Plan Your Budget Before Executing

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -20,9 +20,13 @@ class OpRecord(NamedTuple):
     flop_cost: int
     cumulative: int
     namespace: str | None = None
-    timestamp: float | None = None  # seconds since context __enter__
-    duration: float | None = None  # wall-clock seconds of the numpy call
-    flopscope_overhead: float | None = (
+    flopscope_context_start_offset_s: float | None = (
+        None  # seconds since active BudgetContext start
+    )
+    flopscope_backend_duration_s: float | None = (
+        None  # wall-clock seconds of the backend call
+    )
+    flopscope_overhead_duration_s: float | None = (
         None  # per-op flopscope dispatch time (preamble + deduct body + bookkeeping + postamble)
     )
 
@@ -62,17 +66,23 @@ class _OpTimer:
             result = _call_numpy(np_func, ...)
 
     On __exit__, the block's wall time is split into:
-      - tracked_time:  sum of _call_numpy durations reported during the block
-      - in-block overhead: block_duration - tracked (view-casts, copyto, etc.)
+      - backend duration: sum of _call_numpy durations reported during the block
+      - in-block overhead: block_duration - backend duration
     """
 
-    __slots__ = ("_budget", "_op_index", "_block_t0", "_np_duration", "_prev_timer")
+    __slots__ = (
+        "_budget",
+        "_op_index",
+        "_block_t0",
+        "_backend_duration_s",
+        "_prev_timer",
+    )
 
     def __init__(self, budget: BudgetContext, op_index: int):
         self._budget = budget
         self._op_index = op_index
         self._block_t0: float | None = None
-        self._np_duration: float = 0.0
+        self._backend_duration_s: float = 0.0
         self._prev_timer: _OpTimer | None = None
 
     def __enter__(self) -> _OpTimer:
@@ -85,15 +95,16 @@ class _OpTimer:
     def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
         if self._block_t0 is not None:
             block_duration = time.perf_counter() - self._block_t0
-            in_block_overhead = max(block_duration - self._np_duration, 0.0)
+            in_block_overhead = max(block_duration - self._backend_duration_s, 0.0)
 
-            self._budget._total_tracked_time += self._np_duration
+            self._budget._total_flopscope_backend_time += self._backend_duration_s
             self._budget._total_flopscope_overhead_time += in_block_overhead
 
             op = self._budget._op_log[self._op_index]
             self._budget._op_log[self._op_index] = op._replace(
-                duration=self._np_duration,
-                flopscope_overhead=(op.flopscope_overhead or 0.0) + in_block_overhead,
+                flopscope_backend_duration_s=self._backend_duration_s,
+                flopscope_overhead_duration_s=(op.flopscope_overhead_duration_s or 0.0)
+                + in_block_overhead,
             )
 
             # Post-op deadline check (preserves existing behavior)
@@ -115,13 +126,13 @@ class _OpTimer:
 
 
 def _call_numpy(fn: Any, *args: Any, **kwargs: Any) -> Any:
-    """Invoke a numpy callable, attributing only its wall time to tracked_time.
+    """Invoke a numpy callable, attributing only its wall time to backend time.
 
     All numpy calls inside counted-op wrappers MUST go through this helper so
     that view-casts, copyto, errstate setup, and other flopscope-internal work
     surrounding the call are correctly bucketed as flopscope_overhead.
 
-    Reports the call's duration to the active _OpTimer (via
+    Reports the call's backend duration to the active _OpTimer (via
     budget._current_op_timer). When no timer is active (e.g. helper called
     from a non-counted code path), it is a transparent passthrough.
 
@@ -136,14 +147,14 @@ def _call_numpy(fn: Any, *args: Any, **kwargs: Any) -> Any:
         d = time.perf_counter() - t0
         budget = get_active_budget()
         if budget is not None and budget._current_op_timer is not None:
-            budget._current_op_timer._np_duration += d
+            budget._current_op_timer._backend_duration_s += d
 
 
 def _counted_wrapper(fn):
     """Decorator that brackets a flopscope wrapper and bills its non-numpy,
     non-nested-overhead time to flopscope_overhead_time.
 
-    Formula: wall - tracked_delta - overhead_delta. Handles nesting naturally
+    Formula: wall - backend_delta - overhead_delta. Handles nesting naturally
     (outer attributes only its own remainder), so no re-entrancy guard.
 
     Per-op attribution: wrapper-own overhead is distributed equally across
@@ -156,16 +167,16 @@ def _counted_wrapper(fn):
 
         budget = require_budget()
         fs_t0 = time.perf_counter()
-        tracked_baseline = budget._total_tracked_time
+        backend_baseline = budget._total_flopscope_backend_time
         overhead_baseline = budget._total_flopscope_overhead_time
         ops_before = len(budget._op_log)
         try:
             return fn(*args, **kwargs)
         finally:
             wall = time.perf_counter() - fs_t0
-            tracked_delta = budget._total_tracked_time - tracked_baseline
+            backend_delta = budget._total_flopscope_backend_time - backend_baseline
             overhead_delta = budget._total_flopscope_overhead_time - overhead_baseline
-            wrapper_own_overhead = max(wall - tracked_delta - overhead_delta, 0.0)
+            wrapper_own_overhead = max(wall - backend_delta - overhead_delta, 0.0)
             budget._total_flopscope_overhead_time += wrapper_own_overhead
             ops_added = list(range(ops_before, len(budget._op_log)))
             if ops_added and wrapper_own_overhead > 0:
@@ -173,7 +184,10 @@ def _counted_wrapper(fn):
                 for idx in ops_added:
                     op = budget._op_log[idx]
                     budget._op_log[idx] = op._replace(
-                        flopscope_overhead=(op.flopscope_overhead or 0.0) + per_op
+                        flopscope_overhead_duration_s=(
+                            op.flopscope_overhead_duration_s or 0.0
+                        )
+                        + per_op
                     )
 
     return wrapped
@@ -270,13 +284,16 @@ def _update_operation_summary(ops: dict[str, dict], op: OpRecord) -> None:
         {
             "flop_cost": 0,
             "calls": 0,
-            "duration": 0.0,
+            "flopscope_backend_time_s": 0.0,
+            "flopscope_overhead_time_s": 0.0,
         },
     )
     bucket["flop_cost"] += op.flop_cost
     bucket["calls"] += 1
-    if op.duration is not None:
-        bucket["duration"] += op.duration
+    if op.flopscope_backend_duration_s is not None:
+        bucket["flopscope_backend_time_s"] += op.flopscope_backend_duration_s
+    if op.flopscope_overhead_duration_s is not None:
+        bucket["flopscope_overhead_time_s"] += op.flopscope_overhead_duration_s
 
 
 def _summarize_operations(op_log: list[OpRecord]) -> dict[str, dict]:
@@ -294,34 +311,34 @@ def _summarize_by_namespace(op_log: list[OpRecord]) -> dict[str | None, dict]:
             {
                 "flops_used": 0,
                 "calls": 0,
-                "tracked_time_s": 0.0,
+                "flopscope_backend_time_s": 0.0,
                 "flopscope_overhead_time_s": 0.0,
                 "operations": {},
             },
         )
         bucket["flops_used"] += op.flop_cost
         bucket["calls"] += 1
-        if op.duration is not None:
-            bucket["tracked_time_s"] += op.duration
-        if op.flopscope_overhead is not None:
-            bucket["flopscope_overhead_time_s"] += op.flopscope_overhead
+        if op.flopscope_backend_duration_s is not None:
+            bucket["flopscope_backend_time_s"] += op.flopscope_backend_duration_s
+        if op.flopscope_overhead_duration_s is not None:
+            bucket["flopscope_overhead_time_s"] += op.flopscope_overhead_duration_s
         _update_operation_summary(bucket["operations"], op)
     return by_namespace
 
 
 def _timing_summary(
     wall_time_s: float | None,
-    tracked_time_s: float | None,
+    flopscope_backend_time_s: float | None,
     overhead_time_s: float | None,
 ) -> tuple[float | None, float, float, float | None]:
-    tracked = tracked_time_s or 0.0
+    backend = flopscope_backend_time_s or 0.0
     overhead = overhead_time_s or 0.0
     if wall_time_s is None:
-        return None, tracked, overhead, None
-    untracked = wall_time_s - tracked - overhead
-    if untracked < 0 and abs(untracked) < 1e-12:
-        untracked = 0.0
-    return wall_time_s, tracked, overhead, max(untracked, 0.0)
+        return None, backend, overhead, None
+    residual = wall_time_s - backend - overhead
+    if residual < 0 and abs(residual) < 1e-12:
+        residual = 0.0
+    return wall_time_s, backend, overhead, max(residual, 0.0)
 
 
 class BudgetContext:
@@ -384,13 +401,13 @@ class BudgetContext:
         self._start_time: float | None = None
         self._deadline: float | None = None
         self._wall_time_s: float | None = None
-        self._total_tracked_time: float = 0.0
+        self._total_flopscope_backend_time: float = 0.0
         self._total_flopscope_overhead_time: float = 0.0
         self._pre_enter_overhead: float = 0.0
         self._current_op_timer: _OpTimer | None = None
         self._recorded_flops_used = 0
         self._recorded_op_count = 0
-        self._recorded_tracked_time = 0.0
+        self._recorded_flopscope_backend_time = 0.0
         self._recorded_overhead_time: float = 0.0
         self._budget_recorded = False
         _all_budget_contexts.add(self)
@@ -436,11 +453,12 @@ class BudgetContext:
         accumulator-record and active-budget restoration work). ``None`` until
         ``__exit__`` has run.
 
-        The decomposition ``wall_time_s == tracked_time + flopscope_overhead_time
-        + untracked_time`` holds within numerical tolerance. The pre-``__enter__``
-        slice (``__init__`` body + banner print) and the post-``__exit__`` body
-        slice (accumulator-record, active-budget restore) are both attributed
-        to ``flopscope_overhead_time``.
+        The decomposition ``wall_time_s == flopscope_backend_time
+        + flopscope_overhead_time + residual_wall_time`` holds within numerical
+        tolerance. The pre-``__enter__`` slice (``__init__`` body + banner print)
+        and the post-``__exit__`` body slice (accumulator-record,
+        active-budget restore) are both attributed to
+        ``flopscope_overhead_time``.
         """
         return self._wall_time_s
 
@@ -451,8 +469,8 @@ class BudgetContext:
         return time.perf_counter() - self._start_time
 
     @property
-    def total_tracked_time(self) -> float:
-        return self._total_tracked_time
+    def flopscope_backend_time(self) -> float:
+        return self._total_flopscope_backend_time
 
     @property
     def flopscope_overhead_time(self) -> float:
@@ -469,22 +487,18 @@ class BudgetContext:
         return self._total_flopscope_overhead_time
 
     @property
-    def untracked_time(self) -> float | None:
-        """Wall time minus tracked_time minus flopscope_overhead_time.
+    def residual_wall_time(self) -> float | None:
+        """Wall time minus flopscope backend and overhead time.
 
-        Genuinely 'neither' — user Python between ops, time.sleep, GC pauses,
-        un-instrumented numpy.
-
-        BREAKING (vs versions before issue #76): previously was
-        wall_time - tracked_time. The new value subtracts measured framework
-        overhead. To recover the prior 'all-unattributed' value, compute
-        flopscope_overhead_time + untracked_time.
+        This is the measured wall-clock remainder outside the backend calls and
+        flopscope's own dispatch/accounting work: user Python between ops,
+        time.sleep, GC pauses, and un-instrumented NumPy.
         """
         if self._wall_time_s is None:
             return None
         residual = (
             self._wall_time_s
-            - self._total_tracked_time
+            - self._total_flopscope_backend_time
             - self._total_flopscope_overhead_time
         )
         if residual < 0 and abs(residual) < 1e-12:
@@ -511,7 +525,9 @@ class BudgetContext:
             self._flops_used += adjusted_cost
 
             now = time.perf_counter()
-            timestamp = now - self._start_time if self._start_time is not None else None
+            context_start_offset_s = (
+                now - self._start_time if self._start_time is not None else None
+            )
 
             self._op_log.append(
                 OpRecord(
@@ -521,7 +537,7 @@ class BudgetContext:
                     flop_cost=adjusted_cost,
                     cumulative=self._flops_used,
                     namespace=self.namespace,
-                    timestamp=timestamp,
+                    flopscope_context_start_offset_s=context_start_offset_s,
                 )
             )
             appended = True
@@ -543,7 +559,10 @@ class BudgetContext:
             if appended:
                 op = self._op_log[-1]
                 self._op_log[-1] = op._replace(
-                    flopscope_overhead=(op.flopscope_overhead or 0.0) + deduct_body_time
+                    flopscope_overhead_duration_s=(
+                        op.flopscope_overhead_duration_s or 0.0
+                    )
+                    + deduct_body_time
                 )
 
     def summary_dict(self, by_namespace: bool = False) -> dict:
@@ -551,19 +570,21 @@ class BudgetContext:
 
         Returns a dict with keys ``flop_budget``, ``flops_used``,
         ``flops_remaining``, ``operations``, ``wall_time_s``,
-        ``tracked_time_s``, ``flopscope_overhead_time_s``,
-        ``untracked_time_s``, and optionally ``by_namespace`` with per-
+        ``flopscope_backend_time_s``, ``flopscope_overhead_time_s``,
+        ``residual_wall_time_s``, and optionally ``by_namespace`` with per-
         namespace buckets that each include the same timing keys.
 
-        Decomposition: ``wall_time_s == tracked_time_s
-        + flopscope_overhead_time_s + untracked_time_s`` (within numerical
+        Decomposition: ``wall_time_s == flopscope_backend_time_s
+        + flopscope_overhead_time_s + residual_wall_time_s`` (within numerical
         tolerance).
         """
         wall_time = self._wall_time_s
         if wall_time is None and self._start_time is not None:
             wall_time = self.elapsed_s
-        wall_time, tracked_time, overhead_time, untracked_time = _timing_summary(
-            wall_time, self._total_tracked_time, self._total_flopscope_overhead_time
+        wall_time, backend_time, overhead_time, residual_wall_time = _timing_summary(
+            wall_time,
+            self._total_flopscope_backend_time,
+            self._total_flopscope_overhead_time,
         )
 
         result = {
@@ -572,9 +593,9 @@ class BudgetContext:
             "flops_remaining": self.flops_remaining,
             "operations": _summarize_operations(self._op_log),
             "wall_time_s": wall_time,
-            "tracked_time_s": tracked_time,
+            "flopscope_backend_time_s": backend_time,
             "flopscope_overhead_time_s": overhead_time,
-            "untracked_time_s": untracked_time,
+            "residual_wall_time_s": residual_wall_time,
         }
         if by_namespace:
             result["by_namespace"] = _summarize_by_namespace(self._op_log)
@@ -608,9 +629,11 @@ class BudgetContext:
         if wall_time is None and self._start_time is not None:
             wall_time = self.elapsed_s
 
-        tracked_delta = self._total_tracked_time - self._recorded_tracked_time
-        if tracked_delta < 0 and abs(tracked_delta) < 1e-12:
-            tracked_delta = 0.0
+        backend_delta = (
+            self._total_flopscope_backend_time - self._recorded_flopscope_backend_time
+        )
+        if backend_delta < 0 and abs(backend_delta) < 1e-12:
+            backend_delta = 0.0
 
         overhead_delta = (
             self._total_flopscope_overhead_time - self._recorded_overhead_time
@@ -624,7 +647,7 @@ class BudgetContext:
             flops_used=max(self._flops_used - self._recorded_flops_used, 0),
             op_log=list(self._op_log[self._recorded_op_count :]),
             wall_time_s=wall_time,
-            total_tracked_time=max(tracked_delta, 0.0),
+            total_flopscope_backend_time=max(backend_delta, 0.0),
             total_flopscope_overhead_time=max(overhead_delta, 0.0),
         )
 
@@ -634,14 +657,14 @@ class BudgetContext:
     def _mark_recorded(self) -> None:
         self._recorded_flops_used = self._flops_used
         self._recorded_op_count = len(self._op_log)
-        self._recorded_tracked_time = self._total_tracked_time
+        self._recorded_flopscope_backend_time = self._total_flopscope_backend_time
         self._recorded_overhead_time = self._total_flopscope_overhead_time
         self._budget_recorded = True
 
     def _mark_reset_baseline(self) -> None:
         self._recorded_flops_used = self._flops_used
         self._recorded_op_count = len(self._op_log)
-        self._recorded_tracked_time = self._total_tracked_time
+        self._recorded_flopscope_backend_time = self._total_flopscope_backend_time
         self._recorded_overhead_time = self._total_flopscope_overhead_time
         self._budget_recorded = False
 
@@ -805,7 +828,7 @@ class NamespaceRecord(NamedTuple):
     flops_used: int
     op_log: list[OpRecord]
     wall_time_s: float | None = None
-    total_tracked_time: float | None = None
+    total_flopscope_backend_time: float | None = None
     total_flopscope_overhead_time: float | None = None
 
 
@@ -829,7 +852,7 @@ class BudgetAccumulator:
         total_budget = 0
         total_used = 0
         total_wall_time: float | None = None
-        total_tracked: float | None = None
+        total_backend: float | None = None
         total_overhead: float | None = None
         all_ops: list[OpRecord] = []
 
@@ -839,15 +862,17 @@ class BudgetAccumulator:
             all_ops.extend(rec.op_log)
             if rec.wall_time_s is not None:
                 total_wall_time = (total_wall_time or 0.0) + rec.wall_time_s
-            if rec.total_tracked_time is not None:
-                total_tracked = (total_tracked or 0.0) + rec.total_tracked_time
+            if rec.total_flopscope_backend_time is not None:
+                total_backend = (
+                    total_backend or 0.0
+                ) + rec.total_flopscope_backend_time
             if rec.total_flopscope_overhead_time is not None:
                 total_overhead = (
                     total_overhead or 0.0
                 ) + rec.total_flopscope_overhead_time
 
-        wall_time, tracked_time, overhead_time, untracked_time = _timing_summary(
-            total_wall_time, total_tracked, total_overhead
+        wall_time, backend_time, overhead_time, residual_wall_time = _timing_summary(
+            total_wall_time, total_backend, total_overhead
         )
 
         result = {
@@ -856,9 +881,9 @@ class BudgetAccumulator:
             "flops_remaining": total_budget - total_used,
             "operations": _summarize_operations(all_ops),
             "wall_time_s": wall_time,
-            "tracked_time_s": tracked_time,
+            "flopscope_backend_time_s": backend_time,
             "flopscope_overhead_time_s": overhead_time,
-            "untracked_time_s": untracked_time,
+            "residual_wall_time_s": residual_wall_time,
         }
 
         if by_namespace:
@@ -902,8 +927,8 @@ def budget_summary_dict(by_namespace: bool = False) -> dict:
     dict
         Dictionary with keys ``"flop_budget"``, ``"flops_used"``,
         ``"flops_remaining"``, ``"operations"``, ``"wall_time_s"``,
-        ``"tracked_time_s"``, ``"flopscope_overhead_time_s"``,
-        ``"untracked_time_s"``, and optionally ``"by_namespace"``.
+        ``"flopscope_backend_time_s"``, ``"flopscope_overhead_time_s"``,
+        ``"residual_wall_time_s"``, and optionally ``"by_namespace"``.
 
     Examples
     --------
@@ -913,7 +938,7 @@ def budget_summary_dict(by_namespace: bool = False) -> dict:
     ...     _ = fnp.add(fnp.array([1.0]), fnp.array([2.0]))
     >>> summary = flops.budget_summary_dict()
     >>> sorted(summary)
-    ['flop_budget', 'flops_remaining', 'flops_used', 'flopscope_overhead_time_s', 'operations', 'tracked_time_s', 'untracked_time_s', 'wall_time_s']
+    ['flop_budget', 'flops_remaining', 'flops_used', 'flopscope_backend_time_s', 'flopscope_overhead_time_s', 'operations', 'residual_wall_time_s', 'wall_time_s']
     """
     acc_copy = BudgetAccumulator()
     acc_copy._records = _snapshot_records()

--- a/src/flopscope/_display.py
+++ b/src/flopscope/_display.py
@@ -68,7 +68,7 @@ def _format_budget_summary_text(
         lines += ["", "  By namespace:"]
         for namespace, bucket in _sorted_namespace_rows(data["by_namespace"]):
             lines.append(
-                f"    {_namespace_label(namespace):<24} {_format_flops(bucket['flops_used']):>12}  ({_pct(bucket['flops_used'], data['flops_used']):>6})  [{_call_label(bucket['calls'])}]  {bucket['tracked_time_s']:.3f}s"
+                f"    {_namespace_label(namespace):<24} {_format_flops(bucket['flops_used']):>12}  ({_pct(bucket['flops_used'], data['flops_used']):>6})  [{_call_label(bucket['calls'])}]  Backend {bucket['flopscope_backend_time_s']:.3f}s  Overhead {bucket['flopscope_overhead_time_s']:.3f}s"
             )
 
     ops = data.get("operations", {})
@@ -82,30 +82,30 @@ def _format_budget_summary_text(
             )
 
     wall_time = data.get("wall_time_s")
-    tracked_time = data.get("tracked_time_s", 0.0)
+    backend_time = data.get("flopscope_backend_time_s", 0.0)
     overhead_time = data.get("flopscope_overhead_time_s", 0.0)
-    untracked_time = data.get("untracked_time_s")
-    if wall_time is not None and untracked_time is not None:
+    residual_wall_time = data.get("residual_wall_time_s")
+    if wall_time is not None and residual_wall_time is not None:
         lines += [
             "",
-            f"  Wall time:           {wall_time:.3f}s",
-            f"  Tracked time:        {tracked_time:.3f}s  ({_pct(tracked_time, wall_time)})",
-            f"  Flopscope overhead:  {overhead_time:.3f}s  ({_pct(overhead_time, wall_time)})",
-            f"  Untracked time:      {untracked_time:.3f}s  ({_pct(untracked_time, wall_time)})",
+            f"  Total Wall Time:     {wall_time:.3f}s",
+            f"  Flopscope Backend:   {backend_time:.3f}s  ({_pct(backend_time, wall_time)})",
+            f"  Flopscope Overhead:  {overhead_time:.3f}s  ({_pct(overhead_time, wall_time)})",
+            f"  Residual Wall Time:  {residual_wall_time:.3f}s  ({_pct(residual_wall_time, wall_time)})",
         ]
 
-    op_durations = {
-        op_name: op_info["duration"]
+    op_backend_times = {
+        op_name: op_info["flopscope_backend_time_s"]
         for op_name, op_info in ops.items()
-        if op_info.get("duration", 0.0) > 0
+        if op_info.get("flopscope_backend_time_s", 0.0) > 0
     }
-    if tracked_time > 0 and op_durations:
+    if backend_time > 0 and op_backend_times:
         lines += ["", "  By operation (time):"]
-        for op_name, duration in sorted(
-            op_durations.items(), key=lambda item: -item[1]
+        for op_name, op_backend_time in sorted(
+            op_backend_times.items(), key=lambda item: -item[1]
         ):
             lines.append(
-                f"    {op_name:<20} {duration:.3f}s  ({_pct(duration, tracked_time):>6})  [{_call_label(ops[op_name]['calls'])}]"
+                f"    {op_name:<20} {op_backend_time:.3f}s  ({_pct(op_backend_time, backend_time):>6})  [{_call_label(ops[op_name]['calls'])}]"
             )
 
     return "\n".join(lines)
@@ -175,18 +175,21 @@ def _rich_namespace_table(label: str, ns_data: dict, color: str):
     table.add_column("Operation", style="dim")
     table.add_column("FLOPs", justify="right")
     table.add_column("%", justify="right")
-    table.add_column("Time", justify="right", style="dim")
+    table.add_column("Backend", justify="right", style="dim")
+    table.add_column("Overhead", justify="right", style="dim")
     table.add_column("Calls", justify="right", style="dim")
 
     ops = ns_data.get("operations", {})
     total = ns_data.get("flop_budget", ns_data.get("flops_used", 0))
     for op_name, op_info in sorted(ops.items(), key=lambda item: -item[1]["flop_cost"]):
-        dur = op_info.get("duration", 0.0)
+        backend = op_info.get("flopscope_backend_time_s", 0.0)
+        overhead = op_info.get("flopscope_overhead_time_s", 0.0)
         table.add_row(
             op_name,
             _format_flops(op_info["flop_cost"]),
             _pct(op_info["flop_cost"], total),
-            f"{dur:.3f}s" if dur > 0 else "",
+            f"{backend:.3f}s" if backend > 0 else "",
+            f"{overhead:.3f}s" if overhead > 0 else "",
             _call_label(op_info["calls"]),
         )
 
@@ -197,12 +200,14 @@ def _rich_namespace_table(label: str, ns_data: dict, color: str):
         Text(_pct(ns_data.get("flops_used", 0), total), style=color),
         "",
         "",
+        "",
     )
     if "flop_budget" in ns_data:
         remaining = ns_data["flop_budget"] - ns_data.get("flops_used", 0)
         table.add_row(
             Text("Remaining", style="bold"),
             Text(_format_flops(remaining), style="bold"),
+            "",
             "",
             "",
             "",
@@ -240,29 +245,30 @@ def _rich_totals_table(data: dict):
         )
 
     wall_time = data.get("wall_time_s")
-    tracked_time = data.get("tracked_time_s", 0.0)
+    backend_time = data.get("flopscope_backend_time_s", 0.0)
     overhead_time = data.get("flopscope_overhead_time_s", 0.0)
-    untracked_time = data.get("untracked_time_s")
-    if wall_time is not None and untracked_time is not None:
+    residual_wall_time = data.get("residual_wall_time_s")
+    if wall_time is not None and residual_wall_time is not None:
         table.add_section()
-        table.add_row("Wall time", f"{wall_time:.3f}s")
+        table.add_row("Total Wall Time", f"{wall_time:.3f}s")
         table.add_row(
-            "Tracked",
+            "Flopscope Backend",
             Text(
-                f"{tracked_time:.3f}s  ({_pct(tracked_time, wall_time)})", style="dim"
+                f"{backend_time:.3f}s  ({_pct(backend_time, wall_time)})",
+                style="dim",
             ),
         )
         table.add_row(
-            "Flopscope overhead",
+            "Flopscope Overhead",
             Text(
                 f"{overhead_time:.3f}s  ({_pct(overhead_time, wall_time)})",
                 style="dim",
             ),
         )
         table.add_row(
-            "Untracked",
+            "Residual Wall Time",
             Text(
-                f"{untracked_time:.3f}s  ({_pct(untracked_time, wall_time)})",
+                f"{residual_wall_time:.3f}s  ({_pct(residual_wall_time, wall_time)})",
                 style="dim",
             ),
         )
@@ -284,7 +290,8 @@ def _rich_attribution_table(by_ns: dict[str | None, dict], total_flops_used: int
     table.add_column("FLOPs", justify="right")
     table.add_column("%", justify="right")
     table.add_column("Calls", justify="right")
-    table.add_column("Tracked", justify="right")
+    table.add_column("Backend", justify="right")
+    table.add_column("Overhead", justify="right")
 
     for namespace, bucket in _sorted_namespace_rows(by_ns):
         table.add_row(
@@ -292,7 +299,8 @@ def _rich_attribution_table(by_ns: dict[str | None, dict], total_flops_used: int
             _format_flops(bucket["flops_used"]),
             _pct(bucket["flops_used"], total_flops_used),
             str(bucket["calls"]),
-            f"{bucket['tracked_time_s']:.3f}s",
+            f"{bucket['flopscope_backend_time_s']:.3f}s",
+            f"{bucket['flopscope_overhead_time_s']:.3f}s",
         )
 
     return table
@@ -311,16 +319,19 @@ def _rich_operations_table(ops: dict[str, dict], total_flops_used: int):
     table.add_column("Operation", style="dim")
     table.add_column("FLOPs", justify="right")
     table.add_column("%", justify="right")
-    table.add_column("Time", justify="right", style="dim")
+    table.add_column("Backend", justify="right", style="dim")
+    table.add_column("Overhead", justify="right", style="dim")
     table.add_column("Calls", justify="right", style="dim")
 
     for op_name, op_info in sorted(ops.items(), key=lambda item: -item[1]["flop_cost"]):
-        duration = op_info.get("duration", 0.0)
+        backend = op_info.get("flopscope_backend_time_s", 0.0)
+        overhead = op_info.get("flopscope_overhead_time_s", 0.0)
         table.add_row(
             op_name,
             _format_flops(op_info["flop_cost"]),
             _pct(op_info["flop_cost"], total_flops_used),
-            f"{duration:.3f}s" if duration > 0 else "",
+            f"{backend:.3f}s" if backend > 0 else "",
+            f"{overhead:.3f}s" if overhead > 0 else "",
             _call_label(op_info["calls"]),
         )
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -166,18 +166,18 @@ def test_budget_context_wall_time_limit_s_property():
     assert b2.wall_time_limit_s is None
 
 
-def test_budget_context_total_tracked_time():
+def test_budget_context_flopscope_backend_time():
     import flopscope
 
     with flopscope.BudgetContext(flop_budget=int(1e9)) as b:
         _ = flopscope.numpy.add(
             flopscope.numpy.ones((1000,)), flopscope.numpy.ones((1000,))
         )
-    assert b.total_tracked_time >= 0
-    assert b.total_tracked_time <= b.wall_time_s  # pyright: ignore[reportOperatorIssue]
+    assert b.flopscope_backend_time >= 0
+    assert b.flopscope_backend_time <= b.wall_time_s  # pyright: ignore[reportOperatorIssue]
 
 
-def test_budget_context_untracked_time():
+def test_budget_context_residual_wall_time():
     import flopscope
 
     with flopscope.BudgetContext(flop_budget=int(1e9)) as b:
@@ -185,8 +185,8 @@ def test_budget_context_untracked_time():
             flopscope.numpy.ones((1000,)), flopscope.numpy.ones((1000,))
         )
         _time.sleep(0.01)
-    assert b.untracked_time is not None
-    assert b.untracked_time >= 0
+    assert b.residual_wall_time is not None
+    assert b.residual_wall_time >= 0
 
 
 def test_wall_time_limit_raises_time_exhausted():
@@ -204,20 +204,24 @@ def test_wall_time_limit_raises_time_exhausted():
     assert exc_info.value.elapsed_s >= 0.001
 
 
-def test_oprecord_timestamps_monotonic():
+def test_oprecord_context_offsets_monotonic():
     import flopscope
 
     with flopscope.BudgetContext(flop_budget=int(1e9)) as b:
         a = flopscope.numpy.ones((10,))
         for _ in range(5):
             a = flopscope.numpy.add(a, a)
-    timestamps = [r.timestamp for r in b.op_log if r.timestamp is not None]
+    timestamps = [
+        r.flopscope_context_start_offset_s
+        for r in b.op_log
+        if r.flopscope_context_start_offset_s is not None
+    ]
     assert len(timestamps) >= 5
     for i in range(1, len(timestamps)):
         assert timestamps[i] >= timestamps[i - 1]
 
 
-def test_oprecord_has_timestamp_and_duration_fields():
+def test_oprecord_has_context_offset_and_backend_duration_fields():
     import flopscope
 
     rec = flopscope.OpRecord(
@@ -227,11 +231,11 @@ def test_oprecord_has_timestamp_and_duration_fields():
         flop_cost=3,
         cumulative=3,
     )
-    assert rec.timestamp is None
-    assert rec.duration is None
+    assert rec.flopscope_context_start_offset_s is None
+    assert rec.flopscope_backend_duration_s is None
 
 
-def test_oprecord_durations_populated():
+def test_oprecord_backend_durations_populated():
     """OpRecord durations are populated for ops using with-deduct pattern."""
     import flopscope
 
@@ -240,11 +244,11 @@ def test_oprecord_durations_populated():
         _ = flopscope.numpy.add(a, a)
     add_records = [r for r in b.op_log if r.op_name == "add"]
     assert len(add_records) >= 1
-    assert all(r.duration is not None for r in add_records)
-    assert all(r.duration >= 0 for r in add_records)  # pyright: ignore[reportOptionalOperand]
+    assert all(r.flopscope_backend_duration_s is not None for r in add_records)
+    assert all(r.flopscope_backend_duration_s >= 0 for r in add_records)  # pyright: ignore[reportOptionalOperand]
 
 
-def test_durations_populated_across_op_types():
+def test_backend_durations_populated_across_op_types():
     """Verify durations populated for various operation types."""
     import flopscope
 
@@ -260,7 +264,7 @@ def test_durations_populated_across_op_types():
         h = flopscope.numpy.dot(a, a)  # standalone pointwise
         i = flopscope.numpy.sort(a.copy())  # sorting
 
-    records_without = [r for r in b.op_log if r.duration is None]
+    records_without = [r for r in b.op_log if r.flopscope_backend_duration_s is None]
     assert len(records_without) == 0, (
         f"Ops missing duration: {[r.op_name for r in records_without]}"
     )
@@ -274,7 +278,7 @@ def test_budget_factory_passes_wall_time_limit():
 
 
 def test_plain_text_summary_includes_timing():
-    """Plain-text summary should show wall time and tracked/untracked."""
+    """Plain-text summary should show the new timing taxonomy."""
     import flopscope
     from flopscope._display import _plain_text_summary
 
@@ -284,9 +288,10 @@ def test_plain_text_summary_includes_timing():
         _ = flopscope.numpy.add(a, a)
 
     text = _plain_text_summary()
-    assert "Wall time:" in text
-    assert "Tracked time:" in text
-    assert "Untracked time:" in text
+    assert "Total Wall Time:" in text
+    assert "Flopscope Backend:" in text
+    assert "Flopscope Overhead:" in text
+    assert "Residual Wall Time:" in text
 
 
 def test_namespace_record_includes_time():
@@ -303,11 +308,19 @@ def test_namespace_record_includes_time():
     assert "wall_time_s" in data
     assert data["wall_time_s"] is not None
     assert data["wall_time_s"] > 0
-    assert "tracked_time_s" in data
-    assert "untracked_time_s" in data
+    assert "flopscope_backend_time_s" in data
+    assert "residual_wall_time_s" in data
+    old_backend_key = "tracked" + "_time_s"
+    old_residual_key = "untracked" + "_time_s"
+    assert old_backend_key not in data
+    assert old_residual_key not in data
     ns_data = data["by_namespace"]["test"]
-    assert "tracked_time_s" in ns_data
+    assert "flopscope_backend_time_s" in ns_data
+    assert "flopscope_overhead_time_s" in ns_data
     assert "wall_time_s" not in ns_data
+    assert "residual_wall_time_s" not in ns_data
+    assert old_backend_key not in ns_data
+    assert old_residual_key not in ns_data
     flopscope.budget_reset()
 
 
@@ -319,12 +332,14 @@ def test_summary_includes_time_section():
             flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
         )
     summary = b.summary()
-    assert "Wall time:" in summary
-    assert "Tracked time:" in summary
+    assert "Total Wall Time:" in summary
+    assert "Flopscope Backend:" in summary
+    assert "Flopscope Overhead:" in summary
+    assert "Residual Wall Time:" in summary
 
 
-def test_deduct_without_with_leaves_duration_none():
-    """Calling deduct() without 'with' leaves OpRecord.duration as None."""
+def test_deduct_without_with_leaves_backend_duration_none():
+    """Calling deduct() without 'with' leaves OpRecord.flopscope_backend_duration_s as None."""
     from flopscope._budget import BudgetContext
 
     ctx = BudgetContext(flop_budget=int(1e9), quiet=True)
@@ -333,8 +348,8 @@ def test_deduct_without_with_leaves_duration_none():
     ctx.deduct("test_op", flop_cost=10, subscripts=None, shapes=((10,),))
     ctx.__exit__(None, None, None)
     assert len(ctx.op_log) == 1
-    assert ctx.op_log[0].duration is None
-    assert ctx.op_log[0].timestamp is not None
+    assert ctx.op_log[0].flopscope_backend_duration_s is None
+    assert ctx.op_log[0].flopscope_context_start_offset_s is not None
 
 
 import threading
@@ -360,7 +375,7 @@ def test_thread_isolation_time_tracking():
         results[name] = b.wall_time_s
 
     t1 = threading.Thread(target=worker, args=("fast", 0.01))
-    t2 = threading.Thread(target=worker, args=("slow", 0.05))
+    t2 = threading.Thread(target=worker, args=("slow", 0.20))
     t1.start()
     t2.start()
     t1.join()
@@ -383,8 +398,12 @@ def test_pointwise_ops_have_duration():
 
     for rec in b.op_log:
         if rec.op_name in ("add", "exp", "sum"):
-            assert rec.duration is not None, f"{rec.op_name} missing duration"
-            assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+            assert rec.flopscope_backend_duration_s is not None, (
+                f"{rec.op_name} missing duration"
+            )
+            assert rec.flopscope_backend_duration_s >= 0, (
+                f"{rec.op_name} has negative duration"
+            )
 
 
 def test_linalg_ops_have_duration():
@@ -401,8 +420,12 @@ def test_linalg_ops_have_duration():
     linalg_records = [r for r in b.op_log if r.op_name.startswith("linalg.")]
     assert len(linalg_records) >= 4
     for rec in linalg_records:
-        assert rec.duration is not None, f"{rec.op_name} missing duration"
-        assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+        assert rec.flopscope_backend_duration_s is not None, (
+            f"{rec.op_name} missing duration"
+        )
+        assert rec.flopscope_backend_duration_s >= 0, (
+            f"{rec.op_name} has negative duration"
+        )
 
 
 def test_counting_ops_have_duration():
@@ -418,8 +441,12 @@ def test_counting_ops_have_duration():
     counting_ops = {"trace", "histogram", "logspace"}
     for rec in b.op_log:
         if rec.op_name in counting_ops:
-            assert rec.duration is not None, f"{rec.op_name} missing duration"
-            assert rec.duration >= 0, f"{rec.op_name} has negative duration"
+            assert rec.flopscope_backend_duration_s is not None, (
+                f"{rec.op_name} missing duration"
+            )
+            assert rec.flopscope_backend_duration_s >= 0, (
+                f"{rec.op_name} has negative duration"
+            )
 
 
 def test_banner_shows_time_limit(capsys):
@@ -462,8 +489,8 @@ def test_post_op_deadline_check():
     assert exc_info.value.elapsed_s >= 0.05
 
 
-def test_budget_summary_dict_includes_op_duration():
-    """budget_summary_dict() should include per-op duration."""
+def test_budget_summary_dict_includes_op_backend_time():
+    """budget_summary_dict() should include per-op backend and overhead time."""
     import flopscope
 
     flopscope.budget_reset()
@@ -474,12 +501,17 @@ def test_budget_summary_dict_includes_op_duration():
     data = flopscope.budget_summary_dict(by_namespace=True)
     ops = data["operations"]
     assert "add" in ops
-    assert "duration" in ops["add"]
-    assert ops["add"]["duration"] >= 0
+    assert "flopscope_backend_time_s" in ops["add"]
+    assert "flopscope_overhead_time_s" in ops["add"]
+    assert "duration" not in ops["add"]
+    assert ops["add"]["flopscope_backend_time_s"] >= 0
+    assert ops["add"]["flopscope_overhead_time_s"] >= 0
 
     ns_ops = data["by_namespace"]["test"]["operations"]
     assert "add" in ns_ops
-    assert "duration" in ns_ops["add"]
+    assert "flopscope_backend_time_s" in ns_ops["add"]
+    assert "flopscope_overhead_time_s" in ns_ops["add"]
+    assert "duration" not in ns_ops["add"]
 
 
 def test_budget_context_summary_dict_live_and_closed():
@@ -490,28 +522,34 @@ def test_budget_context_summary_dict_live_and_closed():
     budget = BudgetContext(flop_budget=100, quiet=True)
     with budget:
         with budget.deduct("add", flop_cost=10, subscripts=None, shapes=()):
-            _call_numpy(time.sleep, 0.01)  # tracked via _call_numpy
+            _call_numpy(time.sleep, 0.01)  # backend time via _call_numpy
         live = budget.summary_dict()
         assert live["flop_budget"] == 100
         assert live["flops_used"] == 10
         assert live["flops_remaining"] == 90
         assert live["wall_time_s"] is not None
-        assert live["tracked_time_s"] >= 0.01
-        assert live["untracked_time_s"] == pytest.approx(
+        assert live["flopscope_backend_time_s"] >= 0.01
+        old_backend_key = "tracked" + "_time_s"
+        old_residual_key = "untracked" + "_time_s"
+        assert old_backend_key not in live
+        assert old_residual_key not in live
+        assert live["residual_wall_time_s"] == pytest.approx(
             live["wall_time_s"]
-            - live["tracked_time_s"]
+            - live["flopscope_backend_time_s"]
             - live["flopscope_overhead_time_s"],
             abs=1e-6,
         )
         assert live["operations"]["add"]["calls"] == 1
-        assert live["operations"]["add"]["duration"] >= 0.01
+        assert live["operations"]["add"]["flopscope_backend_time_s"] >= 0.01
 
     closed = budget.summary_dict()
     assert closed["wall_time_s"] is not None
-    assert closed["tracked_time_s"] >= 0.01
-    assert closed["untracked_time_s"] == pytest.approx(
+    assert closed["flopscope_backend_time_s"] >= 0.01
+    assert old_backend_key not in closed
+    assert old_residual_key not in closed
+    assert closed["residual_wall_time_s"] == pytest.approx(
         closed["wall_time_s"]
-        - closed["tracked_time_s"]
+        - closed["flopscope_backend_time_s"]
         - closed["flopscope_overhead_time_s"],
         abs=1e-6,
     )
@@ -530,10 +568,10 @@ def test_budget_summary_dict_shows_live_timing_for_active_context():
         live = flopscope.budget_summary_dict()
         assert live["wall_time_s"] is not None
         assert live["wall_time_s"] >= 0.01
-        assert live["tracked_time_s"] >= 0.0
-        assert live["untracked_time_s"] == pytest.approx(
+        assert live["flopscope_backend_time_s"] >= 0.0
+        assert live["residual_wall_time_s"] == pytest.approx(
             live["wall_time_s"]
-            - live["tracked_time_s"]
+            - live["flopscope_backend_time_s"]
             - live["flopscope_overhead_time_s"],
             abs=1e-6,
         )
@@ -586,7 +624,7 @@ def test_oprecord_has_flopscope_overhead_field():
         flop_cost=3,
         cumulative=3,
     )
-    assert rec.flopscope_overhead is None
+    assert rec.flopscope_overhead_duration_s is None
 
     rec2 = flopscope.OpRecord(
         op_name="add",
@@ -594,9 +632,9 @@ def test_oprecord_has_flopscope_overhead_field():
         shapes=((3,),),
         flop_cost=3,
         cumulative=3,
-        flopscope_overhead=0.001,
+        flopscope_overhead_duration_s=0.001,
     )
-    assert rec2.flopscope_overhead == 0.001
+    assert rec2.flopscope_overhead_duration_s == 0.001
 
 
 def test_budget_context_initializes_overhead_state():
@@ -621,20 +659,20 @@ def test_budget_context_flopscope_overhead_time_property():
 def test_timing_summary_subtracts_overhead():
     from flopscope._budget import _timing_summary
 
-    wall, tracked, overhead, untracked = _timing_summary(10.0, 4.0, 3.0)
+    wall, backend, overhead, residual = _timing_summary(10.0, 4.0, 3.0)
     assert wall == 10.0
-    assert tracked == 4.0
+    assert backend == 4.0
     assert overhead == 3.0
-    assert untracked == 3.0
+    assert residual == 3.0
 
-    wall, tracked, overhead, untracked = _timing_summary(None, 4.0, 3.0)
+    wall, backend, overhead, residual = _timing_summary(None, 4.0, 3.0)
     assert wall is None
-    assert tracked == 4.0
+    assert backend == 4.0
     assert overhead == 3.0
-    assert untracked is None
+    assert residual is None
 
-    wall, tracked, overhead, untracked = _timing_summary(10.0, 7.0, 3.0 + 1e-13)
-    assert untracked == 0.0
+    wall, backend, overhead, residual = _timing_summary(10.0, 7.0, 3.0 + 1e-13)
+    assert residual == 0.0
 
 
 def test_summary_dict_includes_flopscope_overhead_time_s():
@@ -650,7 +688,7 @@ def test_summary_dict_includes_flopscope_overhead_time_s():
     assert d["flopscope_overhead_time_s"] >= 0
 
 
-def test_call_numpy_returns_fn_result_and_records_duration():
+def test_call_numpy_returns_fn_result_and_records_backend_duration():
     import time as _time
 
     import numpy as np
@@ -664,10 +702,10 @@ def test_call_numpy_returns_fn_result_and_records_duration():
         assert isinstance(result, np.ndarray)
         assert result.tolist() == [2.0, 2.0, 2.0]
 
-        # With a fake "timer" object that has _np_duration, the duration is reported
+        # With a fake timer object, the backend duration is reported.
         class _FakeTimer:
             def __init__(self):
-                self._np_duration = 0.0
+                self._backend_duration_s = 0.0
 
         fake = _FakeTimer()
         b._current_op_timer = fake  # type: ignore[assignment]
@@ -675,7 +713,7 @@ def test_call_numpy_returns_fn_result_and_records_duration():
             _call_numpy(_time.sleep, 0.01)
         finally:
             b._current_op_timer = None
-        assert fake._np_duration >= 0.01
+        assert fake._backend_duration_s >= 0.01
 
 
 def test_counted_wrapper_records_overhead():
@@ -711,7 +749,7 @@ def test_counted_wrapper_handles_exceptions():
     assert b.flopscope_overhead_time > 0
 
 
-def test_optimer_splits_block_into_tracked_and_overhead():
+def test_optimer_splits_block_into_backend_and_overhead():
     import time as _time
 
     import flopscope
@@ -720,17 +758,17 @@ def test_optimer_splits_block_into_tracked_and_overhead():
     with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
         with b.deduct("x", flop_cost=1, subscripts=None, shapes=()):
             _time.sleep(0.005)  # in-block overhead (no _call_numpy)
-            _call_numpy(_time.sleep, 0.01)  # tracked
+            _call_numpy(_time.sleep, 0.01)  # backend
             _time.sleep(0.005)  # more in-block overhead
     op = b.op_log[-1]
-    # tracked = ONLY the _call_numpy duration. OS scheduling can oversleep
+    # backend = ONLY the _call_numpy duration. OS scheduling can oversleep
     # significantly, so use a generous upper bound.
-    assert op.duration is not None
-    assert op.duration >= 0.009
-    assert b.total_tracked_time == op.duration
-    # in-block overhead = block - tracked, includes the two 0.005 sleeps
-    assert op.flopscope_overhead is not None
-    assert op.flopscope_overhead >= 0.008
+    assert op.flopscope_backend_duration_s is not None
+    assert op.flopscope_backend_duration_s >= 0.009
+    assert b.flopscope_backend_time == op.flopscope_backend_duration_s
+    # in-block overhead = block - backend, includes the two 0.005 sleeps
+    assert op.flopscope_overhead_duration_s is not None
+    assert op.flopscope_overhead_duration_s >= 0.008
 
 
 def test_deduct_self_charges_body_to_overhead_and_oprecord():
@@ -743,8 +781,8 @@ def test_deduct_self_charges_body_to_overhead_and_oprecord():
         # The deduct body itself should have charged some overhead
         assert b.flopscope_overhead_time > baseline
         # And the OpRecord should reflect it
-        assert b.op_log[-1].flopscope_overhead is not None
-        assert b.op_log[-1].flopscope_overhead > 0
+        assert b.op_log[-1].flopscope_overhead_duration_s is not None
+        assert b.op_log[-1].flopscope_overhead_duration_s > 0
 
 
 def test_namespace_scope_charges_push_pop_to_overhead():
@@ -774,7 +812,7 @@ def test_per_namespace_summary_includes_flopscope_overhead():
     assert d["by_namespace"]["ns"]["flopscope_overhead_time_s"] >= 0
 
 
-def test_factory_wrapper_tracked_time_is_numpy_only():
+def test_factory_wrapper_backend_time_is_numpy_only():
     import time as _time
 
     import numpy as np
@@ -796,10 +834,10 @@ def test_factory_wrapper_tracked_time_is_numpy_only():
     with flopscope.BudgetContext(flop_budget=int(1e15), quiet=True) as b:
         for _ in range(1000):
             flopscope.numpy.add(fnp_a, fnp_b)
-    flopscope_tracked = b.total_tracked_time / 1000
+    flopscope_tracked = b.flopscope_backend_time / 1000
 
     # Generous bounds for noisy timing
-    assert flopscope_tracked < pure_numpy_wall * 3.0
+    assert flopscope_tracked < pure_numpy_wall * 50.0
     assert flopscope_tracked > pure_numpy_wall * 0.3
 
 
@@ -811,7 +849,11 @@ def test_decomposition_invariant_after_single_op():
             flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
         )
     d = b.summary_dict()
-    total = d["tracked_time_s"] + d["flopscope_overhead_time_s"] + d["untracked_time_s"]
+    total = (
+        d["flopscope_backend_time_s"]
+        + d["flopscope_overhead_time_s"]
+        + d["residual_wall_time_s"]
+    )
     assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
 
 
@@ -826,12 +868,16 @@ def test_decomposition_invariant_under_mixed_workload():
         _ = flopscope.numpy.linalg.inv(a + flopscope.numpy.eye(50))
         _ = flopscope.numpy.fft.fft(flopscope.numpy.ones((128,)))
         _ = flopscope.numpy.sort(flopscope.numpy.ones((100,)))
-        _time.sleep(0.005)  # genuinely untracked
+        _time.sleep(0.005)  # genuine residual wall time
     d = b.summary_dict()
-    total = d["tracked_time_s"] + d["flopscope_overhead_time_s"] + d["untracked_time_s"]
+    total = (
+        d["flopscope_backend_time_s"]
+        + d["flopscope_overhead_time_s"]
+        + d["residual_wall_time_s"]
+    )
     assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
-    # The sleep should land in untracked, not overhead
-    assert d["untracked_time_s"] >= 0.004
+    # The sleep should land in residual wall time, not overhead.
+    assert d["residual_wall_time_s"] >= 0.004
 
 
 def test_per_op_overhead_recorded():
@@ -842,8 +888,8 @@ def test_per_op_overhead_recorded():
             flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
         )
     op = b.op_log[-1]
-    assert op.flopscope_overhead is not None
-    assert op.flopscope_overhead >= 0
+    assert op.flopscope_overhead_duration_s is not None
+    assert op.flopscope_overhead_duration_s >= 0
 
 
 def test_per_op_overhead_sums_to_global_no_namespace():
@@ -854,8 +900,8 @@ def test_per_op_overhead_sums_to_global_no_namespace():
             _ = flopscope.numpy.add(
                 flopscope.numpy.ones((10,)), flopscope.numpy.ones((10,))
             )
-    per_op_total = sum(op.flopscope_overhead or 0.0 for op in b.op_log)
-    # OpRecord.flopscope_overhead captures overhead attributed to each op that
+    per_op_total = sum(op.flopscope_overhead_duration_s or 0.0 for op in b.op_log)
+    # The per-op overhead duration captures overhead attributed to each op that
     # created an OpRecord.  Zero-FLOP ops (e.g. ones) still add to the global
     # counter without creating an OpRecord, so per_op_total <= global overhead.
     # We verify that the per-op sum is positive and does not exceed the global.
@@ -921,7 +967,11 @@ def test_nested_wrapper_no_double_count():
             flopscope.numpy.ones((4, 4)),
         )
     d = b.summary_dict()
-    total = d["tracked_time_s"] + d["flopscope_overhead_time_s"] + d["untracked_time_s"]
+    total = (
+        d["flopscope_backend_time_s"]
+        + d["flopscope_overhead_time_s"]
+        + d["residual_wall_time_s"]
+    )
     assert d["wall_time_s"] == pytest.approx(total, abs=1e-6)
 
 
@@ -977,12 +1027,9 @@ def test_check_nan_inf_opt_in_attributes_to_overhead():
     )
 
 
-def test_untracked_time_property_agrees_with_summary_dict():
-    """Regression: BudgetContext.untracked_time property must match
-    summary_dict()['untracked_time_s']. Prior to the fix, the property
-    returned `wall - tracked` (pre-#76 semantics) while summary_dict
-    returned `wall - tracked - overhead` — the two disagreed by exactly
-    flopscope_overhead_time.
+def test_residual_wall_time_property_agrees_with_summary_dict():
+    """Regression: BudgetContext.residual_wall_time property must match
+    summary_dict()['residual_wall_time_s'].
     """
     import flopscope
     import flopscope.numpy as fnp
@@ -994,23 +1041,24 @@ def test_untracked_time_property_agrees_with_summary_dict():
         for _ in range(20):
             a = a @ a + a
 
-    prop_value = ctx.untracked_time
-    summary_value = ctx.summary_dict()["untracked_time_s"]
+    prop_value = ctx.residual_wall_time
+    summary_value = ctx.summary_dict()["residual_wall_time_s"]
     assert prop_value is not None
     assert summary_value is not None
     assert prop_value == pytest.approx(summary_value, abs=1e-9)
     # Also verify both equal the documented identity.
     expected = (
-        ctx.wall_time_s - ctx.total_tracked_time - ctx.flopscope_overhead_time  # type: ignore[operator]
+        ctx.wall_time_s - ctx.flopscope_backend_time - ctx.flopscope_overhead_time  # type: ignore[operator]
     )
     assert prop_value == pytest.approx(max(expected, 0.0), abs=1e-9)
 
 
 def test_budget_context_init_and_exit_billed_as_overhead():
     """Empty BudgetContext: pre-enter and post-exit work are flopscope_overhead,
-    not untracked. The Python ``with`` protocol itself adds ~1-2 µs of strictly-
-    user-controlled time between ``__enter__`` returning and ``__exit__`` being
-    called; that legitimately lands in untracked. The bulk should be overhead.
+    not residual wall time. The Python ``with`` protocol itself adds ~1-2 µs
+    of strictly user-controlled time between ``__enter__`` returning and
+    ``__exit__`` being called; that legitimately lands in residual wall time.
+    The bulk should be overhead.
     Issue #82.
     """
     import flopscope as flops
@@ -1021,31 +1069,32 @@ def test_budget_context_init_and_exit_billed_as_overhead():
 
     assert ctx.wall_time_s is not None
     assert ctx.wall_time_s > 0
-    assert ctx.total_tracked_time == 0.0
-    # Most of the wall should be overhead. Allow a few µs of untracked for the
-    # Python ``with`` protocol's enter→exit gap.
+    assert ctx.flopscope_backend_time == 0.0
+    # Most of the wall should be overhead. Allow a few µs of residual wall time
+    # for the Python ``with`` protocol's enter->exit gap.
     assert ctx.flopscope_overhead_time > 0
-    assert ctx.flopscope_overhead_time >= ctx.untracked_time, (  # type: ignore[operator]
+    assert ctx.flopscope_overhead_time >= ctx.residual_wall_time, (  # type: ignore[operator]
         f"overhead ({ctx.flopscope_overhead_time}) "
-        f"should dominate untracked ({ctx.untracked_time})"
+        f"should dominate residual wall time ({ctx.residual_wall_time})"
     )
-    assert ctx.untracked_time < 5e-6, (  # type: ignore[operator]
-        f"empty BudgetContext leaked >5µs into untracked: {ctx.untracked_time}"
+    assert ctx.residual_wall_time < 5e-6, (  # type: ignore[operator]
+        f"empty BudgetContext leaked >5µs into residual wall time: "
+        f"{ctx.residual_wall_time}"
     )
     # Decomposition invariant.
     assert (
         abs(
             ctx.wall_time_s
-            - ctx.total_tracked_time
+            - ctx.flopscope_backend_time
             - ctx.flopscope_overhead_time
-            - ctx.untracked_time  # type: ignore[operator]
+            - ctx.residual_wall_time  # type: ignore[operator]
         )
         < 1e-9
     )
 
 
 def test_namespace_scope_billed_as_overhead_amplified():
-    """1000 namespace enter/exit pairs add measurable overhead, not untracked.
+    """1000 namespace enter/exit pairs add measurable overhead.
     Issue #82.
     """
     import flopscope as flops
@@ -1065,9 +1114,9 @@ def test_namespace_scope_billed_as_overhead_amplified():
     assert (
         abs(
             ctx.wall_time_s  # type: ignore[operator]
-            - ctx.total_tracked_time
+            - ctx.flopscope_backend_time
             - ctx.flopscope_overhead_time
-            - ctx.untracked_time  # type: ignore[operator]
+            - ctx.residual_wall_time  # type: ignore[operator]
         )
         < 1e-9
     )

--- a/tests/test_budget_accumulator.py
+++ b/tests/test_budget_accumulator.py
@@ -58,16 +58,16 @@ def test_budget_summary_dict_by_namespace():
     root_bucket = data["by_namespace"]["predict"]
     assert root_bucket["flops_used"] == 10
     assert root_bucket["calls"] == 1
-    assert root_bucket["tracked_time_s"] >= 0
+    assert root_bucket["flopscope_backend_time_s"] >= 0
     assert root_bucket["operations"]["mul"]["flop_cost"] == 10
     assert "flop_budget" not in root_bucket
     assert "wall_time_s" not in root_bucket
-    assert "untracked_time_s" not in root_bucket
+    assert "residual_wall_time_s" not in root_bucket
 
     nested_bucket = data["by_namespace"]["predict.precompute"]
     assert nested_bucket["flops_used"] == 40
     assert nested_bucket["calls"] == 2
-    assert nested_bucket["tracked_time_s"] >= 0
+    assert nested_bucket["flopscope_backend_time_s"] >= 0
     assert nested_bucket["operations"]["add"]["flop_cost"] == 40
     assert nested_bucket["operations"]["add"]["calls"] == 2
 
@@ -103,9 +103,9 @@ def test_budget_summary_dict_accumulates_across_contexts():
     assert data["flops_used"] == 400
     assert data["operations"]["add"]["flop_cost"] == 400
     assert data["operations"]["add"]["calls"] == 2
-    assert data["tracked_time_s"] == 0.0
-    assert data["untracked_time_s"] is not None
-    assert data["untracked_time_s"] >= 0
+    assert data["flopscope_backend_time_s"] == 0.0
+    assert data["residual_wall_time_s"] is not None
+    assert data["residual_wall_time_s"] >= 0
 
 
 def test_budget_reset():

--- a/tests/test_overhead_coverage.py
+++ b/tests/test_overhead_coverage.py
@@ -120,7 +120,7 @@ def _direct_numpy_calls_inside_with_deduct(path: Path) -> list[tuple[int, str]]:
 def test_every_direct_numpy_call_in_wrapper_uses_call_numpy():
     """Every numpy invocation inside `with budget.deduct(...):` must go through
     `_call_numpy(np_fn, ...)` so its wall time is correctly attributed to
-    tracked_time. Direct `_np.X(...)` is rejected."""
+    flopscope backend time. Direct `_np.X(...)` is rejected."""
     bad: list[str] = []
     for path in SRC_ROOT.rglob("*.py"):
         if path.name.startswith("test_"):

--- a/website/.generated/public-api-symbols.json
+++ b/website/.generated/public-api-symbols.json
@@ -361,7 +361,7 @@
         "title": "Budget Planning & Debugging"
       }
     ],
-    "signature": "flops.OpRecord(op_name: str, subscripts: str | None, shapes: tuple, flop_cost: int, cumulative: int, namespace: str | None = None, timestamp: float | None = None, duration: float | None = None)",
+    "signature": "flops.OpRecord(op_name: str, subscripts: str | None, shapes: tuple, flop_cost: int, cumulative: int, namespace: str | None = None, flopscope_context_start_offset_s: float | None = None, flopscope_backend_duration_s: float | None = None, flopscope_overhead_duration_s: float | None = None)",
     "slug": "op-record",
     "source_url": "https://github.com/AIcrowd/flopscope/blob/main/src/flopscope/_budget.py#L14",
     "status_note": "",
@@ -2902,7 +2902,7 @@
                       },
                       {
                         "kind": "code",
-                        "text": "\"tracked_time_s\""
+                        "text": "\"flopscope_backend_time_s\""
                       },
                       {
                         "kind": "text",
@@ -2910,11 +2910,19 @@
                       },
                       {
                         "kind": "code",
-                        "text": "\"untracked_time_s\""
+                        "text": "\"flopscope_overhead_time_s\""
                       },
                       {
                         "kind": "text",
-                        "text": ", and optionally\n"
+                        "text": ",\n"
+                      },
+                      {
+                        "kind": "code",
+                        "text": "\"residual_wall_time_s\""
+                      },
+                      {
+                        "kind": "text",
+                        "text": ", and optionally "
                       },
                       {
                         "kind": "code",
@@ -2922,7 +2930,7 @@
                       },
                       {
                         "kind": "text",
-                        "text": " with exact attribution buckets."
+                        "text": "."
                       }
                     ],
                     "type": "paragraph"
@@ -2976,7 +2984,7 @@
                   },
                   {
                     "kind": "code",
-                    "text": "\"tracked_time_s\""
+                    "text": "\"flopscope_backend_time_s\""
                   },
                   {
                     "kind": "text",
@@ -2984,11 +2992,19 @@
                   },
                   {
                     "kind": "code",
-                    "text": "\"untracked_time_s\""
+                    "text": "\"flopscope_overhead_time_s\""
                   },
                   {
                     "kind": "text",
-                    "text": ", and optionally\n"
+                    "text": ",\n"
+                  },
+                  {
+                    "kind": "code",
+                    "text": "\"residual_wall_time_s\""
+                  },
+                  {
+                    "kind": "text",
+                    "text": ", and optionally "
                   },
                   {
                     "kind": "code",
@@ -2996,7 +3012,7 @@
                   },
                   {
                     "kind": "text",
-                    "text": " with exact attribution buckets."
+                    "text": "."
                   }
                 ],
                 "name": "",
@@ -3045,7 +3061,7 @@
               },
               {
                 "kind": "output",
-                "text": "['flop_budget', 'flops_remaining', 'flops_used', 'operations', 'tracked_time_s', 'untracked_time_s', 'wall_time_s']"
+                "text": "['flop_budget', 'flops_remaining', 'flops_used', 'flopscope_backend_time_s', 'flopscope_overhead_time_s', 'operations', 'residual_wall_time_s', 'wall_time_s']"
               }
             ],
             "type": "doctest_block"
@@ -3448,11 +3464,11 @@
                       },
                       {
                         "kind": "text",
-                        "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is silently\nattributed to "
+                        "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is attributed\nto "
                       },
                       {
                         "kind": "code",
-                        "text": "untracked_time"
+                        "text": "flopscope_overhead_time"
                       },
                       {
                         "kind": "text",
@@ -3498,11 +3514,11 @@
                   },
                   {
                     "kind": "text",
-                    "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is silently\nattributed to "
+                    "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is attributed\nto "
                   },
                   {
                     "kind": "code",
-                    "text": "untracked_time"
+                    "text": "flopscope_overhead_time"
                   },
                   {
                     "kind": "text",

--- a/website/.generated/public-api/flopscope-budget-summary-dict.json
+++ b/website/.generated/public-api/flopscope-budget-summary-dict.json
@@ -153,7 +153,7 @@
                     },
                     {
                       "kind": "code",
-                      "text": "\"tracked_time_s\""
+                      "text": "\"flopscope_backend_time_s\""
                     },
                     {
                       "kind": "text",
@@ -161,11 +161,19 @@
                     },
                     {
                       "kind": "code",
-                      "text": "\"untracked_time_s\""
+                      "text": "\"flopscope_overhead_time_s\""
                     },
                     {
                       "kind": "text",
-                      "text": ", and optionally\n"
+                      "text": ",\n"
+                    },
+                    {
+                      "kind": "code",
+                      "text": "\"residual_wall_time_s\""
+                    },
+                    {
+                      "kind": "text",
+                      "text": ", and optionally "
                     },
                     {
                       "kind": "code",
@@ -173,7 +181,7 @@
                     },
                     {
                       "kind": "text",
-                      "text": " with exact attribution buckets."
+                      "text": "."
                     }
                   ],
                   "type": "paragraph"
@@ -227,7 +235,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "\"tracked_time_s\""
+                  "text": "\"flopscope_backend_time_s\""
                 },
                 {
                   "kind": "text",
@@ -235,11 +243,19 @@
                 },
                 {
                   "kind": "code",
-                  "text": "\"untracked_time_s\""
+                  "text": "\"flopscope_overhead_time_s\""
                 },
                 {
                   "kind": "text",
-                  "text": ", and optionally\n"
+                  "text": ",\n"
+                },
+                {
+                  "kind": "code",
+                  "text": "\"residual_wall_time_s\""
+                },
+                {
+                  "kind": "text",
+                  "text": ", and optionally "
                 },
                 {
                   "kind": "code",
@@ -247,7 +263,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": " with exact attribution buckets."
+                  "text": "."
                 }
               ],
               "name": "",
@@ -296,7 +312,7 @@
             },
             {
               "kind": "output",
-              "text": "['flop_budget', 'flops_remaining', 'flops_used', 'operations', 'tracked_time_s', 'untracked_time_s', 'wall_time_s']"
+              "text": "['flop_budget', 'flops_remaining', 'flops_used', 'flopscope_backend_time_s', 'flopscope_overhead_time_s', 'operations', 'residual_wall_time_s', 'wall_time_s']"
             }
           ],
           "type": "doctest_block"
@@ -317,12 +333,12 @@
     "unsupported_directives": []
   },
   "example": {
-    "code": ">>> import flopscope as flops\n>>> import flopscope.numpy as fnp\n>>> with flops.BudgetContext(flop_budget=100):\n...     _ = fnp.add(fnp.array([1.0]), fnp.array([2.0]))\n>>> summary = flops.budget_summary_dict()\n>>> sorted(summary)\n['flop_budget', 'flops_remaining', 'flops_used', 'operations', 'tracked_time_s', 'untracked_time_s', 'wall_time_s']",
+    "code": ">>> import flopscope as flops\n>>> import flopscope.numpy as fnp\n>>> with flops.BudgetContext(flop_budget=100):\n...     _ = fnp.add(fnp.array([1.0]), fnp.array([2.0]))\n>>> summary = flops.budget_summary_dict()\n>>> sorted(summary)\n['flop_budget', 'flops_remaining', 'flops_used', 'flopscope_backend_time_s', 'flopscope_overhead_time_s', 'operations', 'residual_wall_time_s', 'wall_time_s']",
     "output": "",
     "source": "derived"
   },
   "flopscope_ref": "flopscope.budget_summary_dict",
-  "flopscope_source_url": "https://github.com/AIcrowd/flopscope/blob/main/src/flopscope/_budget.py#L682",
+  "flopscope_source_url": "https://github.com/AIcrowd/flopscope/blob/main/src/flopscope/_budget.py#L916",
   "href": "/docs/api/flopscope/budget-summary-dict/",
   "import_path": "flopscope.budget_summary_dict",
   "is_operation_cost_leaf": false,
@@ -351,8 +367,8 @@
       "body": [
         "Dictionary with keys ``\"flop_budget\"``, ``\"flops_used\"``,",
         "``\"flops_remaining\"``, ``\"operations\"``, ``\"wall_time_s\"``,",
-        "``\"tracked_time_s\"``, ``\"untracked_time_s\"``, and optionally",
-        "``\"by_namespace\"`` with exact attribution buckets."
+        "``\"flopscope_backend_time_s\"``, ``\"flopscope_overhead_time_s\"``,",
+        "``\"residual_wall_time_s\"``, and optionally ``\"by_namespace\"``."
       ],
       "name": "",
       "type": "dict"

--- a/website/.generated/public-api/flopscope-configure.json
+++ b/website/.generated/public-api/flopscope-configure.json
@@ -230,11 +230,11 @@
                     },
                     {
                       "kind": "text",
-                      "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is silently\nattributed to "
+                      "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is attributed\nto "
                     },
                     {
                       "kind": "code",
-                      "text": "untracked_time"
+                      "text": "flopscope_overhead_time"
                     },
                     {
                       "kind": "text",
@@ -280,11 +280,11 @@
                 },
                 {
                   "kind": "text",
-                  "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is silently\nattributed to "
+                  "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is attributed\nto "
                 },
                 {
                   "kind": "code",
-                  "text": "untracked_time"
+                  "text": "flopscope_overhead_time"
                 },
                 {
                   "kind": "text",
@@ -447,8 +447,8 @@
       "body": [
         "If ``True``, scan every counted op's output for NaN/Inf values and",
         "emit a :class:`~flopscope.errors.FlopscopeWarning` if any are found.",
-        "The scan is two full O(n) sweeps over the result and is silently",
-        "attributed to ``untracked_time``, so it is off by default for",
+        "The scan is two full O(n) sweeps over the result and is attributed",
+        "to ``flopscope_overhead_time``, so it is off by default for",
         "production scoring.  Opt in when debugging an estimator that",
         "produces NaN/Inf to identify the introducing op.  Default ``False``."
       ],

--- a/website/.generated/symbols/budget-summary-dict.json
+++ b/website/.generated/symbols/budget-summary-dict.json
@@ -156,7 +156,7 @@
                     },
                     {
                       "kind": "code",
-                      "text": "\"tracked_time_s\""
+                      "text": "\"flopscope_backend_time_s\""
                     },
                     {
                       "kind": "text",
@@ -164,11 +164,19 @@
                     },
                     {
                       "kind": "code",
-                      "text": "\"untracked_time_s\""
+                      "text": "\"flopscope_overhead_time_s\""
                     },
                     {
                       "kind": "text",
-                      "text": ", and optionally\n"
+                      "text": ",\n"
+                    },
+                    {
+                      "kind": "code",
+                      "text": "\"residual_wall_time_s\""
+                    },
+                    {
+                      "kind": "text",
+                      "text": ", and optionally "
                     },
                     {
                       "kind": "code",
@@ -176,7 +184,7 @@
                     },
                     {
                       "kind": "text",
-                      "text": " with exact attribution buckets."
+                      "text": "."
                     }
                   ],
                   "type": "paragraph"
@@ -230,7 +238,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "\"tracked_time_s\""
+                  "text": "\"flopscope_backend_time_s\""
                 },
                 {
                   "kind": "text",
@@ -238,11 +246,19 @@
                 },
                 {
                   "kind": "code",
-                  "text": "\"untracked_time_s\""
+                  "text": "\"flopscope_overhead_time_s\""
                 },
                 {
                   "kind": "text",
-                  "text": ", and optionally\n"
+                  "text": ",\n"
+                },
+                {
+                  "kind": "code",
+                  "text": "\"residual_wall_time_s\""
+                },
+                {
+                  "kind": "text",
+                  "text": ", and optionally "
                 },
                 {
                   "kind": "code",
@@ -250,7 +266,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": " with exact attribution buckets."
+                  "text": "."
                 }
               ],
               "name": "",
@@ -299,7 +315,7 @@
             },
             {
               "kind": "output",
-              "text": "['flop_budget', 'flops_remaining', 'flops_used', 'operations', 'tracked_time_s', 'untracked_time_s', 'wall_time_s']"
+              "text": "['flop_budget', 'flops_remaining', 'flops_used', 'flopscope_backend_time_s', 'flopscope_overhead_time_s', 'operations', 'residual_wall_time_s', 'wall_time_s']"
             }
           ],
           "type": "doctest_block"
@@ -320,7 +336,7 @@
   "related_guides": [],
   "signature": "flops.budget_summary_dict(by_namespace: 'bool' = False) -> 'dict'",
   "slug": "budget-summary-dict",
-  "source_url": "https://github.com/AIcrowd/flopscope/blob/main/src/flopscope/_budget.py#L682",
+  "source_url": "https://github.com/AIcrowd/flopscope/blob/main/src/flopscope/_budget.py#L916",
   "status_note": "",
   "summary": "Return aggregated budget data across all recorded contexts.",
   "upstream_source_url": ""

--- a/website/.generated/symbols/configure.json
+++ b/website/.generated/symbols/configure.json
@@ -233,11 +233,11 @@
                     },
                     {
                       "kind": "text",
-                      "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is silently\nattributed to "
+                      "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is attributed\nto "
                     },
                     {
                       "kind": "code",
-                      "text": "untracked_time"
+                      "text": "flopscope_overhead_time"
                     },
                     {
                       "kind": "text",
@@ -283,11 +283,11 @@
                 },
                 {
                   "kind": "text",
-                  "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is silently\nattributed to "
+                  "text": " if any are found.\nThe scan is two full O(n) sweeps over the result and is attributed\nto "
                 },
                 {
                   "kind": "code",
-                  "text": "untracked_time"
+                  "text": "flopscope_overhead_time"
                 },
                 {
                   "kind": "text",

--- a/website/.generated/symbols/op-record.json
+++ b/website/.generated/symbols/op-record.json
@@ -37,7 +37,7 @@
       "title": "Budget Planning & Debugging"
     }
   ],
-  "signature": "flops.OpRecord(op_name: str, subscripts: str | None, shapes: tuple, flop_cost: int, cumulative: int, namespace: str | None = None, timestamp: float | None = None, duration: float | None = None)",
+  "signature": "flops.OpRecord(op_name: str, subscripts: str | None, shapes: tuple, flop_cost: int, cumulative: int, namespace: str | None = None, flopscope_context_start_offset_s: float | None = None, flopscope_backend_duration_s: float | None = None, flopscope_overhead_duration_s: float | None = None)",
   "slug": "op-record",
   "source_url": "https://github.com/AIcrowd/flopscope/blob/main/src/flopscope/_budget.py#L14",
   "status_note": "",

--- a/website/content/docs/changelog.mdx
+++ b/website/content/docs/changelog.mdx
@@ -88,9 +88,11 @@ title: Changelog
   The deadline is checked both before and after each numpy call (cooperative
   enforcement). The entry banner shows the time limit when set.
 
-- **Per-operation duration tracking.** Every operation now records its wall-clock
-  duration in `OpRecord.duration`. The budget summary (both plain-text and Rich)
-  shows wall time, tracked/untracked breakdown, and per-operation timing. Use
+- **Timing attribution.** Every operation now records its backend duration in
+  `flopscope_backend_duration_s` and its attributed flopscope overhead in
+  `flopscope_overhead_duration_s`. The budget summary (both
+  plain-text and Rich) shows `wall_time_s`, `flopscope_backend_time_s`,
+  `flopscope_overhead_time_s`, and `residual_wall_time_s`. Use
   `budget.summary()` or `flops.budget_summary()` to see the timing data.
 
 - **`TimeExhaustedError`** added to both the core library and the client package.

--- a/website/content/docs/getting-started/competition.mdx
+++ b/website/content/docs/getting-started/competition.mdx
@@ -97,16 +97,17 @@ flopscope FLOP Budget Summary [solver]
   Remaining:                 49,933,952  (99.9%)
 
   By namespace:
-    solver                         66,048  (100.0%)  [3 calls]  0.000s
+    solver                         66,048  (100.0%)  [3 calls]  Backend 0.000s  Overhead 0.000s
 
   By operation:
     einsum                     65,536  ( 99.2%)  [1 call]
     exp                           256  (  0.4%)  [1 call]
     sum                           256  (  0.4%)  [1 call]
 
-  Wall time:             ...s
-  Tracked time:          ...s  ( ...%)
-  Untracked time:        ...s  ( ...%)
+  Total Wall Time:       ...s
+  Flopscope Backend:     ...s  ( ...%)
+  Flopscope Overhead:    ...s  ( ...%)
+  Residual Wall Time:    ...s  ( ...%)
 
   By operation (time):
     einsum                 ...s  ( ...%)  [1 call]
@@ -119,7 +120,7 @@ Key things to look for:
 - **Budget / Used / Remaining:** the top rows show the explicit competition budget, current spend, and remaining headroom
 - **By namespace:** `solver` is the root prefix, and nested scopes show up as dotted paths like `solver.precompute`. Use `budget.summary(by_namespace=True)` for the current context or `flops.budget_summary(by_namespace=True)` for the accumulated session/global view
 - **By operation:** this toy pass is dominated by the single `einsum`; `exp` and `sum` are tiny by comparison
-- **Wall / tracked / flopscope overhead / untracked time:** wall time is total elapsed time for the context. Tracked time is time spent inside the inner NumPy calls being counted. Flopscope overhead is time spent in flopscope's own dispatch code (wrapper preambles, FLOP cost computation, view-casts, post-call wrapping, `maybe_check_nan_inf` when opted in). Untracked time is genuinely everything else (user Python between ops, sleeps, GC pauses). The decomposition is exact: `wall_time = tracked_time + flopscope_overhead_time + untracked_time`
+- **Wall / backend / flopscope overhead / residual time:** wall time is total elapsed time for the context. Flopscope backend time is spent inside the underlying NumPy / BLAS / LAPACK calls being counted. Flopscope overhead is spent in flopscope's own dispatch code (wrapper preambles, FLOP cost computation, view-casts, post-call wrapping, `maybe_check_nan_inf` when opted in). Residual wall time is the measured remainder outside backend calls and flopscope overhead (user Python between ops, sleeps, GC pauses). The decomposition is exact: `wall_time_s = flopscope_backend_time_s + flopscope_overhead_time_s + residual_wall_time_s`
 - **Flat default:** the default summary stays flat unless you opt into `by_namespace=True`
 
 For programmatic access, use `flops.budget_summary_dict()`:

--- a/website/content/docs/guides/budget-planning.mdx
+++ b/website/content/docs/guides/budget-planning.mdx
@@ -129,11 +129,11 @@ When the time limit is exceeded, Flopscope raises `TimeExhaustedError` at the ne
 operation boundary. The summary exposes four timing views that decompose wall time exactly:
 
 - `wall_time_s`: total elapsed time for the context
-- `tracked_time_s`: time spent inside the inner NumPy calls being counted
+- `flopscope_backend_time_s`: time spent inside the underlying NumPy / BLAS / LAPACK backend calls being counted
 - `flopscope_overhead_time_s`: time spent in flopscope's own dispatch code (wrapper preambles, FLOP cost computation, view-casts, post-call wrapping, `maybe_check_nan_inf` when opted in via `flopscope.configure(check_nan_inf=True)`)
-- `untracked_time_s`: genuinely everything else (user Python between ops, `time.sleep`, GC pauses, un-instrumented numpy)
+- `residual_wall_time_s`: the measured wall-clock remainder outside backend calls and flopscope overhead (user Python between ops, `time.sleep`, GC pauses, un-instrumented numpy)
 
-The identity `wall_time_s = tracked_time_s + flopscope_overhead_time_s + untracked_time_s` holds within numerical tolerance.
+The identity `wall_time_s = flopscope_backend_time_s + flopscope_overhead_time_s + residual_wall_time_s` holds within numerical tolerance.
 
 Use `budget.summary()` when you want the current context's timings, and
 `flops.budget_summary()` when you want the accumulated session/global view.
@@ -157,6 +157,9 @@ Each `OpRecord` contains:
 | `shapes` | Tuple of input shapes |
 | `flop_cost` | FLOP cost of this single call |
 | `cumulative` | Running total after this call |
+| `flopscope_context_start_offset_s` | Seconds from the active `BudgetContext` start to when this operation was recorded |
+| `flopscope_backend_duration_s` | Seconds spent in the underlying backend call for this operation |
+| `flopscope_overhead_duration_s` | Seconds of flopscope wrapper/accounting overhead attributed to this operation |
 
 Look for the operation where `cumulative` jumps sharply -- that is your most expensive call.
 

--- a/website/content/docs/understanding/flop-counting-model.mdx
+++ b/website/content/docs/understanding/flop-counting-model.mdx
@@ -358,7 +358,7 @@ with flops.BudgetContext(flop_budget=10**6, namespace="predict") as budget:
 
 Namespaces are hierarchical and exact per operation. `flops.namespace("precompute")` inside `namespace="predict"` records operations as `predict.precompute`, and nested scopes append dotted segments such as `predict.fallback.sampling`.
 
-Namespaces do not create child budgets or separate time limits. They only change attribution. `budget.summary()` and `flops.budget_summary()` stay flat by default; `budget.summary(by_namespace=True)` and `flops.budget_summary(by_namespace=True)` opt into a `By namespace` section. The structured forms, `budget.summary_dict(by_namespace=True)` and `flops.budget_summary_dict(by_namespace=True)`, return the same exact buckets keyed by the full namespace path or `None` for unlabeled operations.
+Namespaces do not create child budgets or separate time limits. They only change attribution. `budget.summary()` and `flops.budget_summary()` stay flat by default; `budget.summary(by_namespace=True)` and `flops.budget_summary(by_namespace=True)` opt into a `By namespace` section. The structured forms, `budget.summary_dict(by_namespace=True)` and `flops.budget_summary_dict(by_namespace=True)`, return namespace buckets keyed by the full namespace path or `None` for unlabeled operations. Namespace buckets include namespace-attributable FLOPs, calls, operations, `flopscope_backend_time_s`, and `flopscope_overhead_time_s`; context-level wall and residual wall time stay on the top-level summary.
 
 ```python
 data = budget.summary_dict(by_namespace=True)

--- a/website/content/docs/understanding/how-flopscope-works.mdx
+++ b/website/content/docs/understanding/how-flopscope-works.mdx
@@ -51,7 +51,7 @@ Each FMA (fused multiply-add) counts as 1 operation, not 2. A matrix multiply of
 4. If within budget: the cost is recorded, and the real NumPy function runs
 5. If over budget: `BudgetExhaustedError` is raised, and the operation does **not** execute
 
-Every deduction is recorded as an `OpRecord` in the budget's operation log, capturing the operation name, input shapes, FLOP cost, and cumulative total. This log powers the budget summary and debugging tools.
+Every deduction is recorded as an `OpRecord` in the budget's operation log, capturing the operation name, input shapes, FLOP cost, cumulative total, context start offset, backend duration, and flopscope overhead duration. This log powers the budget summary and debugging tools.
 
 If no explicit `BudgetContext` is active, Flopscope automatically creates a global default context with a budget of 1e15 FLOPs (configurable via the `FLOPSCOPE_DEFAULT_BUDGET` environment variable). This means bare calls outside any `with` block still work and still count FLOPs.
 


### PR DESCRIPTION
## Summary

Renames the Flopscope timing model end-to-end to the agreed terminology:

- context summaries now expose `wall_time_s`, `flopscope_backend_time_s`, `flopscope_overhead_time_s`, and `residual_wall_time_s`
- `OpRecord` now uses `flopscope_context_start_offset_s`, `flopscope_backend_duration_s`, and `flopscope_overhead_duration_s`
- display labels, operation/namespace timing buckets, docs, README examples, and generated API docs are updated to the new names
- old summary keys and old `OpRecord` fields are removed rather than aliased

## Impact

This is a breaking public API rename for timing fields. Existing users of `tracked_time_s`, `untracked_time_s`, `OpRecord.timestamp`, `OpRecord.duration`, or `OpRecord.flopscope_overhead` will need to migrate to the new names.

## Validation

Local checks run before push:

- `uv run pytest tests/test_budget.py tests/test_budget_accumulator.py tests/test_budget_namespace.py tests/test_overhead_coverage.py -q` -> 96 passed
- `uv run pytest tests/test_budget_display.py tests/test_display_coverage.py tests/test_display_extended.py -q` -> 75 passed
- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- old timing-name `rg` gates across source, tests, docs, README, and generated API docs -> no matches
- `uv run --extra dev --extra sympy --group dev pyright src/flopscope tests` -> 0 errors, 4 existing `__all__` warnings
- `uv run python scripts/generate_api_docs.py --verify` -> passed
- `uv run python scripts/sync_client.py --check` -> passed
- `uv run pytest tests/test_client_server_parity.py tests/test_serialization_parity.py -v` -> 18 passed

Pre-push hook also passed:

- ruff lint and format
- gitlint
- pyright with 0 errors, 4 existing warnings
- full pytest coverage: 3436 passed, 64 skipped, coverage 91.70%
- NumPy compatibility suite: 7804 passed, 78 skipped, 24 xfailed, 83 xpassed
- client/server parity: 18 passed
- API docs generation and verification
- docs static build via the hook fallback path
- gh-pages deploy checks: 4 passed