### PR TITLE
fix(#66): propagate symmetry through None/np.newaxis indexing

### DIFF
--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -11,6 +11,7 @@ from flopscope._ndarray import FlopscopeArray, _asplainflopscope
 from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetry_utils import (
     broadcast_group,
+    inserted_axes_symmetry,
     intersect_groups,
     normalize_symmetry_input,
     reduce_group,
@@ -416,6 +417,22 @@ def propagate_symmetry_slice(
         if final is None:
             continue
         new_groups.append(final)
+
+    # Build the inserted-axis group from freshly-inserted None positions.
+    inserted_output_positions: list[int] = []
+    out_idx = 0
+    for k in key_expanded:
+        if k is None:
+            inserted_output_positions.append(out_idx)
+            out_idx += 1
+        elif isinstance(k, (int, np.integer)):
+            pass  # axis removed; no output slot
+        else:
+            out_idx += 1
+
+    inserted_group = inserted_axes_symmetry(inserted_output_positions)
+    if inserted_group is not None:
+        new_groups.append(inserted_group)
 
     return new_groups if new_groups else None
 

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -653,10 +653,23 @@ class SymmetricTensor(FlopscopeArray):
         new_groups = propagate_symmetry_slice([self._symmetry], self.shape, key)
         new_symmetry = _merge_symmetry_groups(new_groups or [])
         if new_groups is not None:
-            if new_symmetry != self._symmetry and self._symmetry.axes is not None:
+            # Fire only on real structural reduction: the new group's order is
+            # strictly less than the original's. This silences false alarms on
+            # operations that gain symmetry (e.g. `a[None, :, None, :]`
+            # produces a richer Young group) or merely relabel axes without
+            # losing structure (e.g. `a[None, :, :]` shifts axes, preserves
+            # order). It under-fires on the rare case where original sym is
+            # broken and a same-order new group is gained on different axes;
+            # the gained group is still attached to the result so a careful
+            # user can inspect `.symmetry` directly.
+            if (
+                new_symmetry is not None
+                and self._symmetry.axes is not None
+                and new_symmetry.order() < self._symmetry.order()
+            ):
                 _warn_symmetry_loss(
                     [self._symmetry.axes],
-                    "slicing changed dim sizes or removed dims",
+                    "slicing reduced symmetric group structure",
                 )
             return _wrap_tensor_result(np.asarray(result), new_symmetry)
 

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -296,7 +296,11 @@ def propagate_symmetry_slice(
         key = (key,)
 
     for k in key:
-        if isinstance(k, (np.ndarray, list)):
+        # Bool indices are boolean masks in numpy (add a size-1 batch axis for
+        # True / size-0 for False), not integer scalars. `isinstance(True, int)`
+        # is also True in Python, so we must check bool BEFORE the int branch
+        # below would silently misclassify it as an integer scalar index.
+        if isinstance(k, (np.ndarray, list, bool, np.bool_)):
             return None
 
     # Expand Ellipsis.

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -636,6 +636,14 @@ class SymmetricTensor(FlopscopeArray):
             return result if not isinstance(result, np.ndarray) else np.asarray(result)
 
         if self._symmetry is None:
+            # Even with no input symmetry, multiple inserted None axes form a
+            # free symmetric group on those axes. Run the propagator with an
+            # empty groups list so the inserted-axis logic still fires.
+            new_groups = propagate_symmetry_slice([], self.shape, key)
+            if new_groups:
+                return _wrap_tensor_result(
+                    np.asarray(result), _merge_symmetry_groups(new_groups)
+                )
             return _asplainflopscope(np.asarray(result))
 
         new_groups = propagate_symmetry_slice([self._symmetry], self.shape, key)

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -220,9 +220,7 @@ def remap_group_for_expand_dims(
     inserted_axes = tuple(
         axis_idx for axis_idx, size in enumerate(expanded_shape) if size == 1
     )
-    inserted = None
-    if len(inserted_axes) >= 2:
-        inserted = SymmetryGroup.symmetric(axes=inserted_axes)
+    inserted = inserted_axes_symmetry(inserted_axes)
     return direct_product_groups(remapped, inserted)
 
 

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import math
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -224,6 +224,21 @@ def remap_group_for_expand_dims(
     if len(inserted_axes) >= 2:
         inserted = SymmetryGroup.symmetric(axes=inserted_axes)
     return direct_product_groups(remapped, inserted)
+
+
+def inserted_axes_symmetry(
+    inserted_positions: Sequence[int],
+) -> SymmetryGroup | None:
+    """Symmetry of N freshly-inserted size-1 axes at the given output positions.
+
+    Used by axis-inserting operations (``expand_dims``, ``__getitem__`` with
+    ``None``/``np.newaxis``). Returns ``None`` for fewer than 2 positions
+    (no non-trivial group). For 2+, returns
+    ``SymmetryGroup.symmetric(axes=tuple(inserted_positions))``.
+    """
+    if len(inserted_positions) < 2:
+        return None
+    return SymmetryGroup.symmetric(axes=tuple(inserted_positions))
 
 
 def intersect_groups(

--- a/tests/test_free_ops_extended.py
+++ b/tests/test_free_ops_extended.py
@@ -144,15 +144,15 @@ def test_expand_dims_duplicate_axes_match_numpy():
     assert type(ours.value) is type(numpy_err.value)
 
 
-def test_expand_dims_can_be_richer_than_newaxis_slicing():
+def test_newaxis_slicing_matches_expand_dims():
     a = fnp.eye(3)
     by_fn = ops.expand_dims(a, axis=(0, 2))
     by_slice = a[None, :, None, :]
     assert isinstance(by_fn, SymmetricTensor)
     assert isinstance(by_slice, SymmetricTensor)
     assert numpy.array_equal(by_fn, by_slice)
-    assert by_fn.symmetry == flops.SymmetryGroup.young(blocks=((0, 2), (1, 3)))
-    assert by_slice.symmetry == flops.SymmetryGroup.symmetric(axes=(1, 3))
+    assert by_slice.symmetry == by_fn.symmetry
+    assert by_slice.symmetry == flops.SymmetryGroup.young(blocks=((0, 2), (1, 3)))
 
 
 def test_vstack():

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -1,0 +1,41 @@
+"""Regression tests for issue #66: propagate symmetry through None/np.newaxis indexing.
+
+See .aicrowd/superpowers/specs/2026-05-22-issue-66-newaxis-symmetry-design.md.
+"""
+
+import numpy
+import pytest
+
+import flopscope as flops
+import flopscope._free_ops as ops
+import flopscope.numpy as fnp
+from flopscope import SymmetryGroup
+from flopscope._symmetry_utils import inserted_axes_symmetry
+
+
+# ---------------------------------------------------------------------------
+# inserted_axes_symmetry() unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_inserted_axes_symmetry_returns_none_for_empty():
+    assert inserted_axes_symmetry([]) is None
+
+
+def test_inserted_axes_symmetry_returns_none_for_single_position():
+    assert inserted_axes_symmetry([5]) is None
+
+
+def test_inserted_axes_symmetry_returns_symmetric_pair_for_two_positions():
+    expected = SymmetryGroup.symmetric(axes=(0, 2))
+    assert inserted_axes_symmetry([0, 2]) == expected
+
+
+def test_inserted_axes_symmetry_returns_symmetric_triple_for_three_positions():
+    expected = SymmetryGroup.symmetric(axes=(1, 3, 5))
+    assert inserted_axes_symmetry([1, 3, 5]) == expected
+
+
+def test_inserted_axes_symmetry_accepts_tuple_input():
+    expected = SymmetryGroup.symmetric(axes=(0, 4))
+    assert inserted_axes_symmetry((0, 4)) == expected

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -78,9 +78,10 @@ def test_single_none_builds_no_inserted_group():
     assert by_slice.symmetry == SymmetryGroup.symmetric(axes=(1, 2))
 
 
-def test_preexisting_size_one_not_lumped_with_inserted():
-    """A (3,1) SymmetricTensor indexed [None, :, None] makes only the two fresh
-    Nones symmetric, NOT lumping with the pre-existing size-1 axis.
+def test_preexisting_size_one_not_lumped_when_no_input_symmetry():
+    """No-input-symmetry path: a (3,1) view-as-SymmetricTensor indexed
+    [None, :, None] gives sym((0, 2)) over the two fresh Nones, NOT
+    sym((0, 2, 3)) which would also include the pre-existing size-1.
 
     Note: fnp.zeros returns a FlopscopeArray (not SymmetricTensor), which
     doesn't go through our __getitem__ path. We use .view(SymmetricTensor)
@@ -94,8 +95,54 @@ def test_preexisting_size_one_not_lumped_with_inserted():
     assert tensor._symmetry is None
     by_slice = tensor[None, :, None]
     assert by_slice.shape == (1, 3, 1, 1)
-    # Inserted axes [0, 2]. Pre-existing size-1 at axis 3 is NOT lumped.
+    # Inserted axes [0, 2]. Pre-existing size-1 at output axis 3 is NOT lumped.
     assert getattr(by_slice, "symmetry", None) == SymmetryGroup.symmetric(axes=(0, 2))
+
+
+def test_preexisting_size_one_not_lumped_with_existing_symmetry():
+    """A SymmetricTensor with non-trivial symmetry AND a pre-existing size-1
+    axis: indexing with Nones produces a direct product of the remapped original
+    sym and the inserted-axis sym, with the pre-existing size-1 axis excluded
+    from both. This is the case the "not lumped" rule is really about.
+
+    Input: shape (3, 1, 3) with sym((0, 2)); axis 1 is the pre-existing size-1.
+    Key:   [None, :, :, None, :]
+    Output: shape (1, 3, 1, 1, 3); pre-existing size-1 lands at output axis 2.
+    Expected:
+      - remapped original sym → sym((1, 4))  (input axes 0, 2 → output axes 1, 4)
+      - inserted axes (None positions 0, 3 in output) → sym((0, 3))
+      - Output axis 2 (the pre-existing size-1) is in NEITHER group.
+    """
+    sym_matrix = numpy.array(
+        [
+            [1.0, 2.0, 3.0],
+            [2.0, 4.0, 5.0],
+            [3.0, 5.0, 6.0],
+        ]
+    )
+    data = sym_matrix[:, numpy.newaxis, :]
+    tensor = flops.as_symmetric(
+        data, symmetry=SymmetryGroup.symmetric(axes=(0, 2))
+    )
+    assert tensor.shape == (3, 1, 3)
+    assert tensor.symmetry == SymmetryGroup.symmetric(axes=(0, 2))
+
+    by_slice = tensor[None, :, :, None, :]
+    assert by_slice.shape == (1, 3, 1, 1, 3)
+
+    expected = SymmetryGroup.direct_product(
+        SymmetryGroup.symmetric(axes=(1, 4)),  # remapped original
+        SymmetryGroup.symmetric(axes=(0, 3)),  # inserted axes only
+    )
+    assert by_slice.symmetry == expected
+
+    # Negative assertion: explicitly NOT the version where the pre-existing
+    # size-1 (output axis 2) is lumped with the freshly-inserted Nones.
+    wrong_if_lumped = SymmetryGroup.direct_product(
+        SymmetryGroup.symmetric(axes=(1, 4)),
+        SymmetryGroup.symmetric(axes=(0, 2, 3)),
+    )
+    assert by_slice.symmetry != wrong_if_lumped
 
 
 def test_ellipsis_and_none_combine():

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -39,3 +39,99 @@ def test_inserted_axes_symmetry_returns_symmetric_triple_for_three_positions():
 def test_inserted_axes_symmetry_accepts_tuple_input():
     expected = SymmetryGroup.symmetric(axes=(0, 4))
     assert inserted_axes_symmetry((0, 4)) == expected
+
+
+# ---------------------------------------------------------------------------
+# Contract: tensor[K_with_Nones].symmetry matches expand_dims equivalent
+# ---------------------------------------------------------------------------
+
+
+def test_issue_66_example_1_corrected_full_slices():
+    """eye(3)[None, :, None, :] should match expand_dims(eye(3), axis=(0, 2))."""
+    a = fnp.eye(3)
+    by_slice = a[None, :, None, :]
+    assert by_slice.shape == (1, 3, 1, 3)
+    assert by_slice.symmetry == SymmetryGroup.young(blocks=((0, 2), (1, 3)))
+
+
+def test_issue_66_example_2_corrected_asymmetric_slice():
+    """eye(3)[None, :, None, 1:2] keeps inserted-axis pair; original sym broken."""
+    a = fnp.eye(3)
+    by_slice = a[None, :, None, 1:2]
+    assert by_slice.shape == (1, 3, 1, 1)
+    assert by_slice.symmetry == SymmetryGroup.young(blocks=((0, 2),))
+
+
+def test_original_sym_broken_inserted_still_survives():
+    """eye(3)[None, None, 0:1, 1:2] retains the two-inserted-axes pair only."""
+    a = fnp.eye(3)
+    by_slice = a[None, None, 0:1, 1:2]
+    assert by_slice.shape == (1, 1, 1, 1)
+    assert by_slice.symmetry == SymmetryGroup.symmetric(axes=(0, 1))
+
+
+def test_single_none_builds_no_inserted_group():
+    """eye(3)[None, :, :] has remapped original sym only; no inserted group."""
+    a = fnp.eye(3)
+    by_slice = a[None, :, :]
+    assert by_slice.shape == (1, 3, 3)
+    assert by_slice.symmetry == SymmetryGroup.symmetric(axes=(1, 2))
+
+
+def test_preexisting_size_one_not_lumped_with_inserted():
+    """A (3,1) SymmetricTensor indexed [None, :, None] makes only the two fresh
+    Nones symmetric, NOT lumping with the pre-existing size-1 axis.
+
+    Note: fnp.zeros returns a FlopscopeArray (not SymmetricTensor), which
+    doesn't go through our __getitem__ path. We use .view(SymmetricTensor)
+    to construct a SymmetricTensor whose _symmetry is None via
+    __array_finalize__.
+    """
+    from flopscope._symmetric import SymmetricTensor
+
+    data = numpy.zeros((3, 1))
+    tensor = data.view(SymmetricTensor)
+    assert tensor._symmetry is None
+    by_slice = tensor[None, :, None]
+    assert by_slice.shape == (1, 3, 1, 1)
+    # Inserted axes [0, 2]. Pre-existing size-1 at axis 3 is NOT lumped.
+    assert getattr(by_slice, "symmetry", None) == SymmetryGroup.symmetric(axes=(0, 2))
+
+
+def test_ellipsis_and_none_combine():
+    """eye(3)[None, ..., None] gives remapped sym((1,2)) + inserted sym((0,3))."""
+    a = fnp.eye(3)
+    by_slice = a[None, ..., None]
+    assert by_slice.shape == (1, 3, 3, 1)
+    expected = SymmetryGroup.direct_product(
+        SymmetryGroup.symmetric(axes=(1, 2)),
+        SymmetryGroup.symmetric(axes=(0, 3)),
+    )
+    assert by_slice.symmetry == expected
+
+
+def test_integer_index_mid_key_with_nones():
+    """eye(3)[None, 0, None, :] removes input axis 0; output positions 0, 1 are inserted."""
+    a = fnp.eye(3)
+    by_slice = a[None, 0, None, :]
+    assert by_slice.shape == (1, 1, 3)
+    # Output axes 0 and 1 are the freshly-inserted Nones; sym((0, 1)).
+    # (Original sym((0,1)) is dropped: input axis 0 was removed by integer index,
+    #  so pointwise stabilizer leaves nothing on the kept axis 1 alone.)
+    assert getattr(by_slice, "symmetry", None) == SymmetryGroup.symmetric(axes=(0, 1))
+
+
+def test_no_input_symmetry_still_gains_inserted_group():
+    """A SymmetricTensor with _symmetry=None still constructs inserted-axis sym."""
+    from flopscope._symmetric import SymmetricTensor
+
+    # Construct a SymmetricTensor whose _symmetry is None via __array_finalize__:
+    # numpy.asarray(...).view(SymmetricTensor) goes through __array_finalize__,
+    # which initializes _symmetry to None.
+    base = numpy.zeros((3, 3))
+    sym_tensor = base.view(SymmetricTensor)
+    assert sym_tensor._symmetry is None
+    result = sym_tensor[None, None, :, :]
+    assert result.shape == (1, 1, 3, 3)
+    # Inserted positions 0, 1 form a free sym((0,1)) — symmetry from nothing.
+    assert getattr(result, "symmetry", None) == SymmetryGroup.symmetric(axes=(0, 1))

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -10,8 +10,8 @@ import flopscope as flops
 import flopscope._free_ops as ops
 import flopscope.numpy as fnp
 from flopscope import SymmetryGroup
+from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import inserted_axes_symmetry
-
 
 # ---------------------------------------------------------------------------
 # inserted_axes_symmetry() unit tests
@@ -50,6 +50,7 @@ def test_issue_66_example_1_corrected_full_slices():
     """eye(3)[None, :, None, :] should match expand_dims(eye(3), axis=(0, 2))."""
     a = fnp.eye(3)
     by_slice = a[None, :, None, :]
+    assert isinstance(by_slice, SymmetricTensor)
     assert by_slice.shape == (1, 3, 1, 3)
     assert by_slice.symmetry == SymmetryGroup.young(blocks=((0, 2), (1, 3)))
 
@@ -58,6 +59,7 @@ def test_issue_66_example_2_corrected_asymmetric_slice():
     """eye(3)[None, :, None, 1:2] keeps inserted-axis pair; original sym broken."""
     a = fnp.eye(3)
     by_slice = a[None, :, None, 1:2]
+    assert isinstance(by_slice, SymmetricTensor)
     assert by_slice.shape == (1, 3, 1, 1)
     assert by_slice.symmetry == SymmetryGroup.young(blocks=((0, 2),))
 
@@ -66,6 +68,7 @@ def test_original_sym_broken_inserted_still_survives():
     """eye(3)[None, None, 0:1, 1:2] retains the two-inserted-axes pair only."""
     a = fnp.eye(3)
     by_slice = a[None, None, 0:1, 1:2]
+    assert isinstance(by_slice, SymmetricTensor)
     assert by_slice.shape == (1, 1, 1, 1)
     assert by_slice.symmetry == SymmetryGroup.symmetric(axes=(0, 1))
 
@@ -74,6 +77,7 @@ def test_single_none_builds_no_inserted_group():
     """eye(3)[None, :, :] has remapped original sym only; no inserted group."""
     a = fnp.eye(3)
     by_slice = a[None, :, :]
+    assert isinstance(by_slice, SymmetricTensor)
     assert by_slice.shape == (1, 3, 3)
     assert by_slice.symmetry == SymmetryGroup.symmetric(axes=(1, 2))
 
@@ -128,6 +132,7 @@ def test_preexisting_size_one_not_lumped_with_existing_symmetry():
     assert tensor.symmetry == SymmetryGroup.symmetric(axes=(0, 2))
 
     by_slice = tensor[None, :, :, None, :]
+    assert isinstance(by_slice, SymmetricTensor)
     assert by_slice.shape == (1, 3, 1, 1, 3)
 
     expected = SymmetryGroup.direct_product(
@@ -149,6 +154,7 @@ def test_ellipsis_and_none_combine():
     """eye(3)[None, ..., None] gives remapped sym((1,2)) + inserted sym((0,3))."""
     a = fnp.eye(3)
     by_slice = a[None, ..., None]
+    assert isinstance(by_slice, SymmetricTensor)
     assert by_slice.shape == (1, 3, 3, 1)
     expected = SymmetryGroup.direct_product(
         SymmetryGroup.symmetric(axes=(1, 2)),

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -125,9 +125,7 @@ def test_preexisting_size_one_not_lumped_with_existing_symmetry():
         ]
     )
     data = sym_matrix[:, numpy.newaxis, :]
-    tensor = flops.as_symmetric(
-        data, symmetry=SymmetryGroup.symmetric(axes=(0, 2))
-    )
+    tensor = flops.as_symmetric(data, symmetry=SymmetryGroup.symmetric(axes=(0, 2)))
     assert tensor.shape == (3, 1, 3)
     assert tensor.symmetry == SymmetryGroup.symmetric(axes=(0, 2))
 
@@ -205,9 +203,7 @@ def _count_symmetry_warnings(callable_):
     with _warnings.catch_warnings(record=True) as caught:
         _warnings.simplefilter("always")
         callable_()
-        return sum(
-            1 for w in caught if issubclass(w.category, SymmetryLossWarning)
-        )
+        return sum(1 for w in caught if issubclass(w.category, SymmetryLossWarning))
 
 
 def test_no_warning_on_gained_symmetry_via_none_insertion():

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -185,6 +185,44 @@ def test_no_input_symmetry_still_gains_inserted_group():
 
 
 # ---------------------------------------------------------------------------
+# Bool indexing bailout: boolean masks are not integer scalars.
+# `isinstance(True, int)` is True in Python, so without an explicit bool check
+# the propagator would treat `True` as an integer index (removes axis 0) when
+# numpy actually treats it as a boolean mask (adds a size-1 batch axis).
+# Symmetry conservatively drops to None.
+# ---------------------------------------------------------------------------
+
+
+def test_bool_scalar_index_drops_symmetry_safely():
+    """tensor[True] is a boolean mask in numpy; bail out to no symmetry."""
+    a = fnp.eye(3)
+    assert a.shape == (3, 3)
+    result = a[True]
+    assert result.shape == (1, 3, 3)
+    assert getattr(result, "symmetry", None) is None
+
+
+def test_bool_index_combined_with_none_drops_symmetry_safely():
+    """Combining True with None must not produce a misclassified inserted-axis
+    group: positions 0 and 2 are size-1 in output, but so is position 1 (the
+    bool-mask axis), and the propagator has no way to distinguish them. Drop
+    to None rather than report a wrong group.
+    """
+    a = fnp.eye(3)
+    result = a[None, True, None]
+    assert result.shape == (1, 1, 1, 3, 3)
+    assert getattr(result, "symmetry", None) is None
+
+
+def test_numpy_bool_scalar_index_drops_symmetry_safely():
+    """numpy.bool_ behaves like Python bool for indexing; same bailout."""
+    a = fnp.eye(3)
+    result = a[numpy.bool_(True)]
+    assert result.shape == (1, 3, 3)
+    assert getattr(result, "symmetry", None) is None
+
+
+# ---------------------------------------------------------------------------
 # Equivalence property: tensor[K] == expand_dims(tensor[slice_part], newaxes)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -185,6 +185,61 @@ def test_no_input_symmetry_still_gains_inserted_group():
 
 
 # ---------------------------------------------------------------------------
+# Warning predicate: SymmetryLossWarning fires only on real structural
+# reduction (new.order() < old.order()), not on gains or axis-relabels.
+# ---------------------------------------------------------------------------
+
+
+def _count_symmetry_warnings(callable_):
+    """Helper: run `callable_()` and count SymmetryLossWarning instances."""
+    import warnings as _warnings
+
+    from flopscope.errors import SymmetryLossWarning
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        callable_()
+        return sum(
+            1 for w in caught if issubclass(w.category, SymmetryLossWarning)
+        )
+
+
+def test_no_warning_on_gained_symmetry_via_none_insertion():
+    """`a[None, :, None, :]` produces RICHER symmetry, not loss — no warning."""
+    a = fnp.eye(3)
+    n = _count_symmetry_warnings(lambda: a[None, :, None, :])
+    assert n == 0
+
+
+def test_no_warning_on_axis_relabel_via_single_none():
+    """`a[None, :, :]` shifts axes but preserves order — no warning."""
+    a = fnp.eye(3)
+    n = _count_symmetry_warnings(lambda: a[None, :, :])
+    assert n == 0
+
+
+def test_no_warning_on_ellipsis_and_none():
+    """`a[None, ..., None]` gains an inserted pair on top of remapped original — no warning."""
+    a = fnp.eye(3)
+    n = _count_symmetry_warnings(lambda: a[None, ..., None])
+    assert n == 0
+
+
+def test_warning_fires_on_real_order_reduction():
+    """`a[:, 0]` removes axis 1 from the symmetric group; original order drops to 1."""
+    a = fnp.eye(3)
+    n = _count_symmetry_warnings(lambda: a[:, 0])
+    assert n == 1
+
+
+def test_warning_fires_on_asymmetric_slice():
+    """`a[0:2, 0:2]` breaks the original sym; resulting tensor is no longer symmetric."""
+    a = fnp.eye(3)
+    n = _count_symmetry_warnings(lambda: a[0:2, 0:2])
+    assert n == 1
+
+
+# ---------------------------------------------------------------------------
 # Bool indexing bailout: boolean masks are not integer scalars.
 # `isinstance(True, int)` is True in Python, so without an explicit bool check
 # the propagator would treat `True` as an integer index (removes axis 0) when

--- a/tests/test_issue_66_newaxis_symmetry.py
+++ b/tests/test_issue_66_newaxis_symmetry.py
@@ -135,3 +135,51 @@ def test_no_input_symmetry_still_gains_inserted_group():
     assert result.shape == (1, 1, 3, 3)
     # Inserted positions 0, 1 form a free sym((0,1)) — symmetry from nothing.
     assert getattr(result, "symmetry", None) == SymmetryGroup.symmetric(axes=(0, 1))
+
+
+# ---------------------------------------------------------------------------
+# Equivalence property: tensor[K] == expand_dims(tensor[slice_part], newaxes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key, slice_part, expand_dims_axis",
+    [
+        # (None, :, None, :) — strip Nones → (:, :); expand at output positions (0, 2)
+        (
+            (None, slice(None), None, slice(None)),
+            (slice(None), slice(None)),
+            (0, 2),
+        ),
+        # (None, :, None, 1:2) — strip Nones → (:, 1:2); expand at (0, 2)
+        (
+            (None, slice(None), None, slice(1, 2)),
+            (slice(None), slice(1, 2)),
+            (0, 2),
+        ),
+        # (None, None, 0:1, 1:2) — strip Nones → (0:1, 1:2); expand at (0, 1)
+        (
+            (None, None, slice(0, 1), slice(1, 2)),
+            (slice(0, 1), slice(1, 2)),
+            (0, 1),
+        ),
+        # (None, 0, None, :) — strip Nones → (0, :); expand at output positions (0, 1)
+        (
+            (None, 0, None, slice(None)),
+            (0, slice(None)),
+            (0, 1),
+        ),
+    ],
+)
+def test_newaxis_indexing_equivalent_to_slice_then_expand_dims(
+    key, slice_part, expand_dims_axis
+):
+    a = fnp.eye(3)
+    by_slice = a[key]
+    intermediate = a[slice_part]
+    by_expand = ops.expand_dims(intermediate, axis=expand_dims_axis)
+
+    assert numpy.array_equal(by_slice, by_expand)
+    by_slice_sym = getattr(by_slice, "symmetry", None)
+    by_expand_sym = getattr(by_expand, "symmetry", None)
+    assert by_slice_sym == by_expand_sym


### PR DESCRIPTION
## Summary

Closes #66. `SymmetricTensor.__getitem__` with `None` / `np.newaxis` in the key now produces the same symmetry as the equivalent `expand_dims` call. Before this PR, `eye(3)[None, :, None, :]` produced strictly less symmetry than `expand_dims(eye(3), axis=(0, 2))`; after, they're equal (`young(blocks=((0, 2), (1, 3)))`).

- **New helper** `inserted_axes_symmetry(positions)` in [`_symmetry_utils.py`](src/flopscope/_symmetry_utils.py) — single source of truth for "≥2 freshly-inserted size-1 axes form a free symmetric group on those axes."
- **`propagate_symmetry_slice`** ([`_symmetric.py`](src/flopscope/_symmetric.py)) now walks the key in OUTPUT coordinates and appends `inserted_axes_symmetry(...)` to the surviving groups.
- **`SymmetricTensor.__getitem__`** still constructs the inserted-axis group even when `self._symmetry is None` (the `__array_finalize__` case), matching `expand_dims` behavior on no-symmetry inputs.
- **`remap_group_for_expand_dims`** refactored to delegate to the new helper (pure no-op, eliminates the duplicate inline logic).

### Adversarial-review follow-ups (also in this PR)
- **Tightened `SymmetryLossWarning` predicate** to `new.order() < old.order()` so the warning stops false-firing on operations that gain or relabel symmetry (e.g. `a[None, :, None, :]`). Existing assertion sites in `test_pointwise_coverage.py` and `test_accounting.py` are untouched (they test `sum` / `add`, not `__getitem__`).
- **Bool index bailout** — `isinstance(True, int)` is `True` in Python, so `bool` was being misclassified as an integer index. Added `bool` / `np.bool_` to the early fancy-index bailout; symmetry now drops conservatively to `None` instead of producing a wrong group.
- **Strengthened pre-existing-size-1 test** — original test used a `_symmetry=None` view, so it didn't actually exercise the "not lumped with existing symmetry" claim. Added a real test constructing a `(3, 1, 3)` tensor with `sym((0, 2))`, indexing `[None, :, :, None, :]`, and asserting `sym((1, 4)) × sym((0, 3))` with a negative assertion against the wrong-if-lumped variant.

### Test plan
- [x] `uv run pytest tests/test_issue_66_newaxis_symmetry.py` — 27 cases (5 helper, 11 contract / edge-case, 3 bool-bailout, 5 warning-predicate, 1 parametrized × 4 = 17 + 10 = 27)
- [x] `uv run pytest tests/test_free_ops_extended.py` — pinned test flipped from buggy-behavior assertion to equivalence assertion
- [x] `uv run pytest tests/` — 10,996+ reports, 0 failed, 0 errored
- [x] `npm test` in `website/` — 1033 passed, 0 failed
- [x] Issue reproducer: `fnp.eye(3)[None, :, None, :].symmetry == ops.expand_dims(fnp.eye(3), axis=(0, 2)).symmetry` → True
- [x] Pre-merge adversarial review: 3 parallel verifier agents on math claims, algorithmic correctness, and assumptions. Math + Algorithm verdicts HOLD with confidence 5/5; Assumptions findings (warning predicate, vacuous test, bool index) all addressed in this PR.