### PR TITLE
Rename masthead eyebrow to "An interactive walkthrough"

### DIFF
--- a/website/components/symmetry-aware-einsum-contractions/SymmetryAwareEinsumContractionsApp.jsx
+++ b/website/components/symmetry-aware-einsum-contractions/SymmetryAwareEinsumContractionsApp.jsx
@@ -741,7 +741,7 @@ export default function SymmetryAwareEinsumContractionsApp() {
             style={{ letterSpacing: '0.2em' }}
 	          >
 	            <span aria-hidden className="mr-2 inline-block h-px w-8 align-middle bg-gray-300" />
-	            An interactive paper
+	            An interactive walkthrough
           </div>
 
           <h1

--- a/website/components/symmetry-aware-einsum-contractions/content/main/preamble.js
+++ b/website/components/symmetry-aware-einsum-contractions/content/main/preamble.js
@@ -2,7 +2,7 @@ const p = (text) => ({ kind: 'paragraph', text });
 
 const preamble = {
   title: 'Counting symmetry-aware einsums',
-  deck: 'Multiply once; accumulate wherever the orbit projects. This interactive paper counts exact direct events as representative-product multiplication chains plus $O \\to Q$ accumulation updates.',
+  deck: 'Multiply once; accumulate wherever the orbit projects. This interactive walkthrough counts exact direct events as representative-product multiplication chains plus $O \\to Q$ accumulation updates.',
   slots: {
     einsumIntroBeforeSummed: [
       p('A direct einsum visits assignments of index labels. Labels that appear on inputs but not on the output are '),

--- a/website/symmetry-explorer.route.test.mjs
+++ b/website/symmetry-explorer.route.test.mjs
@@ -76,7 +76,7 @@ test('masthead lands the result and appendix transition exposes an A-E map', () 
     'utf8',
   );
 
-  assert.match(appSource, /An interactive paper/);
+  assert.match(appSource, /An interactive walkthrough/);
   assert.match(appSource, /Counting symmetry-aware einsums/);
   assert.match(appSource, /Symmetry can turn many label assignments into one representative product/);
   assert.match(appSource, /reuse is only half the cost/);


### PR DESCRIPTION
## Summary
- Masthead eyebrow above the H1: "An interactive paper" → "An interactive walkthrough"
- Preamble deck: "This interactive paper counts …" → "This interactive walkthrough counts …" (so prose matches the eyebrow)
- Atomic test retarget on `symmetry-explorer.route.test.mjs:79`

## Test plan
- [ ] CI green
- [ ] `npm test` → 1034/1034 (verified)
- [ ] `npm run build` → green (verified)