### PR TITLE
feat: per-op symmetry transport for shape ops (closes #68)

### DIFF
--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -31,6 +31,15 @@ from flopscope._validation import require_budget
 from flopscope.errors import SymmetryError, UnsupportedFunctionError, _warn_symmetry_loss
 
 
+def _warn_if_symmetric(arr, op_name: str) -> None:
+    """Emit SymmetryLossWarning if `arr` is a SymmetricTensor with a group."""
+    if isinstance(arr, SymmetricTensor) and arr.symmetry is not None:
+        _warn_symmetry_loss(
+            lost_dims=[arr.symmetry.axes or tuple(range(arr.symmetry.degree))],
+            reason=f"op '{op_name}' is not symmetry-aware",
+        )
+
+
 @lru_cache(maxsize=1024)
 def _infer_constant_shape_symmetry(shape):
     if len(shape) < 2:
@@ -821,6 +830,7 @@ attach_docstring(roll, _np.roll, "free", "0 FLOPs")
 def pad(array: ArrayLike, pad_width: Any, **kwargs: Any) -> FlopscopeArray:
     """Pad an array. Cost: numel(output)."""
     budget = require_budget()
+    _warn_if_symmetric(array, "pad")
     # cost depends on result; duration is post-hoc
     # pad_width parsing is complex (scalar, per-axis, per-side) — not worth replicating
     result = _np.pad(_to_base_ndarray(array), pad_width, **kwargs)
@@ -835,6 +845,7 @@ attach_docstring(pad, _np.pad, "free", "0 FLOPs")
 
 def triu(m: ArrayLike, k: int = 0) -> FlopscopeArray:
     """Upper triangle. Wraps ``numpy.triu``. Cost: 0 FLOPs."""
+    _warn_if_symmetric(m, "triu")
     return _np.triu(_to_base_ndarray(m), k=k)  # type: ignore[return-value]
 
 
@@ -843,6 +854,7 @@ attach_docstring(triu, _np.triu, "free", "0 FLOPs")
 
 def tril(m: ArrayLike, k: int = 0) -> FlopscopeArray:
     """Lower triangle. Wraps ``numpy.tril``. Cost: 0 FLOPs."""
+    _warn_if_symmetric(m, "tril")
     return _np.tril(_to_base_ndarray(m), k=k)  # type: ignore[return-value]
 
 
@@ -858,6 +870,7 @@ def diagonal(
 ) -> FlopscopeArray:
     """Return diagonal. Cost: numel(output)."""
     budget = require_budget()
+    _warn_if_symmetric(a, "diagonal")
     a_arr = _np.asarray(a)
     # Diagonal length along axis1/axis2
     m, n = a_arr.shape[axis1], a_arr.shape[axis2]
@@ -1011,6 +1024,7 @@ def append(
 ) -> FlopscopeArray:
     """Append values. Cost: numel(appended values)."""
     budget = require_budget()
+    _warn_if_symmetric(arr, "append")
     values_arr = _np.asarray(values)
     cost = values_arr.size  # num appended
     with budget.deduct("append", flop_cost=cost, subscripts=None, shapes=()):
@@ -1047,6 +1061,7 @@ attach_docstring(argwhere, _np.argwhere, "free", "0 FLOPs")
 def array_split(ary: ArrayLike, *args: Any, **kwargs: Any) -> list[FlopscopeArray]:
     """Split array into sub-arrays. Cost: numel(input)."""
     budget = require_budget()
+    _warn_if_symmetric(ary, "array_split")
     ary_arr = _np.asarray(ary)
     cost = ary_arr.size
     with budget.deduct(
@@ -1188,6 +1203,15 @@ attach_docstring(binary_repr, _np.binary_repr, "free", "0 FLOPs")
 def block(*args, **kwargs):
     """Assemble array from nested lists. Cost: numel(output)."""
     budget = require_budget()
+    # Warn for any SymmetricTensor found in the nested structure.
+    def _walk_warn(obj):
+        if isinstance(obj, (list, tuple)):
+            for item in obj:
+                _walk_warn(item)
+        else:
+            _warn_if_symmetric(obj, "block")
+    for a in args:
+        _walk_warn(a)
     result = _np.block(*[_to_base_ndarray_tree(a) for a in args], **kwargs)
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("block", flop_cost=cost, subscripts=None, shapes=()):
@@ -1265,6 +1289,9 @@ attach_docstring(can_cast, _np.can_cast, "free", "0 FLOPs")
 def choose(*args, **kwargs):
     """Construct array from index array. Cost: numel(output)."""
     budget = require_budget()
+    # Warn if the first arg (index array) carries symmetry.
+    if args:
+        _warn_if_symmetric(args[0], "choose")
     # Args: (a, choices, ...) or just (a, choices) — strip arrays.
     stripped_args = []
     for arg in args:
@@ -1323,6 +1350,7 @@ def compress(
 ) -> FlopscopeArray:
     """Return selected slices along an axis. Cost: numel(output)."""
     budget = require_budget()
+    _warn_if_symmetric(a, "compress")
     result = _np.compress(
         _to_base_ndarray(condition),  # type: ignore[arg-type]
         _to_base_ndarray(a),
@@ -1397,6 +1425,7 @@ def delete(
 ) -> FlopscopeArray:
     """Return new array with sub-arrays deleted. Cost: num elements removed."""
     budget = require_budget()
+    _warn_if_symmetric(arr, "delete")
     arr_np = _np.asarray(arr)
     result = _np.delete(_to_base_ndarray(arr), obj, axis=axis, **kwargs)
     cost = max(arr_np.size - result.size, 0)  # num deleted
@@ -1475,6 +1504,8 @@ attach_docstring(dsplit, _np.dsplit, "free", "0 FLOPs")
 def dstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     """Stack arrays along third axis. Cost: numel(output)."""
     budget = require_budget()
+    for a in tup:
+        _warn_if_symmetric(a, "dstack")
     result = _np.dstack(_to_base_ndarray_tree(tup))  # type: ignore[arg-type]
     cost = result.size if hasattr(result, "size") else 1
     with budget.deduct("dstack", flop_cost=cost, subscripts=None, shapes=()):

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -15,9 +15,10 @@ from typing import Any
 import numpy as _np
 from numpy.typing import ArrayLike, DTypeLike
 
+from flopscope import _symmetry_transport as _st
 from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
-from flopscope._ndarray import FlopscopeArray, _to_base_ndarray, _to_base_ndarray_tree
+from flopscope._ndarray import FlopscopeArray, _asplainflopscope, _to_base_ndarray, _to_base_ndarray_tree
 from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import (
@@ -29,7 +30,7 @@ from flopscope._symmetry_utils import (
     wrap_with_trusted_symmetry,
 )
 from flopscope._validation import require_budget
-from flopscope.errors import SymmetryError, UnsupportedFunctionError
+from flopscope.errors import SymmetryError, UnsupportedFunctionError, _warn_symmetry_loss
 
 
 @lru_cache(maxsize=1024)
@@ -492,13 +493,22 @@ def split(
     budget = require_budget()
     ary_arr = _np.asarray(ary)
     cost = ary_arr.size
+    in_group = ary.symmetry if isinstance(ary, SymmetricTensor) else None
+    out_group = _st.transport_split(in_group, input_shape=ary_arr.shape, axis=axis)
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason=f"split along axis {axis} breaks block symmetry",
+        )
     with budget.deduct(
         "split", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _call_numpy(
-            _np.split, _to_base_ndarray(ary), indices_or_sections, axis=axis
+        raw_pieces = _call_numpy(
+            _np.split, ary_arr, indices_or_sections, axis=axis,
         )
-    return result  # type: ignore[return-value]
+    if out_group is not None:
+        return [wrap_with_symmetry(p, out_group) for p in raw_pieces]  # type: ignore[return-value]
+    return [_asplainflopscope(p) for p in raw_pieces]  # type: ignore[return-value]
 
 
 attach_docstring(split, _np.split, "free", "0 FLOPs")
@@ -509,7 +519,18 @@ def hsplit(
     indices_or_sections: int | Sequence[int],
 ) -> list[FlopscopeArray]:
     """Split array horizontally. Wraps ``numpy.hsplit``. Cost: 0 FLOPs."""
-    return _np.hsplit(_to_base_ndarray(ary), indices_or_sections)  # type: ignore[return-value]
+    ary_arr = _np.asarray(ary)
+    in_group = ary.symmetry if isinstance(ary, SymmetricTensor) else None
+    out_group = _st.transport_hsplit(in_group, input_shape=ary_arr.shape)
+    raw_pieces = _np.hsplit(ary_arr, indices_or_sections)
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="hsplit breaks block symmetry",
+        )
+    if out_group is not None:
+        return [wrap_with_symmetry(p, out_group) for p in raw_pieces]  # type: ignore[return-value]
+    return [_asplainflopscope(p) for p in raw_pieces]  # type: ignore[return-value]
 
 
 attach_docstring(hsplit, _np.hsplit, "free", "0 FLOPs")
@@ -524,11 +545,20 @@ def vsplit(
     budget = require_budget()
     ary_arr = _np.asarray(ary)
     cost = ary_arr.size
+    in_group = ary.symmetry if isinstance(ary, SymmetricTensor) else None
+    out_group = _st.transport_vsplit(in_group, input_shape=ary_arr.shape)
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="vsplit breaks block symmetry",
+        )
     with budget.deduct(
         "vsplit", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _call_numpy(_np.vsplit, _to_base_ndarray(ary), indices_or_sections)
-    return result  # type: ignore[return-value]
+        raw_pieces = _call_numpy(_np.vsplit, ary_arr, indices_or_sections)
+    if out_group is not None:
+        return [wrap_with_symmetry(p, out_group) for p in raw_pieces]  # type: ignore[return-value]
+    return [_asplainflopscope(p) for p in raw_pieces]  # type: ignore[return-value]
 
 
 attach_docstring(vsplit, _np.vsplit, "free", "0 FLOPs")
@@ -539,7 +569,18 @@ def squeeze(
     axis: int | tuple[int, ...] | None = None,
 ) -> FlopscopeArray:
     """Remove length-1 axes. Wraps ``numpy.squeeze``. Cost: 0 FLOPs."""
-    return _np.squeeze(_to_base_ndarray(a), axis=axis)  # type: ignore[return-value]
+    a_arr = _np.asarray(a)
+    result = _np.squeeze(a_arr, axis=axis)
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_squeeze(in_group, input_shape=a_arr.shape, axis=axis)
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="squeeze removes an axis inside the symmetric block",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(squeeze, _np.squeeze, "free", "0 FLOPs")
@@ -641,17 +682,20 @@ def repeat(
     """Repeat elements. Cost: numel(output)."""
     budget = require_budget()
     a_arr = _np.asarray(a)
-    # Output size: each element repeated; total = sum of repeats or size * repeats
-    reps = _np.asarray(repeats)
-    if reps.ndim == 0:
-        cost = max(a_arr.size * int(reps), 1)
-    else:
-        cost = max(int(reps.sum()), 1)
-    with budget.deduct("repeat", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(
-            _np.repeat, _to_base_ndarray(a), _to_base_ndarray(repeats), axis=axis
-        )  # type: ignore[arg-type, call-overload]
-    return result
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_repeat(in_group, input_shape=a_arr.shape, axis=axis)
+    result = _np.repeat(a_arr, repeats, axis=axis)
+    cost = max(result.size, 1)
+    with budget.deduct("repeat", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)):
+        pass  # cost deducted; result already computed
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="repeat along a block axis breaks block symmetry",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(repeat, _np.repeat, "free", "0 FLOPs")
@@ -668,19 +712,24 @@ def flip(
 attach_docstring(flip, _np.flip, "free", "0 FLOPs")
 
 
-@_counted_wrapper
 def roll(
     a: ArrayLike,
     shift: int | Sequence[int],
     axis: int | Sequence[int] | None = None,
 ) -> FlopscopeArray:
-    """Roll array elements. Cost: numel(output)."""
-    budget = require_budget()
+    """Roll array elements along an axis. Wraps ``numpy.roll``. Cost: 0 FLOPs."""
     a_arr = _np.asarray(a)
-    cost = max(a_arr.size, 1)
-    with budget.deduct("roll", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.roll, _to_base_ndarray(a), shift, axis=axis)
-    return result  # type: ignore[return-value]
+    result = _np.roll(a_arr, shift, axis=axis)
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_roll(in_group, input_shape=a_arr.shape, axis=axis)
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="roll along a block axis breaks block symmetry",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(roll, _np.roll, "free", "0 FLOPs")
@@ -953,30 +1002,75 @@ attach_docstring(asarray_chkfinite, _np.asarray_chkfinite, "free", "0 FLOPs")
 
 
 def atleast_1d(
-    *args: ArrayLike, **kwargs: Any
-) -> FlopscopeArray | list[FlopscopeArray]:
+    *arys: ArrayLike,
+) -> FlopscopeArray | tuple[FlopscopeArray, ...]:
     """Convert to 1-D or higher. Wraps ``numpy.atleast_1d``. Cost: 0 FLOPs."""
-    return _np.atleast_1d(*[_to_base_ndarray(a) for a in args], **kwargs)  # type: ignore[return-value]
+    def _one(a):
+        a_arr = _np.asarray(a)
+        result = _np.atleast_1d(a_arr)
+        in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+        out_group = _st.transport_atleast_1d(in_group, input_shape=a_arr.shape)
+        if in_group is not None and out_group is None:
+            _warn_symmetry_loss(
+                lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+                reason="atleast_1d incompatible with block structure",
+            )
+        if out_group is not None:
+            return wrap_with_symmetry(result, out_group)
+        return _asplainflopscope(result)
+    if len(arys) == 1:
+        return _one(arys[0])
+    return tuple(_one(a) for a in arys)
 
 
 attach_docstring(atleast_1d, _np.atleast_1d, "free", "0 FLOPs")
 
 
 def atleast_2d(
-    *args: ArrayLike, **kwargs: Any
-) -> FlopscopeArray | list[FlopscopeArray]:
+    *arys: ArrayLike,
+) -> FlopscopeArray | tuple[FlopscopeArray, ...]:
     """Convert to 2-D or higher. Wraps ``numpy.atleast_2d``. Cost: 0 FLOPs."""
-    return _np.atleast_2d(*[_to_base_ndarray(a) for a in args], **kwargs)  # type: ignore[return-value]
+    def _one(a):
+        a_arr = _np.asarray(a)
+        result = _np.atleast_2d(a_arr)
+        in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+        out_group = _st.transport_atleast_2d(in_group, input_shape=a_arr.shape)
+        if in_group is not None and out_group is None:
+            _warn_symmetry_loss(
+                lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+                reason="atleast_2d incompatible with block structure",
+            )
+        if out_group is not None:
+            return wrap_with_symmetry(result, out_group)
+        return _asplainflopscope(result)
+    if len(arys) == 1:
+        return _one(arys[0])
+    return tuple(_one(a) for a in arys)
 
 
 attach_docstring(atleast_2d, _np.atleast_2d, "free", "0 FLOPs")
 
 
 def atleast_3d(
-    *args: ArrayLike, **kwargs: Any
-) -> FlopscopeArray | list[FlopscopeArray]:
+    *arys: ArrayLike,
+) -> FlopscopeArray | tuple[FlopscopeArray, ...]:
     """Convert to 3-D or higher. Wraps ``numpy.atleast_3d``. Cost: 0 FLOPs."""
-    return _np.atleast_3d(*[_to_base_ndarray(a) for a in args], **kwargs)  # type: ignore[return-value]
+    def _one(a):
+        a_arr = _np.asarray(a)
+        result = _np.atleast_3d(a_arr)
+        in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+        out_group = _st.transport_atleast_3d(in_group, input_shape=a_arr.shape)
+        if in_group is not None and out_group is None:
+            _warn_symmetry_loss(
+                lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+                reason="atleast_3d incompatible with block structure",
+            )
+        if out_group is not None:
+            return wrap_with_symmetry(result, out_group)
+        return _asplainflopscope(result)
+    if len(arys) == 1:
+        return _one(arys[0])
+    return tuple(_one(a) for a in arys)
 
 
 attach_docstring(atleast_3d, _np.atleast_3d, "free", "0 FLOPs")
@@ -1265,11 +1359,20 @@ def dsplit(ary: ArrayLike, *args: Any, **kwargs: Any) -> list[FlopscopeArray]:
     budget = require_budget()
     ary_arr = _np.asarray(ary)
     cost = ary_arr.size
+    in_group = ary.symmetry if isinstance(ary, SymmetricTensor) else None
+    out_group = _st.transport_dsplit(in_group, input_shape=ary_arr.shape)
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="dsplit breaks block symmetry",
+        )
     with budget.deduct(
         "dsplit", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
-        result = _call_numpy(_np.dsplit, _to_base_ndarray(ary), *args, **kwargs)
-    return result  # type: ignore[return-value]
+        raw_pieces = _call_numpy(_np.dsplit, ary_arr, *args, **kwargs)
+    if out_group is not None:
+        return [wrap_with_symmetry(p, out_group) for p in raw_pieces]  # type: ignore[return-value]
+    return [_asplainflopscope(p) for p in raw_pieces]  # type: ignore[return-value]
 
 
 attach_docstring(dsplit, _np.dsplit, "free", "0 FLOPs")
@@ -1606,10 +1709,20 @@ def mask_indices(*args, **kwargs):
 attach_docstring(mask_indices, _np.mask_indices, "free", "0 FLOPs")
 
 
-def matrix_transpose(*args, **kwargs):
-    """Transpose a matrix or stack of matrices. Wraps ``numpy.matrix_transpose``. Cost: 0 FLOPs."""
-    stripped_args = _to_base_ndarray_tree(args)
-    return _np.matrix_transpose(*stripped_args, **kwargs)
+def matrix_transpose(x: ArrayLike) -> FlopscopeArray:
+    """Swap last two axes. Wraps ``numpy.matrix_transpose``. Cost: 0 FLOPs."""
+    x_arr = _np.asarray(x)
+    result = _np.matrix_transpose(x_arr)
+    in_group = x.symmetry if isinstance(x, SymmetricTensor) else None
+    out_group = _st.transport_matrix_transpose(in_group, ndim=x_arr.ndim)
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="matrix_transpose: rank too low for sym",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(matrix_transpose, _np.matrix_transpose, "free", "0 FLOPs")

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -23,8 +23,6 @@ from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import (
     broadcast_group,
-    remap_group_axes,
-    remap_group_for_expand_dims,
     validate_symmetry_group,
     wrap_with_symmetry,
     wrap_with_trusted_symmetry,
@@ -67,9 +65,6 @@ def _compatible_symmetry_for_shape(symmetry, shape):
         return None
     return symmetry
 
-
-def _normalize_axis_order(axes, ndim):
-    return tuple(axis % ndim for axis in axes)
 
 
 def _infer_structural_constructor_symmetry(*, kind, N=None, M=None, k=0, v_ndim=None):
@@ -378,15 +373,14 @@ def transpose(
     axes: Sequence[int] | None = None,
 ) -> FlopscopeArray:
     """Permute array dimensions. Wraps ``numpy.transpose``. Cost: 0 FLOPs."""
-    if not isinstance(a, SymmetricTensor):
-        return _np.transpose(_to_base_ndarray(a), axes=axes)  # type: ignore[return-value]
-    result = _np.transpose(_np.asarray(a), axes=axes)
-    if axes is None:
-        order = tuple(reversed(range(a.ndim)))
-    else:
-        order = _normalize_axis_order(tuple(axes), a.ndim)
-    mapping = {old: new for new, old in enumerate(order)}
-    return wrap_with_symmetry(result, remap_group_axes(a.symmetry, mapping))  # type: ignore[return-value]
+    a_arr = _np.asarray(a)
+    result = _np.transpose(a_arr, axes=axes)
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_transpose(in_group, ndim=a_arr.ndim, axes=axes)
+    # transpose never genuinely drops (axis perm always preserves S_n etc.).
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(transpose, _np.transpose, "free", "0 FLOPs")
@@ -394,15 +388,15 @@ attach_docstring(transpose, _np.transpose, "free", "0 FLOPs")
 
 def swapaxes(a: ArrayLike, axis1: int, axis2: int) -> FlopscopeArray:
     """Swap two axes. Wraps ``numpy.swapaxes``. Cost: 0 FLOPs."""
-    if not isinstance(a, SymmetricTensor):
-        return _np.swapaxes(_to_base_ndarray(a), axis1, axis2)  # type: ignore[return-value]
-    result = _np.swapaxes(_np.asarray(a), axis1, axis2)
-    order = list(range(a.ndim))
-    axis1 %= a.ndim
-    axis2 %= a.ndim
-    order[axis1], order[axis2] = order[axis2], order[axis1]
-    mapping = {old: new for new, old in enumerate(order)}
-    return wrap_with_symmetry(result, remap_group_axes(a.symmetry, mapping))  # type: ignore[return-value]
+    a_arr = _np.asarray(a)
+    result = _np.swapaxes(a_arr, axis1, axis2)
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_swapaxes(
+        in_group, ndim=a_arr.ndim, axis1=axis1, axis2=axis2,
+    )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)
+    return _asplainflopscope(result)
 
 
 attach_docstring(swapaxes, _np.swapaxes, "free", "0 FLOPs")
@@ -410,28 +404,19 @@ attach_docstring(swapaxes, _np.swapaxes, "free", "0 FLOPs")
 
 def moveaxis(
     a: ArrayLike,
-    source: int | Sequence[int],
-    destination: int | Sequence[int],
+    source,
+    destination,
 ) -> FlopscopeArray:
     """Move axes to new positions. Wraps ``numpy.moveaxis``. Cost: 0 FLOPs."""
-    if not isinstance(a, SymmetricTensor):
-        return _np.moveaxis(_to_base_ndarray(a), source, destination)  # type: ignore[return-value]
-    result = _np.moveaxis(_np.asarray(a), source, destination)
-    if _np.ndim(source) == 0:
-        source_axes = (int(source),)  # type: ignore[arg-type, call-overload]
-    else:
-        source_axes = tuple(source)  # type: ignore[arg-type, call-overload]
-    if _np.ndim(destination) == 0:
-        destination_axes = (int(destination),)  # type: ignore[arg-type, call-overload]
-    else:
-        destination_axes = tuple(destination)  # type: ignore[arg-type, call-overload]
-    source_axes = _normalize_axis_order(source_axes, a.ndim)
-    destination_axes = _normalize_axis_order(destination_axes, a.ndim)
-    order = [axis for axis in range(a.ndim) if axis not in source_axes]
-    for dest, src in sorted(zip(destination_axes, source_axes, strict=True)):
-        order.insert(dest, src)
-    mapping = {old: new for new, old in enumerate(order)}
-    return wrap_with_symmetry(result, remap_group_axes(a.symmetry, mapping))  # type: ignore[return-value]
+    a_arr = _np.asarray(a)
+    result = _np.moveaxis(a_arr, source, destination)
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_moveaxis(
+        in_group, ndim=a_arr.ndim, source=source, destination=destination,
+    )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)
+    return _asplainflopscope(result)
 
 
 attach_docstring(moveaxis, _np.moveaxis, "free", "0 FLOPs")
@@ -648,19 +633,17 @@ def squeeze(
 attach_docstring(squeeze, _np.squeeze, "free", "0 FLOPs")
 
 
-def expand_dims(
-    a: ArrayLike,
-    axis: int | tuple[int, ...],
-) -> FlopscopeArray:
+def expand_dims(a: ArrayLike, axis) -> FlopscopeArray:
     """Insert a new axis. Wraps ``numpy.expand_dims``. Cost: 0 FLOPs."""
     a_arr = _np.asarray(a)
-    result = _np.expand_dims(_np.asarray(a), axis=axis)
-    symmetry = remap_group_for_expand_dims(
-        a.symmetry if isinstance(a, SymmetricTensor) else None,
-        ndim=a_arr.ndim,
-        axis=axis,
+    result = _np.expand_dims(a_arr, axis=axis)
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_expand_dims(
+        in_group, input_ndim=a_arr.ndim, axis=axis,
     )
-    return wrap_with_symmetry(result, symmetry) if symmetry is not None else result  # type: ignore[return-value]
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)
+    return _asplainflopscope(result)
 
 
 attach_docstring(expand_dims, _np.expand_dims, "free", "0 FLOPs")
@@ -895,24 +878,22 @@ def diagonal(
 attach_docstring(diagonal, _np.diagonal, "free", "0 FLOPs")
 
 
-@_counted_wrapper
-def broadcast_to(
-    array: ArrayLike,
-    shape: int | Sequence[int],
-) -> FlopscopeArray:
-    """Broadcast array to shape. Cost: numel(output)."""
-    output_shape = (shape,) if isinstance(shape, int) else tuple(shape)
-    input_array = _np.asarray(array)
-    budget = require_budget()
-    cost = max(int(_np.prod(output_shape)), 1)
-    with budget.deduct("broadcast_to", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.broadcast_to, input_array, output_shape)
-    symmetry = broadcast_group(
-        array.symmetry if isinstance(array, SymmetricTensor) else None,
-        input_shape=input_array.shape,
-        output_shape=output_shape,
+def broadcast_to(array: ArrayLike, shape) -> FlopscopeArray:
+    """Broadcast array to a new shape. Wraps ``numpy.broadcast_to``. Cost: 0 FLOPs."""
+    arr = _np.asarray(array)
+    result = _np.broadcast_to(arr, shape)
+    in_group = array.symmetry if isinstance(array, SymmetricTensor) else None
+    out_group = _st.transport_broadcast_to(
+        in_group, input_shape=arr.shape, output_shape=tuple(shape),
     )
-    return wrap_with_symmetry(result, symmetry)  # type: ignore[return-value]
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="broadcast_to expands length-1 block axes",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)
+    return _asplainflopscope(result)
 
 
 attach_docstring(broadcast_to, _np.broadcast_to, "free", "0 FLOPs")

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -18,7 +18,12 @@ from numpy.typing import ArrayLike, DTypeLike
 from flopscope import _symmetry_transport as _st
 from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
-from flopscope._ndarray import FlopscopeArray, _asplainflopscope, _to_base_ndarray, _to_base_ndarray_tree
+from flopscope._ndarray import (
+    FlopscopeArray,
+    _asplainflopscope,
+    _to_base_ndarray,
+    _to_base_ndarray_tree,
+)
 from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import (
@@ -28,7 +33,11 @@ from flopscope._symmetry_utils import (
     wrap_with_trusted_symmetry,
 )
 from flopscope._validation import require_budget
-from flopscope.errors import SymmetryError, UnsupportedFunctionError, _warn_symmetry_loss
+from flopscope.errors import (
+    SymmetryError,
+    UnsupportedFunctionError,
+    _warn_symmetry_loss,
+)
 
 
 def _warn_if_symmetric(arr, op_name: str) -> None:
@@ -73,7 +82,6 @@ def _compatible_symmetry_for_shape(symmetry, shape):
     except (SymmetryError, ValueError):
         return None
     return symmetry
-
 
 
 def _infer_structural_constructor_symmetry(*, kind, N=None, M=None, k=0, v_ndim=None):
@@ -362,7 +370,9 @@ def reshape(a: ArrayLike, /, *args: Any, **kwargs: Any) -> FlopscopeArray:
     result = _np.reshape(a_arr, *args, **kwargs)
     in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
     out_group = _st.transport_reshape(
-        in_group, input_shape=a_arr.shape, output_shape=result.shape,
+        in_group,
+        input_shape=a_arr.shape,
+        output_shape=result.shape,
     )
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
@@ -401,7 +411,10 @@ def swapaxes(a: ArrayLike, axis1: int, axis2: int) -> FlopscopeArray:
     result = _np.swapaxes(a_arr, axis1, axis2)
     in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
     out_group = _st.transport_swapaxes(
-        in_group, ndim=a_arr.ndim, axis1=axis1, axis2=axis2,
+        in_group,
+        ndim=a_arr.ndim,
+        axis1=axis1,
+        axis2=axis2,
     )
     if out_group is not None:
         return wrap_with_symmetry(result, out_group)
@@ -421,7 +434,10 @@ def moveaxis(
     result = _np.moveaxis(a_arr, source, destination)
     in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
     out_group = _st.transport_moveaxis(
-        in_group, ndim=a_arr.ndim, source=source, destination=destination,
+        in_group,
+        ndim=a_arr.ndim,
+        source=source,
+        destination=destination,
     )
     if out_group is not None:
         return wrap_with_symmetry(result, out_group)
@@ -441,15 +457,14 @@ def concatenate(
     budget = require_budget()
     arr_list = [_np.asarray(a) for a in arrays]
     cost = max(sum(a.size for a in arr_list), 1)
-    groups = [
-        (a.symmetry if isinstance(a, SymmetricTensor) else None)
-        for a in arrays
-    ]
+    groups = [(a.symmetry if isinstance(a, SymmetricTensor) else None) for a in arrays]
     raw_arrs = [_to_base_ndarray(a) for a in arrays]
     with budget.deduct("concatenate", flop_cost=cost, subscripts=None, shapes=()):
         result = _call_numpy(_np.concatenate, raw_arrs, axis=axis, **kwargs)
     out_group = _st.transport_concatenate(
-        groups, output_ndim=result.ndim, axis=axis,
+        groups,
+        output_ndim=result.ndim,
+        axis=axis,
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
@@ -476,7 +491,9 @@ def stack(
     cost = max(sum(a.size for a in arr_list), 1)
     groups = [a.symmetry if isinstance(a, SymmetricTensor) else None for a in arrays]
     with budget.deduct("stack", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs)
+        result = _call_numpy(
+            _np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs
+        )
     out_group = _st.transport_stack(groups, output_ndim=result.ndim, axis=axis)
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
@@ -502,7 +519,9 @@ def vstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     with budget.deduct("vstack", flop_cost=cost, subscripts=None, shapes=()):
         result = _call_numpy(_np.vstack, _to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
     out_group = _st.transport_vstack(
-        groups, output_ndim=result.ndim, input_ndims=input_ndims,
+        groups,
+        output_ndim=result.ndim,
+        input_ndims=input_ndims,
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
@@ -524,7 +543,9 @@ def hstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     input_ndims = [a.ndim for a in arr_list]
     result = _np.hstack(_to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
     out_group = _st.transport_hstack(
-        groups, output_ndim=result.ndim, input_ndims=input_ndims,
+        groups,
+        output_ndim=result.ndim,
+        input_ndims=input_ndims,
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
@@ -560,7 +581,10 @@ def split(
         "split", flop_cost=cost, subscripts=None, shapes=(ary_arr.shape,)
     ):
         raw_pieces = _call_numpy(
-            _np.split, ary_arr, indices_or_sections, axis=axis,
+            _np.split,
+            ary_arr,
+            indices_or_sections,
+            axis=axis,
         )
     if out_group is not None:
         return [wrap_with_symmetry(p, out_group) for p in raw_pieces]  # type: ignore[return-value]
@@ -648,7 +672,9 @@ def expand_dims(a: ArrayLike, axis) -> FlopscopeArray:
     result = _np.expand_dims(a_arr, axis=axis)
     in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
     out_group = _st.transport_expand_dims(
-        in_group, input_ndim=a_arr.ndim, axis=axis,
+        in_group,
+        input_ndim=a_arr.ndim,
+        axis=axis,
     )
     if out_group is not None:
         return wrap_with_symmetry(result, out_group)
@@ -666,9 +692,7 @@ def ravel(a: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     cost = max(a_arr.size, 1)
     in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
     out_group = _st.transport_ravel(in_group, input_shape=a_arr.shape)
-    with budget.deduct(
-        "ravel", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
-    ):
+    with budget.deduct("ravel", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)):
         result = _call_numpy(_np.ravel, a_arr, **kwargs)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
@@ -764,7 +788,9 @@ def repeat(
     out_group = _st.transport_repeat(in_group, input_shape=a_arr.shape, axis=axis)
     result = _np.repeat(a_arr, repeats, axis=axis)
     cost = max(result.size, 1)
-    with budget.deduct("repeat", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)):
+    with budget.deduct(
+        "repeat", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
+    ):
         pass  # cost deducted; result already computed
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
@@ -788,7 +814,9 @@ def flip(
     result = _np.flip(a_arr, axis=axis)
     in_group = m.symmetry if isinstance(m, SymmetricTensor) else None
     out_group = _st.transport_flip(
-        in_group, ndim=a_arr.ndim, axes_flipped=axis,
+        in_group,
+        ndim=a_arr.ndim,
+        axes_flipped=axis,
     )
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
@@ -891,13 +919,23 @@ def diagonal(
 attach_docstring(diagonal, _np.diagonal, "free", "0 FLOPs")
 
 
-def broadcast_to(array: ArrayLike, shape) -> FlopscopeArray:
-    """Broadcast array to a new shape. Wraps ``numpy.broadcast_to``. Cost: 0 FLOPs."""
+@_counted_wrapper
+def broadcast_to(
+    array: ArrayLike,
+    shape: int | Sequence[int],
+) -> FlopscopeArray:
+    """Broadcast array to shape. Cost: numel(output)."""
+    output_shape = (shape,) if isinstance(shape, int) else tuple(shape)
     arr = _np.asarray(array)
-    result = _np.broadcast_to(arr, shape)
+    budget = require_budget()
+    cost = max(int(_np.prod(output_shape)), 1)
+    with budget.deduct("broadcast_to", flop_cost=cost, subscripts=None, shapes=()):
+        result = _call_numpy(_np.broadcast_to, arr, output_shape)
     in_group = array.symmetry if isinstance(array, SymmetricTensor) else None
     out_group = _st.transport_broadcast_to(
-        in_group, input_shape=arr.shape, output_shape=tuple(shape),
+        in_group,
+        input_shape=arr.shape,
+        output_shape=output_shape,
     )
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
@@ -1100,6 +1138,7 @@ def atleast_1d(
     *arys: ArrayLike,
 ) -> FlopscopeArray | tuple[FlopscopeArray, ...]:
     """Convert to 1-D or higher. Wraps ``numpy.atleast_1d``. Cost: 0 FLOPs."""
+
     def _one(a):
         a_arr = _np.asarray(a)
         result = _np.atleast_1d(a_arr)
@@ -1113,6 +1152,7 @@ def atleast_1d(
         if out_group is not None:
             return wrap_with_symmetry(result, out_group)
         return _asplainflopscope(result)
+
     if len(arys) == 1:
         return _one(arys[0])
     return tuple(_one(a) for a in arys)
@@ -1125,6 +1165,7 @@ def atleast_2d(
     *arys: ArrayLike,
 ) -> FlopscopeArray | tuple[FlopscopeArray, ...]:
     """Convert to 2-D or higher. Wraps ``numpy.atleast_2d``. Cost: 0 FLOPs."""
+
     def _one(a):
         a_arr = _np.asarray(a)
         result = _np.atleast_2d(a_arr)
@@ -1138,6 +1179,7 @@ def atleast_2d(
         if out_group is not None:
             return wrap_with_symmetry(result, out_group)
         return _asplainflopscope(result)
+
     if len(arys) == 1:
         return _one(arys[0])
     return tuple(_one(a) for a in arys)
@@ -1150,6 +1192,7 @@ def atleast_3d(
     *arys: ArrayLike,
 ) -> FlopscopeArray | tuple[FlopscopeArray, ...]:
     """Convert to 3-D or higher. Wraps ``numpy.atleast_3d``. Cost: 0 FLOPs."""
+
     def _one(a):
         a_arr = _np.asarray(a)
         result = _np.atleast_3d(a_arr)
@@ -1163,6 +1206,7 @@ def atleast_3d(
         if out_group is not None:
             return wrap_with_symmetry(result, out_group)
         return _asplainflopscope(result)
+
     if len(arys) == 1:
         return _one(arys[0])
     return tuple(_one(a) for a in arys)
@@ -1203,6 +1247,7 @@ attach_docstring(binary_repr, _np.binary_repr, "free", "0 FLOPs")
 def block(*args, **kwargs):
     """Assemble array from nested lists. Cost: numel(output)."""
     budget = require_budget()
+
     # Warn for any SymmetricTensor found in the nested structure.
     def _walk_warn(obj):
         if isinstance(obj, (list, tuple)):
@@ -1210,6 +1255,7 @@ def block(*args, **kwargs):
                 _walk_warn(item)
         else:
             _warn_if_symmetric(obj, "block")
+
     for a in args:
         _walk_warn(a)
     result = _np.block(*[_to_base_ndarray_tree(a) for a in args], **kwargs)
@@ -1318,7 +1364,9 @@ def column_stack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     input_ndims = [a.ndim for a in arr_list]
     result = _np.column_stack(_to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
     out_group = _st.transport_column_stack(
-        groups, output_ndim=result.ndim, input_ndims=input_ndims,
+        groups,
+        output_ndim=result.ndim,
+        input_ndims=input_ndims,
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
@@ -1586,6 +1634,7 @@ attach_docstring(flatnonzero, _np.flatnonzero, "free", "0 FLOPs")
 
 def fliplr(*args, **kwargs):
     """Reverse elements along axis 1. Wraps ``numpy.fliplr``. Cost: 0 FLOPs."""
+    _warn_if_symmetric(args[0], "fliplr")
     stripped_args = _to_base_ndarray_tree(args)
     return _np.fliplr(*stripped_args, **kwargs)
 
@@ -1595,6 +1644,7 @@ attach_docstring(fliplr, _np.fliplr, "free", "0 FLOPs")
 
 def flipud(*args, **kwargs):
     """Reverse elements along axis 0. Wraps ``numpy.flipud``. Cost: 0 FLOPs."""
+    _warn_if_symmetric(args[0], "flipud")
     stripped_args = _to_base_ndarray_tree(args)
     return _np.flipud(*stripped_args, **kwargs)
 

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -354,7 +354,20 @@ attach_docstring(identity, _np.identity, "free", "0 FLOPs")
 
 def reshape(a: ArrayLike, /, *args: Any, **kwargs: Any) -> FlopscopeArray:
     """Reshape an array. Wraps ``numpy.reshape``. Cost: 0 FLOPs."""
-    return _np.reshape(_np.asarray(a), *args, **kwargs)
+    a_arr = _np.asarray(a)
+    result = _np.reshape(a_arr, *args, **kwargs)
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_reshape(
+        in_group, input_shape=a_arr.shape, output_shape=result.shape,
+    )
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="reshape merges or splits axes inside the symmetric block",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(reshape, _np.reshape, "free", "0 FLOPs")
@@ -432,12 +445,26 @@ def concatenate(
 ) -> FlopscopeArray:
     """Join arrays along an axis. Cost: numel(output)."""
     budget = require_budget()
-    cost = max(sum(_np.asarray(a).size for a in arrays), 1)
+    arr_list = [_np.asarray(a) for a in arrays]
+    cost = max(sum(a.size for a in arr_list), 1)
+    groups = [
+        (a.symmetry if isinstance(a, SymmetricTensor) else None)
+        for a in arrays
+    ]
+    raw_arrs = [_to_base_ndarray(a) for a in arrays]
     with budget.deduct("concatenate", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(
-            _np.concatenate, _to_base_ndarray_tree(arrays), axis=axis, **kwargs
-        )  # type: ignore[arg-type, call-overload]
-    return result  # type: ignore[return-value]
+        result = _call_numpy(_np.concatenate, raw_arrs, axis=axis, **kwargs)
+    out_group = _st.transport_concatenate(
+        groups, output_ndim=result.ndim, axis=axis,
+    )
+    if any(g is not None for g in groups) and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[g.axes for g in groups if g is not None],
+            reason="concatenate breaks block symmetry or mixes with plain inputs",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(concatenate, _np.concatenate, "counted_custom", "numel(output) FLOPs")
@@ -451,12 +478,20 @@ def stack(
 ) -> FlopscopeArray:
     """Stack arrays along a new axis. Cost: numel(output)."""
     budget = require_budget()
-    cost = max(sum(_np.asarray(a).size for a in arrays), 1)
+    arr_list = [_np.asarray(a) for a in arrays]
+    cost = max(sum(a.size for a in arr_list), 1)
+    groups = [a.symmetry if isinstance(a, SymmetricTensor) else None for a in arrays]
     with budget.deduct("stack", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(
-            _np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs
-        )  # type: ignore[arg-type, call-overload]
-    return result
+        result = _call_numpy(_np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs)
+    out_group = _st.transport_stack(groups, output_ndim=result.ndim, axis=axis)
+    if any(g is not None for g in groups) and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[g.axes for g in groups if g is not None],
+            reason="stack inputs disagree or include plain arrays",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)
+    return _asplainflopscope(result)
 
 
 attach_docstring(stack, _np.stack, "free", "0 FLOPs")
@@ -466,10 +501,23 @@ attach_docstring(stack, _np.stack, "free", "0 FLOPs")
 def vstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     """Stack arrays vertically. Cost: numel(output)."""
     budget = require_budget()
-    cost = max(sum(_np.asarray(a).size for a in tup), 1)
+    arr_list = [_np.asarray(a) for a in tup]
+    cost = max(sum(a.size for a in arr_list), 1)
+    groups = [a.symmetry if isinstance(a, SymmetricTensor) else None for a in tup]
+    input_ndims = [a.ndim for a in arr_list]
     with budget.deduct("vstack", flop_cost=cost, subscripts=None, shapes=()):
         result = _call_numpy(_np.vstack, _to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
-    return result
+    out_group = _st.transport_vstack(
+        groups, output_ndim=result.ndim, input_ndims=input_ndims,
+    )
+    if any(g is not None for g in groups) and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[g.axes for g in groups if g is not None],
+            reason="vstack breaks block symmetry",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)
+    return _asplainflopscope(result)
 
 
 attach_docstring(vstack, _np.vstack, "free", "0 FLOPs")
@@ -477,7 +525,21 @@ attach_docstring(vstack, _np.vstack, "free", "0 FLOPs")
 
 def hstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     """Stack arrays horizontally. Wraps ``numpy.hstack``. Cost: 0 FLOPs."""
-    return _np.hstack(_to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
+    arr_list = [_np.asarray(a) for a in tup]
+    groups = [a.symmetry if isinstance(a, SymmetricTensor) else None for a in tup]
+    input_ndims = [a.ndim for a in arr_list]
+    result = _np.hstack(_to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
+    out_group = _st.transport_hstack(
+        groups, output_ndim=result.ndim, input_ndims=input_ndims,
+    )
+    if any(g is not None for g in groups) and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[g.axes for g in groups if g is not None],
+            reason="hstack breaks block symmetry",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(hstack, _np.hstack, "free", "0 FLOPs")
@@ -610,9 +672,20 @@ def ravel(a: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     budget = require_budget()
     a_arr = _np.asarray(a)
     cost = max(a_arr.size, 1)
-    with budget.deduct("ravel", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)):
+    in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
+    out_group = _st.transport_ravel(in_group, input_shape=a_arr.shape)
+    with budget.deduct(
+        "ravel", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
+    ):
         result = _call_numpy(_np.ravel, a_arr, **kwargs)
-    return result  # type: ignore[return-value]
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="ravel collapses to a single axis; block cannot fit",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(ravel, _np.ravel, "free", "0 FLOPs")
@@ -662,12 +735,25 @@ def tile(A: ArrayLike, reps: int | Sequence[int]) -> FlopscopeArray:
     """Construct array by repeating. Cost: numel(output)."""
     budget = require_budget()
     a_arr = _np.asarray(A)
-    reps_tup = (reps,) if _np.ndim(reps) == 0 else tuple(reps)  # type: ignore[arg-type, call-overload]
-    # Output size = input size * product of reps
-    cost = max(a_arr.size * int(_np.prod(reps_tup)), 1)
+    result = _np.tile(a_arr, reps)
+    cost = max(result.size, 1)
+    in_group = A.symmetry if isinstance(A, SymmetricTensor) else None
+    out_group = _st.transport_tile(
+        in_group,
+        input_shape=a_arr.shape,
+        output_shape=result.shape,
+        reps=reps,
+    )
     with budget.deduct("tile", flop_cost=cost, subscripts=None, shapes=()):
-        result = _call_numpy(_np.tile, _to_base_ndarray(A), reps)
-    return result  # type: ignore[return-value]
+        pass  # cost deducted; result already computed
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="tile reps not constant on block orbit",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(tile, _np.tile, "free", "0 FLOPs")
@@ -706,7 +792,20 @@ def flip(
     axis: int | tuple[int, ...] | None = None,
 ) -> FlopscopeArray:
     """Reverse order of elements. Wraps ``numpy.flip``. Cost: 0 FLOPs."""
-    return _np.flip(_to_base_ndarray(m), axis=axis)  # type: ignore[return-value]
+    a_arr = _np.asarray(m)
+    result = _np.flip(a_arr, axis=axis)
+    in_group = m.symmetry if isinstance(m, SymmetricTensor) else None
+    out_group = _st.transport_flip(
+        in_group, ndim=a_arr.ndim, axes_flipped=axis,
+    )
+    if in_group is not None and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            reason="flip on a proper subset of block axes breaks group action",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(flip, _np.flip, "free", "0 FLOPs")
@@ -1206,8 +1305,21 @@ attach_docstring(choose, _np.choose, "free", "0 FLOPs")
 
 def column_stack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     """Stack 1-D arrays as columns. Wraps ``numpy.column_stack``. Cost: 0 FLOPs."""
-    # First positional arg is sequence of arrays
-    return _np.column_stack(_to_base_ndarray_tree(tup))  # type: ignore[return-value]
+    arr_list = [_np.asarray(a) for a in tup]
+    groups = [a.symmetry if isinstance(a, SymmetricTensor) else None for a in tup]
+    input_ndims = [a.ndim for a in arr_list]
+    result = _np.column_stack(_to_base_ndarray_tree(tup))  # type: ignore[arg-type, call-overload]
+    out_group = _st.transport_column_stack(
+        groups, output_ndim=result.ndim, input_ndims=input_ndims,
+    )
+    if any(g is not None for g in groups) and out_group is None:
+        _warn_symmetry_loss(
+            lost_dims=[g.axes for g in groups if g is not None],
+            reason="column_stack breaks block symmetry",
+        )
+    if out_group is not None:
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(column_stack, _np.column_stack, "free", "0 FLOPs")

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -376,7 +376,11 @@ def reshape(a: ArrayLike, /, *args: Any, **kwargs: Any) -> FlopscopeArray:
     )
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="reshape merges or splits axes inside the symmetric block",
         )
     if out_group is not None:
@@ -417,8 +421,8 @@ def swapaxes(a: ArrayLike, axis1: int, axis2: int) -> FlopscopeArray:
         axis2=axis2,
     )
     if out_group is not None:
-        return wrap_with_symmetry(result, out_group)
-    return _asplainflopscope(result)
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(swapaxes, _np.swapaxes, "free", "0 FLOPs")
@@ -440,8 +444,8 @@ def moveaxis(
         destination=destination,
     )
     if out_group is not None:
-        return wrap_with_symmetry(result, out_group)
-    return _asplainflopscope(result)
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(moveaxis, _np.moveaxis, "free", "0 FLOPs")
@@ -468,7 +472,11 @@ def concatenate(
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[g.axes for g in groups if g is not None],
+            lost_dims=[
+                g.axes if g.axes is not None else tuple(range(g.degree))
+                for g in groups
+                if g is not None
+            ],
             reason="concatenate breaks block symmetry or mixes with plain inputs",
         )
     if out_group is not None:
@@ -497,12 +505,16 @@ def stack(
     out_group = _st.transport_stack(groups, output_ndim=result.ndim, axis=axis)
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[g.axes for g in groups if g is not None],
+            lost_dims=[
+                g.axes if g.axes is not None else tuple(range(g.degree))
+                for g in groups
+                if g is not None
+            ],
             reason="stack inputs disagree or include plain arrays",
         )
     if out_group is not None:
-        return wrap_with_symmetry(result, out_group)
-    return _asplainflopscope(result)
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(stack, _np.stack, "free", "0 FLOPs")
@@ -525,12 +537,16 @@ def vstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[g.axes for g in groups if g is not None],
+            lost_dims=[
+                g.axes if g.axes is not None else tuple(range(g.degree))
+                for g in groups
+                if g is not None
+            ],
             reason="vstack breaks block symmetry",
         )
     if out_group is not None:
-        return wrap_with_symmetry(result, out_group)
-    return _asplainflopscope(result)
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(vstack, _np.vstack, "free", "0 FLOPs")
@@ -549,7 +565,11 @@ def hstack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[g.axes for g in groups if g is not None],
+            lost_dims=[
+                g.axes if g.axes is not None else tuple(range(g.degree))
+                for g in groups
+                if g is not None
+            ],
             reason="hstack breaks block symmetry",
         )
     if out_group is not None:
@@ -574,7 +594,11 @@ def split(
     out_group = _st.transport_split(in_group, input_shape=ary_arr.shape, axis=axis)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason=f"split along axis {axis} breaks block symmetry",
         )
     with budget.deduct(
@@ -605,7 +629,11 @@ def hsplit(
     raw_pieces = _np.hsplit(ary_arr, indices_or_sections)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="hsplit breaks block symmetry",
         )
     if out_group is not None:
@@ -629,7 +657,11 @@ def vsplit(
     out_group = _st.transport_vsplit(in_group, input_shape=ary_arr.shape)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="vsplit breaks block symmetry",
         )
     with budget.deduct(
@@ -655,7 +687,11 @@ def squeeze(
     out_group = _st.transport_squeeze(in_group, input_shape=a_arr.shape, axis=axis)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="squeeze removes an axis inside the symmetric block",
         )
     if out_group is not None:
@@ -677,8 +713,8 @@ def expand_dims(a: ArrayLike, axis) -> FlopscopeArray:
         axis=axis,
     )
     if out_group is not None:
-        return wrap_with_symmetry(result, out_group)
-    return _asplainflopscope(result)
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(expand_dims, _np.expand_dims, "free", "0 FLOPs")
@@ -696,7 +732,11 @@ def ravel(a: ArrayLike, **kwargs: Any) -> FlopscopeArray:
         result = _call_numpy(_np.ravel, a_arr, **kwargs)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="ravel collapses to a single axis; block cannot fit",
         )
     if out_group is not None:
@@ -764,7 +804,11 @@ def tile(A: ArrayLike, reps: int | Sequence[int]) -> FlopscopeArray:
         pass  # cost deducted; result already computed
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="tile reps not constant on block orbit",
         )
     if out_group is not None:
@@ -786,7 +830,7 @@ def repeat(
     a_arr = _np.asarray(a)
     in_group = a.symmetry if isinstance(a, SymmetricTensor) else None
     out_group = _st.transport_repeat(in_group, input_shape=a_arr.shape, axis=axis)
-    result = _np.repeat(a_arr, repeats, axis=axis)
+    result = _np.repeat(a_arr, repeats, axis=axis)  # type: ignore[arg-type]
     cost = max(result.size, 1)
     with budget.deduct(
         "repeat", flop_cost=cost, subscripts=None, shapes=(a_arr.shape,)
@@ -794,7 +838,11 @@ def repeat(
         pass  # cost deducted; result already computed
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="repeat along a block axis breaks block symmetry",
         )
     if out_group is not None:
@@ -820,7 +868,11 @@ def flip(
     )
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="flip on a proper subset of block axes breaks group action",
         )
     if out_group is not None:
@@ -843,7 +895,11 @@ def roll(
     out_group = _st.transport_roll(in_group, input_shape=a_arr.shape, axis=axis)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="roll along a block axis breaks block symmetry",
         )
     if out_group is not None:
@@ -939,12 +995,16 @@ def broadcast_to(
     )
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="broadcast_to expands length-1 block axes",
         )
     if out_group is not None:
-        return wrap_with_symmetry(result, out_group)
-    return _asplainflopscope(result)
+        return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
+    return _asplainflopscope(result)  # type: ignore[return-value]
 
 
 attach_docstring(broadcast_to, _np.broadcast_to, "free", "0 FLOPs")
@@ -1146,7 +1206,11 @@ def atleast_1d(
         out_group = _st.transport_atleast_1d(in_group, input_shape=a_arr.shape)
         if in_group is not None and out_group is None:
             _warn_symmetry_loss(
-                lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+                lost_dims=[
+                    in_group.axes
+                    if in_group.axes is not None
+                    else tuple(range(in_group.degree))
+                ],
                 reason="atleast_1d incompatible with block structure",
             )
         if out_group is not None:
@@ -1154,8 +1218,8 @@ def atleast_1d(
         return _asplainflopscope(result)
 
     if len(arys) == 1:
-        return _one(arys[0])
-    return tuple(_one(a) for a in arys)
+        return _one(arys[0])  # type: ignore[return-value]
+    return tuple(_one(a) for a in arys)  # type: ignore[return-value]
 
 
 attach_docstring(atleast_1d, _np.atleast_1d, "free", "0 FLOPs")
@@ -1173,7 +1237,11 @@ def atleast_2d(
         out_group = _st.transport_atleast_2d(in_group, input_shape=a_arr.shape)
         if in_group is not None and out_group is None:
             _warn_symmetry_loss(
-                lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+                lost_dims=[
+                    in_group.axes
+                    if in_group.axes is not None
+                    else tuple(range(in_group.degree))
+                ],
                 reason="atleast_2d incompatible with block structure",
             )
         if out_group is not None:
@@ -1181,8 +1249,8 @@ def atleast_2d(
         return _asplainflopscope(result)
 
     if len(arys) == 1:
-        return _one(arys[0])
-    return tuple(_one(a) for a in arys)
+        return _one(arys[0])  # type: ignore[return-value]
+    return tuple(_one(a) for a in arys)  # type: ignore[return-value]
 
 
 attach_docstring(atleast_2d, _np.atleast_2d, "free", "0 FLOPs")
@@ -1200,7 +1268,11 @@ def atleast_3d(
         out_group = _st.transport_atleast_3d(in_group, input_shape=a_arr.shape)
         if in_group is not None and out_group is None:
             _warn_symmetry_loss(
-                lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+                lost_dims=[
+                    in_group.axes
+                    if in_group.axes is not None
+                    else tuple(range(in_group.degree))
+                ],
                 reason="atleast_3d incompatible with block structure",
             )
         if out_group is not None:
@@ -1208,8 +1280,8 @@ def atleast_3d(
         return _asplainflopscope(result)
 
     if len(arys) == 1:
-        return _one(arys[0])
-    return tuple(_one(a) for a in arys)
+        return _one(arys[0])  # type: ignore[return-value]
+    return tuple(_one(a) for a in arys)  # type: ignore[return-value]
 
 
 attach_docstring(atleast_3d, _np.atleast_3d, "free", "0 FLOPs")
@@ -1370,7 +1442,11 @@ def column_stack(tup: Sequence[ArrayLike]) -> FlopscopeArray:
     )
     if any(g is not None for g in groups) and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[g.axes for g in groups if g is not None],
+            lost_dims=[
+                g.axes if g.axes is not None else tuple(range(g.degree))
+                for g in groups
+                if g is not None
+            ],
             reason="column_stack breaks block symmetry",
         )
     if out_group is not None:
@@ -1533,7 +1609,11 @@ def dsplit(ary: ArrayLike, *args: Any, **kwargs: Any) -> list[FlopscopeArray]:
     out_group = _st.transport_dsplit(in_group, input_shape=ary_arr.shape)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="dsplit breaks block symmetry",
         )
     with budget.deduct(
@@ -1891,7 +1971,11 @@ def matrix_transpose(x: ArrayLike) -> FlopscopeArray:
     out_group = _st.transport_matrix_transpose(in_group, ndim=x_arr.ndim)
     if in_group is not None and out_group is None:
         _warn_symmetry_loss(
-            lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+            lost_dims=[
+                in_group.axes
+                if in_group.axes is not None
+                else tuple(range(in_group.degree))
+            ],
             reason="matrix_transpose: rank too low for sym",
         )
     if out_group is not None:

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -30,8 +30,8 @@ from flopscope._ndarray import (
 )
 from flopscope._symmetric import (
     SymmetricTensor,
-    _warn_symmetry_loss,
 )
+from flopscope.errors import _warn_symmetry_loss
 from flopscope._symmetric import (
     is_symmetric as _is_symmetric,
 )

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -30,9 +30,6 @@ from flopscope._ndarray import (
 )
 from flopscope._symmetric import (
     SymmetricTensor,
-)
-from flopscope.errors import _warn_symmetry_loss
-from flopscope._symmetric import (
     is_symmetric as _is_symmetric,
 )
 from flopscope._symmetry_utils import (
@@ -49,6 +46,7 @@ from flopscope.errors import (
     CostFallbackWarning,
     SymmetryError,
     UnsupportedFunctionError,
+    _warn_symmetry_loss,
 )
 
 # ---------------------------------------------------------------------------

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -28,7 +28,6 @@ from flopscope._ndarray import (
     _to_base_ndarray,
     _to_base_ndarray_tree,
 )
-from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetric import is_symmetric as _is_symmetric
 from flopscope._symmetry_utils import (

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -28,10 +28,9 @@ from flopscope._ndarray import (
     _to_base_ndarray,
     _to_base_ndarray_tree,
 )
-from flopscope._symmetric import (
-    SymmetricTensor,
-    is_symmetric as _is_symmetric,
-)
+from flopscope._perm_group import SymmetryGroup
+from flopscope._symmetric import SymmetricTensor
+from flopscope._symmetric import is_symmetric as _is_symmetric
 from flopscope._symmetry_utils import (
     broadcast_group,
     direct_product_groups,

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -16,7 +16,7 @@ from flopscope._symmetry_utils import (
     restrict_group_to_axes,
     validate_symmetry_group,
 )
-from flopscope.errors import SymmetryError, SymmetryLossWarning
+from flopscope.errors import SymmetryError
 
 # ---------------------------------------------------------------------------
 # Validation
@@ -242,8 +242,9 @@ def is_symmetric(
 # Symmetry-loss warning helper
 # ---------------------------------------------------------------------------
 
-from flopscope.errors import _warn_symmetry_loss  # re-exported for back-compat
-
+from flopscope.errors import (  # noqa: E402
+    _warn_symmetry_loss,
+)  # re-exported for back-compat
 
 # ---------------------------------------------------------------------------
 # Symmetry propagation helpers
@@ -670,18 +671,19 @@ class SymmetricTensor(FlopscopeArray):
 
     def reshape(self, *shape, **kwargs):  # type: ignore[override]
         from flopscope._free_ops import reshape as _reshape
+
         return _reshape(self, *shape, **kwargs)
 
     def ravel(self, order: str = "C"):  # type: ignore[override]
         from flopscope._free_ops import ravel as _ravel
+
         return _ravel(self, order=order)
 
     def flatten(self, order: str = "C"):  # type: ignore[override]
         from flopscope._free_ops import ravel as _ravel
-        from flopscope.errors import SymmetryLossWarning, _warn_symmetry_loss
-        # Warn independently (not via _ravel) so the warning has a distinct call
-        # site and is not deduplicated with the separate tensor.ravel() call.
         from flopscope._symmetry_transport import transport_ravel
+        from flopscope.errors import _warn_symmetry_loss
+
         in_group = self._symmetry
         if in_group is not None:
             out_group = transport_ravel(in_group, input_shape=np.asarray(self).shape)
@@ -689,13 +691,14 @@ class SymmetricTensor(FlopscopeArray):
                 _warn_symmetry_loss(
                     lost_dims=[in_group.axes or tuple(range(in_group.degree))],
                     reason="flatten collapses to a single axis; block cannot fit",
-                    stacklevel=2,
                 )
-        out = _ravel(self, order=order)
+        # Pass the raw ndarray view so _ravel does not emit a second warning.
+        out = _ravel(np.asarray(self), order=order)
         return np.array(out, copy=True)
 
     def squeeze(self, axis=None):  # type: ignore[override]
         from flopscope._free_ops import squeeze as _squeeze
+
         return _squeeze(self, axis=axis)
 
     def astype(  # type: ignore[override]

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-import os
-import sys
-import warnings
-
 import numpy as np
 
-from flopscope._config import get_setting
 from flopscope._ndarray import FlopscopeArray, _asplainflopscope
 from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetry_utils import (

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -699,7 +699,7 @@ class SymmetricTensor(FlopscopeArray):
     def squeeze(self, axis=None):  # type: ignore[override]
         from flopscope._free_ops import squeeze as _squeeze
 
-        return _squeeze(self, axis=axis)
+        return _squeeze(self, axis=axis)  # type: ignore[arg-type]
 
     def astype(  # type: ignore[override]
         self,

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -247,43 +247,7 @@ def is_symmetric(
 # Symmetry-loss warning helper
 # ---------------------------------------------------------------------------
 
-
-_FLOPSCOPE_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-def _user_stacklevel() -> int:
-    """Stacklevel for :func:`warnings.warn` that points to the first frame
-    outside the ``flopscope`` package — i.e. the user's call site.
-
-    Walks the active call stack starting from the caller of
-    :func:`_warn_symmetry_loss`. Robust to changes in the number of
-    decorator/wrapper layers between user code and the warn site.
-    """
-    frame = sys._getframe(2)
-    level = 2
-    while frame is not None:
-        if not frame.f_code.co_filename.startswith(_FLOPSCOPE_PKG_DIR):
-            return level
-        frame = frame.f_back
-        level += 1
-    return 3
-
-
-def _warn_symmetry_loss(
-    lost_dims: list[tuple[int, ...]],
-    reason: str,
-) -> None:
-    """Emit a :class:`SymmetryLossWarning` if warnings are enabled."""
-    if not get_setting("symmetry_warnings"):
-        return
-    dim_str = ", ".join(str(g) for g in lost_dims)
-    warnings.warn(
-        f"Symmetry lost along dims {dim_str}: {reason}. "
-        "Use as_symmetric() to re-tag if you know the result is symmetric. "
-        "Suppress with flops.configure(symmetry_warnings=False).",
-        SymmetryLossWarning,
-        stacklevel=_user_stacklevel(),
-    )
+from flopscope.errors import _warn_symmetry_loss  # re-exported for back-compat
 
 
 # ---------------------------------------------------------------------------

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -669,16 +669,34 @@ class SymmetricTensor(FlopscopeArray):
         return out
 
     def reshape(self, *shape, **kwargs):  # type: ignore[override]
-        return _asplainflopscope(np.reshape(np.asarray(self), *shape, **kwargs))
+        from flopscope._free_ops import reshape as _reshape
+        return _reshape(self, *shape, **kwargs)
 
     def ravel(self, order: str = "C"):  # type: ignore[override]
-        return _asplainflopscope(np.ravel(np.asarray(self), order=order))  # type: ignore[arg-type]
+        from flopscope._free_ops import ravel as _ravel
+        return _ravel(self, order=order)
 
     def flatten(self, order: str = "C"):  # type: ignore[override]
-        return _asplainflopscope(np.asarray(self).flatten(order))  # type: ignore[arg-type]
+        from flopscope._free_ops import ravel as _ravel
+        from flopscope.errors import SymmetryLossWarning, _warn_symmetry_loss
+        # Warn independently (not via _ravel) so the warning has a distinct call
+        # site and is not deduplicated with the separate tensor.ravel() call.
+        from flopscope._symmetry_transport import transport_ravel
+        in_group = self._symmetry
+        if in_group is not None:
+            out_group = transport_ravel(in_group, input_shape=np.asarray(self).shape)
+            if out_group is None:
+                _warn_symmetry_loss(
+                    lost_dims=[in_group.axes or tuple(range(in_group.degree))],
+                    reason="flatten collapses to a single axis; block cannot fit",
+                    stacklevel=2,
+                )
+        out = _ravel(self, order=order)
+        return np.array(out, copy=True)
 
     def squeeze(self, axis=None):  # type: ignore[override]
-        return _asplainflopscope(np.squeeze(np.asarray(self), axis=axis))
+        from flopscope._free_ops import squeeze as _squeeze
+        return _squeeze(self, axis=axis)
 
     def astype(  # type: ignore[override]
         self,

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -15,7 +15,14 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from flopscope._perm_group import SymmetryGroup
-from flopscope._symmetry_utils import intersect_groups, remap_group_axes, restrict_group_to_axes, setwise_stabilizer
+from flopscope._symmetry_utils import (
+    group_orbits_on_axes,
+    intersect_groups,
+    _normalize_reps_for_output,
+    remap_group_axes,
+    restrict_group_to_axes,
+    setwise_stabilizer,
+)
 
 
 def _stub(name: str):
@@ -309,7 +316,28 @@ def transport_flip(
     if not F_A or F_A == A:
         return group
     return setwise_stabilizer(group, fixed_set=F_A)
-transport_tile = _stub("tile")
+def transport_tile(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    reps,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    A = group.axes or tuple(range(group.degree))
+    shift = len(output_shape) - len(input_shape)
+    reps_norm = _normalize_reps_for_output(reps, output_ndim=len(output_shape))
+    # Orbit-constancy check on output-positioned reps.
+    for orbit in group_orbits_on_axes(group, A):
+        reps_in_orbit = {reps_norm[a + shift] for a in orbit}
+        if len(reps_in_orbit) > 1:
+            return None
+    if shift == 0:
+        return group
+    # Block axes shift in the output; relabel the group.
+    axis_map = {a: a + shift for a in A}
+    return remap_group_axes(group, axis_map)
 
 
 def transport_repeat(

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -36,9 +36,46 @@ transport_split = _stub("split")
 transport_hsplit = _stub("hsplit")
 transport_vsplit = _stub("vsplit")
 transport_dsplit = _stub("dsplit")
-transport_atleast_1d = _stub("atleast_1d")
-transport_atleast_2d = _stub("atleast_2d")
-transport_atleast_3d = _stub("atleast_3d")
+def transport_atleast_1d(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    # For any input with rank >= 1, atleast_1d is identity.
+    # (Rank 0 -> rank 1, but rank 0 can't carry a multi-axis group.)
+    return group
+
+
+def transport_atleast_2d(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    # For any input with rank >= 2 (which is the only case that can carry
+    # a non-trivial multi-axis group), atleast_2d is identity.
+    return group
+
+
+def transport_atleast_3d(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    if len(input_shape) >= 3:
+        # No-op.
+        return group
+    if len(input_shape) == 2:
+        # NumPy appends a trailing length-1 axis: (M, N) -> (M, N, 1).
+        # Block axes don't shift.
+        return group
+    # len(input_shape) <= 1: cannot carry a multi-axis group; defensive None.
+    return None
 transport_broadcast_to = _stub("broadcast_to")
 transport_expand_dims = _stub("expand_dims")
 def transport_squeeze(

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -12,15 +12,14 @@ from __future__ import annotations
 
 import functools
 import math
-from collections.abc import Iterable, Sequence
-from typing import Any
+from collections.abc import Sequence
 
 from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetry_utils import (
+    _normalize_reps_for_output,
     broadcast_group,
     group_orbits_on_axes,
     intersect_groups,
-    _normalize_reps_for_output,
     remap_group_axes,
     remap_group_for_expand_dims,
     restrict_group_to_axes,
@@ -28,15 +27,9 @@ from flopscope._symmetry_utils import (
 )
 
 
-def _stub(name: str):
-    def _impl(*args, **kwargs):  # pragma: no cover - replaced per task
-        raise NotImplementedError(f"transport_{name} not yet implemented")
-    _impl.__name__ = f"transport_{name}"
-    return _impl
-
-
 def _zero_size_guard(fn):
     """Decorator: any transport receiving a zero-size shape drops to None."""
+
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         for key in ("input_shape", "output_shape"):
@@ -44,6 +37,7 @@ def _zero_size_guard(fn):
             if shape is not None and 0 in shape:
                 return None
         return fn(*args, **kwargs)
+
     return wrapper
 
 
@@ -57,7 +51,9 @@ def transport_reshape(
     if group is None:
         return None
     A = group.axes or tuple(range(group.degree))
-    m = input_shape[A[0]]  # block axis size (must be equal for all a in A by group validity)
+    m = input_shape[
+        A[0]
+    ]  # block axis size (must be equal for all a in A by group validity)
 
     A_sorted = sorted(A)
     n = len(A_sorted)
@@ -104,8 +100,12 @@ def transport_ravel(
     input_shape: tuple[int, ...],
 ) -> SymmetryGroup | None:
     return transport_reshape(
-        group, input_shape=input_shape, output_shape=(math.prod(input_shape),),
+        group,
+        input_shape=input_shape,
+        output_shape=(math.prod(input_shape),),
     )
+
+
 def transport_concatenate(
     groups: Sequence[SymmetryGroup | None],
     *,
@@ -135,6 +135,8 @@ def transport_concatenate(
         if result is None:
             return None
     return result
+
+
 def transport_stack(
     groups: Sequence[SymmetryGroup | None],
     *,
@@ -160,6 +162,8 @@ def transport_stack(
         if result is None:
             return None
     return result
+
+
 def transport_vstack(
     groups: Sequence[SymmetryGroup | None],
     *,
@@ -170,7 +174,7 @@ def transport_vstack(
     # For any input that's 1-D, the promoted form has the data axis at position 1,
     # and 1-D inputs carry no multi-axis group anyway -> None for them.
     promoted = []
-    for g, nd in zip(groups, input_ndims):
+    for g, nd in zip(groups, input_ndims, strict=True):
         if nd >= 2:
             promoted.append(g)
         else:
@@ -200,12 +204,14 @@ def transport_column_stack(
     # column_stack: promote 1-D (N,) -> (N, 1), then concat axis=1.
     # 1-D inputs become column vectors with no multi-axis group.
     promoted = []
-    for g, nd in zip(groups, input_ndims):
+    for g, nd in zip(groups, input_ndims, strict=True):
         if nd >= 2:
             promoted.append(g)
         else:
             promoted.append(None)
     return transport_concatenate(promoted, output_ndim=output_ndim, axis=1)
+
+
 @_zero_size_guard
 def transport_split(
     group: SymmetryGroup | None,
@@ -251,6 +257,8 @@ def transport_dsplit(
     input_shape: tuple[int, ...],
 ) -> SymmetryGroup | None:
     return transport_split(group, input_shape=input_shape, axis=2)
+
+
 @_zero_size_guard
 def transport_atleast_1d(
     group: SymmetryGroup | None,
@@ -294,6 +302,8 @@ def transport_atleast_3d(
         return group
     # len(input_shape) <= 1: cannot carry a multi-axis group; defensive None.
     return None
+
+
 @_zero_size_guard
 def transport_broadcast_to(
     group: SymmetryGroup | None,
@@ -305,7 +315,9 @@ def transport_broadcast_to(
     # produce a non-None result when prepended equal-size axes form a new
     # S_k symmetry on the output. Do not short-circuit on None here.
     return broadcast_group(
-        group, input_shape=input_shape, output_shape=output_shape,
+        group,
+        input_shape=input_shape,
+        output_shape=output_shape,
     )
 
 
@@ -316,6 +328,8 @@ def transport_expand_dims(
     axis,
 ) -> SymmetryGroup | None:
     return remap_group_for_expand_dims(group, ndim=input_ndim, axis=axis)
+
+
 @_zero_size_guard
 def transport_squeeze(
     group: SymmetryGroup | None,
@@ -341,6 +355,8 @@ def transport_squeeze(
     new_index = {old: new for new, old in enumerate(surviving)}
     axis_map = {a: new_index[a] for a in A}
     return remap_group_axes(group, axis_map)
+
+
 def transport_flip(
     group: SymmetryGroup | None,
     *,
@@ -361,6 +377,8 @@ def transport_flip(
     if not F_A or F_A == A:
         return group
     return setwise_stabilizer(group, fixed_set=F_A)
+
+
 @_zero_size_guard
 def transport_tile(
     group: SymmetryGroup | None,
@@ -425,6 +443,8 @@ def transport_roll(
     if rolled & A:
         return None
     return group
+
+
 def transport_transpose(
     group: SymmetryGroup | None,
     *,
@@ -472,7 +492,7 @@ def transport_moveaxis(
     src = tuple(s % ndim for s in src)
     dst = tuple(d % ndim for d in dst)
     order = [i for i in range(ndim) if i not in src]
-    for d, s in sorted(zip(dst, src)):
+    for d, s in sorted(zip(dst, src, strict=True)):
         order.insert(d, s)
     mapping = {old: new for new, old in enumerate(order)}
     return remap_group_axes(group, mapping)

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -1,0 +1,51 @@
+"""Per-op symmetry transport rules for NumPy-protocol shape ops.
+
+Each `transport_<op>(group_or_groups, *, ...)` function returns either a new
+`SymmetryGroup` (the output's surviving symmetry) or `None` (no non-trivial
+group survives — caller emits `SymmetryLossWarning`).
+
+See `.aicrowd/superpowers/specs/2026-05-22-shape-op-symmetry-transport-design.md`
+for the per-op rules and rationale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from flopscope._perm_group import SymmetryGroup
+
+
+def _stub(name: str):
+    def _impl(*args, **kwargs):  # pragma: no cover - replaced per task
+        raise NotImplementedError(f"transport_{name} not yet implemented")
+    _impl.__name__ = f"transport_{name}"
+    return _impl
+
+
+# Stubs — replaced in subsequent tasks.
+transport_reshape = _stub("reshape")
+transport_ravel = _stub("ravel")
+transport_concatenate = _stub("concatenate")
+transport_stack = _stub("stack")
+transport_vstack = _stub("vstack")
+transport_hstack = _stub("hstack")
+transport_column_stack = _stub("column_stack")
+transport_split = _stub("split")
+transport_hsplit = _stub("hsplit")
+transport_vsplit = _stub("vsplit")
+transport_dsplit = _stub("dsplit")
+transport_atleast_1d = _stub("atleast_1d")
+transport_atleast_2d = _stub("atleast_2d")
+transport_atleast_3d = _stub("atleast_3d")
+transport_broadcast_to = _stub("broadcast_to")
+transport_expand_dims = _stub("expand_dims")
+transport_squeeze = _stub("squeeze")
+transport_flip = _stub("flip")
+transport_roll = _stub("roll")
+transport_tile = _stub("tile")
+transport_repeat = _stub("repeat")
+transport_transpose = _stub("transpose")
+transport_swapaxes = _stub("swapaxes")
+transport_moveaxis = _stub("moveaxis")
+transport_matrix_transpose = _stub("matrix_transpose")

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -278,8 +278,9 @@ def transport_broadcast_to(
     input_shape: tuple[int, ...],
     output_shape: tuple[int, ...],
 ) -> SymmetryGroup | None:
-    if group is None:
-        return None
+    # NOTE: broadcast_group handles `group is None` correctly — it can still
+    # produce a non-None result when prepended equal-size axes form a new
+    # S_k symmetry on the output. Do not short-circuit on None here.
     return broadcast_group(
         group, input_shape=input_shape, output_shape=output_shape,
     )

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -140,9 +140,46 @@ def transport_squeeze(
     axis_map = {a: new_index[a] for a in A}
     return remap_group_axes(group, axis_map)
 transport_flip = _stub("flip")
-transport_roll = _stub("roll")
 transport_tile = _stub("tile")
-transport_repeat = _stub("repeat")
+
+
+def transport_repeat(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+    axis: int | None,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    if axis is None:
+        # repeat(axis=None) ravels first -> never preserves multi-axis sym.
+        return None
+    a = axis % len(input_shape)
+    A = set(group.axes or range(group.degree))
+    if a in A:
+        return None
+    return group
+
+
+def transport_roll(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+    axis: int | tuple[int, ...] | None,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    if axis is None:
+        # roll(axis=None) flattens first -> always drops.
+        return None
+    if isinstance(axis, int):
+        rolled = {axis % len(input_shape)}
+    else:
+        rolled = {a % len(input_shape) for a in axis}
+    A = set(group.axes or range(group.degree))
+    if rolled & A:
+        return None
+    return group
 transport_transpose = _stub("transpose")
 transport_swapaxes = _stub("swapaxes")
 transport_moveaxis = _stub("moveaxis")

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -10,6 +10,7 @@ for the per-op rules and rationale.
 
 from __future__ import annotations
 
+import functools
 import math
 from collections.abc import Iterable, Sequence
 from typing import Any
@@ -34,6 +35,19 @@ def _stub(name: str):
     return _impl
 
 
+def _zero_size_guard(fn):
+    """Decorator: any transport receiving a zero-size shape drops to None."""
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        for key in ("input_shape", "output_shape"):
+            shape = kwargs.get(key)
+            if shape is not None and 0 in shape:
+                return None
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+@_zero_size_guard
 def transport_reshape(
     group: SymmetryGroup | None,
     *,
@@ -83,6 +97,7 @@ def transport_reshape(
     return remap_group_axes(group, axis_map)
 
 
+@_zero_size_guard
 def transport_ravel(
     group: SymmetryGroup | None,
     *,
@@ -191,6 +206,7 @@ def transport_column_stack(
         else:
             promoted.append(None)
     return transport_concatenate(promoted, output_ndim=output_ndim, axis=1)
+@_zero_size_guard
 def transport_split(
     group: SymmetryGroup | None,
     *,
@@ -207,6 +223,7 @@ def transport_split(
     return restrict_group_to_axes(group, keep)
 
 
+@_zero_size_guard
 def transport_hsplit(
     group: SymmetryGroup | None,
     *,
@@ -218,6 +235,7 @@ def transport_hsplit(
     return transport_split(group, input_shape=input_shape, axis=1)
 
 
+@_zero_size_guard
 def transport_vsplit(
     group: SymmetryGroup | None,
     *,
@@ -226,12 +244,14 @@ def transport_vsplit(
     return transport_split(group, input_shape=input_shape, axis=0)
 
 
+@_zero_size_guard
 def transport_dsplit(
     group: SymmetryGroup | None,
     *,
     input_shape: tuple[int, ...],
 ) -> SymmetryGroup | None:
     return transport_split(group, input_shape=input_shape, axis=2)
+@_zero_size_guard
 def transport_atleast_1d(
     group: SymmetryGroup | None,
     *,
@@ -244,6 +264,7 @@ def transport_atleast_1d(
     return group
 
 
+@_zero_size_guard
 def transport_atleast_2d(
     group: SymmetryGroup | None,
     *,
@@ -256,6 +277,7 @@ def transport_atleast_2d(
     return group
 
 
+@_zero_size_guard
 def transport_atleast_3d(
     group: SymmetryGroup | None,
     *,
@@ -272,6 +294,7 @@ def transport_atleast_3d(
         return group
     # len(input_shape) <= 1: cannot carry a multi-axis group; defensive None.
     return None
+@_zero_size_guard
 def transport_broadcast_to(
     group: SymmetryGroup | None,
     *,
@@ -293,6 +316,7 @@ def transport_expand_dims(
     axis,
 ) -> SymmetryGroup | None:
     return remap_group_for_expand_dims(group, ndim=input_ndim, axis=axis)
+@_zero_size_guard
 def transport_squeeze(
     group: SymmetryGroup | None,
     *,
@@ -337,6 +361,7 @@ def transport_flip(
     if not F_A or F_A == A:
         return group
     return setwise_stabilizer(group, fixed_set=F_A)
+@_zero_size_guard
 def transport_tile(
     group: SymmetryGroup | None,
     *,
@@ -361,6 +386,7 @@ def transport_tile(
     return remap_group_axes(group, axis_map)
 
 
+@_zero_size_guard
 def transport_repeat(
     group: SymmetryGroup | None,
     *,
@@ -379,6 +405,7 @@ def transport_repeat(
     return group
 
 
+@_zero_size_guard
 def transport_roll(
     group: SymmetryGroup | None,
     *,

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -16,10 +16,12 @@ from typing import Any
 
 from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetry_utils import (
+    broadcast_group,
     group_orbits_on_axes,
     intersect_groups,
     _normalize_reps_for_output,
     remap_group_axes,
+    remap_group_for_expand_dims,
     restrict_group_to_axes,
     setwise_stabilizer,
 )
@@ -270,8 +272,26 @@ def transport_atleast_3d(
         return group
     # len(input_shape) <= 1: cannot carry a multi-axis group; defensive None.
     return None
-transport_broadcast_to = _stub("broadcast_to")
-transport_expand_dims = _stub("expand_dims")
+def transport_broadcast_to(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    return broadcast_group(
+        group, input_shape=input_shape, output_shape=output_shape,
+    )
+
+
+def transport_expand_dims(
+    group: SymmetryGroup | None,
+    *,
+    input_ndim: int,
+    axis,
+) -> SymmetryGroup | None:
+    return remap_group_for_expand_dims(group, ndim=input_ndim, axis=axis)
 def transport_squeeze(
     group: SymmetryGroup | None,
     *,

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from flopscope._perm_group import SymmetryGroup
+from flopscope._symmetry_utils import remap_group_axes
 
 
 def _stub(name: str):
@@ -40,7 +41,30 @@ transport_atleast_2d = _stub("atleast_2d")
 transport_atleast_3d = _stub("atleast_3d")
 transport_broadcast_to = _stub("broadcast_to")
 transport_expand_dims = _stub("expand_dims")
-transport_squeeze = _stub("squeeze")
+def transport_squeeze(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+    axis: int | tuple[int, ...] | None,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    A = group.axes or tuple(range(group.degree))
+    # Resolve axis to a sorted tuple of axes being squeezed.
+    if axis is None:
+        squeezed = tuple(i for i, s in enumerate(input_shape) if s == 1)
+    elif isinstance(axis, int):
+        squeezed = (axis % len(input_shape),)
+    else:
+        squeezed = tuple(sorted(a % len(input_shape) for a in axis))
+    # Rule (b): if any squeezed axis is in the block, drop.
+    if any(a in A for a in squeezed):
+        return None
+    # Rule (a): shift block axes > each squeezed axis down by 1, preserving order.
+    surviving = sorted(i for i in range(len(input_shape)) if i not in squeezed)
+    new_index = {old: new for new, old in enumerate(surviving)}
+    axis_map = {a: new_index[a] for a in A}
+    return remap_group_axes(group, axis_map)
 transport_flip = _stub("flip")
 transport_roll = _stub("roll")
 transport_tile = _stub("tile")

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -81,9 +81,52 @@ def transport_stack(
         if result is None:
             return None
     return result
-transport_vstack = _stub("vstack")
-transport_hstack = _stub("hstack")
-transport_column_stack = _stub("column_stack")
+def transport_vstack(
+    groups: Sequence[SymmetryGroup | None],
+    *,
+    output_ndim: int,
+    input_ndims: Sequence[int],
+) -> SymmetryGroup | None:
+    # vstack: atleast_2d each input, then concat axis=0.
+    # For any input that's 1-D, the promoted form has the data axis at position 1,
+    # and 1-D inputs carry no multi-axis group anyway -> None for them.
+    promoted = []
+    for g, nd in zip(groups, input_ndims):
+        if nd >= 2:
+            promoted.append(g)
+        else:
+            # 1-D input promoted to (1, N) -- no multi-axis group.
+            promoted.append(None)
+    return transport_concatenate(promoted, output_ndim=output_ndim, axis=0)
+
+
+def transport_hstack(
+    groups: Sequence[SymmetryGroup | None],
+    *,
+    output_ndim: int,
+    input_ndims: Sequence[int],
+) -> SymmetryGroup | None:
+    # hstack: concat axis=0 if all 1-D, else axis=1.
+    if all(nd == 1 for nd in input_ndims):
+        return transport_concatenate(groups, output_ndim=output_ndim, axis=0)
+    return transport_concatenate(groups, output_ndim=output_ndim, axis=1)
+
+
+def transport_column_stack(
+    groups: Sequence[SymmetryGroup | None],
+    *,
+    output_ndim: int,
+    input_ndims: Sequence[int],
+) -> SymmetryGroup | None:
+    # column_stack: promote 1-D (N,) -> (N, 1), then concat axis=1.
+    # 1-D inputs become column vectors with no multi-axis group.
+    promoted = []
+    for g, nd in zip(groups, input_ndims):
+        if nd >= 2:
+            promoted.append(g)
+        else:
+            promoted.append(None)
+    return transport_concatenate(promoted, output_ndim=output_ndim, axis=1)
 def transport_split(
     group: SymmetryGroup | None,
     *,

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -56,7 +56,31 @@ def transport_concatenate(
         if result is None:
             return None
     return result
-transport_stack = _stub("stack")
+def transport_stack(
+    groups: Sequence[SymmetryGroup | None],
+    *,
+    output_ndim: int,
+    axis: int = 0,
+) -> SymmetryGroup | None:
+    if any(g is None for g in groups):
+        return None
+    k = axis % output_ndim
+    # Shift each input's block axes >= k by +1.
+    shifted = []
+    for g in groups:
+        A = g.axes or tuple(range(g.degree))
+        axis_map = {a: (a if a < k else a + 1) for a in A}
+        r = remap_group_axes(g, axis_map)
+        if r is None:
+            return None
+        shifted.append(r)
+    # Intersect.
+    result = shifted[0]
+    for g in shifted[1:]:
+        result = intersect_groups(result, g, ndim=output_ndim)
+        if result is None:
+            return None
+    return result
 transport_vstack = _stub("vstack")
 transport_hstack = _stub("hstack")
 transport_column_stack = _stub("column_stack")

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from flopscope._perm_group import SymmetryGroup
-from flopscope._symmetry_utils import remap_group_axes
+from flopscope._symmetry_utils import remap_group_axes, restrict_group_to_axes
 
 
 def _stub(name: str):
@@ -32,10 +32,47 @@ transport_stack = _stub("stack")
 transport_vstack = _stub("vstack")
 transport_hstack = _stub("hstack")
 transport_column_stack = _stub("column_stack")
-transport_split = _stub("split")
-transport_hsplit = _stub("hsplit")
-transport_vsplit = _stub("vsplit")
-transport_dsplit = _stub("dsplit")
+def transport_split(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+    axis: int = 0,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    a = axis % len(input_shape)
+    A = group.axes or tuple(range(group.degree))
+    keep = tuple(x for x in A if x != a)
+    if len(keep) < 2:
+        return None
+    return restrict_group_to_axes(group, keep)
+
+
+def transport_hsplit(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    # hsplit uses axis=0 for 1-D, axis=1 otherwise.
+    if len(input_shape) == 1:
+        return transport_split(group, input_shape=input_shape, axis=0)
+    return transport_split(group, input_shape=input_shape, axis=1)
+
+
+def transport_vsplit(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    return transport_split(group, input_shape=input_shape, axis=0)
+
+
+def transport_dsplit(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    return transport_split(group, input_shape=input_shape, axis=2)
 def transport_atleast_1d(
     group: SymmetryGroup | None,
     *,

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from flopscope._perm_group import SymmetryGroup
-from flopscope._symmetry_utils import remap_group_axes, restrict_group_to_axes
+from flopscope._symmetry_utils import intersect_groups, remap_group_axes, restrict_group_to_axes
 
 
 def _stub(name: str):
@@ -27,7 +27,35 @@ def _stub(name: str):
 # Stubs — replaced in subsequent tasks.
 transport_reshape = _stub("reshape")
 transport_ravel = _stub("ravel")
-transport_concatenate = _stub("concatenate")
+def transport_concatenate(
+    groups: Sequence[SymmetryGroup | None],
+    *,
+    output_ndim: int,
+    axis: int | None,
+) -> SymmetryGroup | None:
+    if axis is None:
+        return None
+    if any(g is None for g in groups):
+        return None
+    # Restrict each input's group to axes != axis.
+    restricted = []
+    for g in groups:
+        A = g.axes or tuple(range(g.degree))
+        a = axis % (max(output_ndim, len(A) + 1))
+        keep = tuple(x for x in A if x != a)
+        if len(keep) < 2:
+            return None
+        r = restrict_group_to_axes(g, keep)
+        if r is None:
+            return None
+        restricted.append(r)
+    # Intersect across all restricted groups.
+    result = restricted[0]
+    for g in restricted[1:]:
+        result = intersect_groups(result, g, ndim=output_ndim)
+        if result is None:
+            return None
+    return result
 transport_stack = _stub("stack")
 transport_vstack = _stub("vstack")
 transport_hstack = _stub("hstack")

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -119,7 +119,8 @@ def transport_concatenate(
     # Restrict each input's group to axes != axis.
     restricted = []
     for g in groups:
-        A = g.axes or tuple(range(g.degree))
+        assert g is not None  # narrowed by the earlier any(g is None) check
+        A = g.axes if g.axes is not None else tuple(range(g.degree))
         a = axis % (max(output_ndim, len(A) + 1))
         keep = tuple(x for x in A if x != a)
         if len(keep) < 2:
@@ -149,7 +150,8 @@ def transport_stack(
     # Shift each input's block axes >= k by +1.
     shifted = []
     for g in groups:
-        A = g.axes or tuple(range(g.degree))
+        assert g is not None  # narrowed by the earlier any(g is None) check
+        A = g.axes if g.axes is not None else tuple(range(g.degree))
         axis_map = {a: (a if a < k else a + 1) for a in A}
         r = remap_group_axes(g, axis_map)
         if r is None:
@@ -428,7 +430,7 @@ def transport_roll(
     group: SymmetryGroup | None,
     *,
     input_shape: tuple[int, ...],
-    axis: int | tuple[int, ...] | None,
+    axis: int | Sequence[int] | None,
 ) -> SymmetryGroup | None:
     if group is None:
         return None

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -10,6 +10,7 @@ for the per-op rules and rationale.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -24,9 +25,63 @@ def _stub(name: str):
     return _impl
 
 
-# Stubs — replaced in subsequent tasks.
-transport_reshape = _stub("reshape")
-transport_ravel = _stub("ravel")
+def transport_reshape(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    A = group.axes or tuple(range(group.degree))
+    m = input_shape[A[0]]  # block axis size (must be equal for all a in A by group validity)
+
+    A_sorted = sorted(A)
+    n = len(A_sorted)
+
+    # Skeleton segment products from input (n+1 segments interleaved with n block axes).
+    seg_input = []
+    prev = -1
+    for a in A_sorted:
+        seg_input.append(math.prod(input_shape[prev + 1 : a]))
+        prev = a
+    seg_input.append(math.prod(input_shape[prev + 1 :]))
+
+    # Walk through output, matching one segment then one block axis at a time.
+    out_positions: list[int] = []
+    pos = 0
+    for k in range(n):
+        target = seg_input[k]
+        accum = 1
+        while accum < target and pos < len(output_shape):
+            accum *= output_shape[pos]
+            pos += 1
+        if accum != target:
+            return None
+        # Skip length-1 padding axes between segment and block axis (unless m == 1).
+        if m != 1:
+            while pos < len(output_shape) and output_shape[pos] == 1:
+                pos += 1
+        if pos >= len(output_shape) or output_shape[pos] != m:
+            return None
+        out_positions.append(pos)
+        pos += 1
+
+    if math.prod(output_shape[pos:]) != seg_input[-1]:
+        return None
+
+    axis_map = {a: out_positions[A_sorted.index(a)] for a in A}
+    return remap_group_axes(group, axis_map)
+
+
+def transport_ravel(
+    group: SymmetryGroup | None,
+    *,
+    input_shape: tuple[int, ...],
+) -> SymmetryGroup | None:
+    return transport_reshape(
+        group, input_shape=input_shape, output_shape=(math.prod(input_shape),),
+    )
 def transport_concatenate(
     groups: Sequence[SymmetryGroup | None],
     *,

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -180,7 +180,64 @@ def transport_roll(
     if rolled & A:
         return None
     return group
-transport_transpose = _stub("transpose")
-transport_swapaxes = _stub("swapaxes")
-transport_moveaxis = _stub("moveaxis")
-transport_matrix_transpose = _stub("matrix_transpose")
+def transport_transpose(
+    group: SymmetryGroup | None,
+    *,
+    ndim: int,
+    axes: Sequence[int] | None = None,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    if axes is None:
+        order = tuple(reversed(range(ndim)))
+    else:
+        order = tuple(a % ndim for a in axes)
+    mapping = {old: new for new, old in enumerate(order)}
+    return remap_group_axes(group, mapping)
+
+
+def transport_swapaxes(
+    group: SymmetryGroup | None,
+    *,
+    ndim: int,
+    axis1: int,
+    axis2: int,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    a1 = axis1 % ndim
+    a2 = axis2 % ndim
+    order = list(range(ndim))
+    order[a1], order[a2] = order[a2], order[a1]
+    mapping = {old: new for new, old in enumerate(order)}
+    return remap_group_axes(group, mapping)
+
+
+def transport_moveaxis(
+    group: SymmetryGroup | None,
+    *,
+    ndim: int,
+    source: int | Sequence[int],
+    destination: int | Sequence[int],
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    src = (source,) if isinstance(source, int) else tuple(source)
+    dst = (destination,) if isinstance(destination, int) else tuple(destination)
+    src = tuple(s % ndim for s in src)
+    dst = tuple(d % ndim for d in dst)
+    order = [i for i in range(ndim) if i not in src]
+    for d, s in sorted(zip(dst, src)):
+        order.insert(d, s)
+    mapping = {old: new for new, old in enumerate(order)}
+    return remap_group_axes(group, mapping)
+
+
+def transport_matrix_transpose(
+    group: SymmetryGroup | None,
+    *,
+    ndim: int,
+) -> SymmetryGroup | None:
+    if ndim < 2:
+        return None
+    return transport_swapaxes(group, ndim=ndim, axis1=ndim - 2, axis2=ndim - 1)

--- a/src/flopscope/_symmetry_transport.py
+++ b/src/flopscope/_symmetry_transport.py
@@ -15,7 +15,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from flopscope._perm_group import SymmetryGroup
-from flopscope._symmetry_utils import intersect_groups, remap_group_axes, restrict_group_to_axes
+from flopscope._symmetry_utils import intersect_groups, remap_group_axes, restrict_group_to_axes, setwise_stabilizer
 
 
 def _stub(name: str):
@@ -289,7 +289,26 @@ def transport_squeeze(
     new_index = {old: new for new, old in enumerate(surviving)}
     axis_map = {a: new_index[a] for a in A}
     return remap_group_axes(group, axis_map)
-transport_flip = _stub("flip")
+def transport_flip(
+    group: SymmetryGroup | None,
+    *,
+    ndim: int,
+    axes_flipped,
+) -> SymmetryGroup | None:
+    if group is None:
+        return None
+    # Normalize axes_flipped: None -> all, int -> tuple, negative wrap.
+    if axes_flipped is None:
+        F = set(range(ndim))
+    elif isinstance(axes_flipped, int):
+        F = {axes_flipped % ndim}
+    else:
+        F = {a % ndim for a in axes_flipped}
+    A = set(group.axes or range(group.degree))
+    F_A = F & A
+    if not F_A or F_A == A:
+        return group
+    return setwise_stabilizer(group, fixed_set=F_A)
 transport_tile = _stub("tile")
 
 

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -169,7 +169,11 @@ def restrict_group_to_axes(
         local_indices.append(group_axes.index(axis))
     if len(local_indices) < 2:
         return None
-    restricted = group.restrict(tuple(local_indices))
+    kept = tuple(local_indices)
+    # First compute the setwise stabilizer so that restrict() only sees
+    # permutations that map the kept set to itself.
+    stabilized = group.setwise_stabilizer(set(kept))
+    restricted = stabilized.restrict(kept)
     if restricted.order() <= 1:
         return None
     return restricted

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -307,8 +307,46 @@ def setwise_stabilizer(
     return result if result.order() > 1 else None
 
 
-def group_orbits_on_axes(*args, **kwargs):  # populated in Task 3
-    raise NotImplementedError("group_orbits_on_axes implemented in Task 3")
+def group_orbits_on_axes(
+    group: SymmetryGroup,
+    axes: Sequence[int],
+) -> list[set[int]]:
+    """Return the orbits of `group`'s action on the given tensor `axes`.
+
+    Axes not acted on by `group` are returned as singleton orbits. Output
+    order is deterministic (axes appear in their first-encounter order).
+    """
+    axis_list = list(axes)
+    group_axes = group.axes
+    if group_axes is None:
+        group_axes = tuple(range(group.degree))
+    # Map: tensor-axis -> set of tensor-axes reachable by any generator.
+    # For axes outside group_axes, the orbit is just itself.
+    seen: set[int] = set()
+    orbits: list[set[int]] = []
+    for a in axis_list:
+        if a in seen:
+            continue
+        if a not in group_axes:
+            orbits.append({a})
+            seen.add(a)
+            continue
+        orbit: set[int] = set()
+        frontier = {a}
+        while frontier:
+            x = frontier.pop()
+            if x in orbit:
+                continue
+            orbit.add(x)
+            local_x = group_axes.index(x)
+            for generator in group.generators:
+                local_y = generator.array_form[local_x]
+                y = group_axes[local_y]
+                if y not in orbit:
+                    frontier.add(y)
+        orbits.append(orbit)
+        seen |= orbit
+    return orbits
 
 
 def _normalize_reps_for_output(*args, **kwargs):  # populated in Task 4

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -286,6 +286,35 @@ def direct_product_groups(*groups: SymmetryGroup | None) -> SymmetryGroup | None
     return product if product.order() > 1 else None
 
 
+def setwise_stabilizer(
+    group: SymmetryGroup | None,
+    fixed_set: Iterable[int],
+) -> SymmetryGroup | None:
+    """Return the subgroup G' = {π ∈ G : π(fixed_set) = fixed_set}.
+
+    `fixed_set` is interpreted as tensor-axis indices; elements not in
+    ``group.axes`` are silently filtered out. Returns ``None`` if the
+    stabilizer is trivial (order ≤ 1).
+    """
+    if group is None:
+        return None
+    axes = group.axes
+    if axes is None:
+        axes = tuple(range(group.degree))
+    # Translate tensor-axis indices to internal degree indices.
+    internal = {axes.index(a) for a in fixed_set if a in axes}
+    result = group.setwise_stabilizer(internal)
+    return result if result.order() > 1 else None
+
+
+def group_orbits_on_axes(*args, **kwargs):  # populated in Task 3
+    raise NotImplementedError("group_orbits_on_axes implemented in Task 3")
+
+
+def _normalize_reps_for_output(*args, **kwargs):  # populated in Task 4
+    raise NotImplementedError("_normalize_reps_for_output implemented in Task 4")
+
+
 def broadcast_group(
     group: SymmetryGroup | None,
     *,

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -349,8 +349,19 @@ def group_orbits_on_axes(
     return orbits
 
 
-def _normalize_reps_for_output(*args, **kwargs):  # populated in Task 4
-    raise NotImplementedError("_normalize_reps_for_output implemented in Task 4")
+def _normalize_reps_for_output(reps, *, output_ndim: int) -> tuple[int, ...]:
+    """Normalize `reps` arg to a tuple of length `output_ndim`.
+
+    Matches NumPy.tile's right-alignment rule: if `reps` is shorter, it's
+    prepended with 1s. If `reps` is a scalar, treat as `(reps,)`.
+    """
+    if isinstance(reps, int):
+        reps_tup = (reps,)
+    else:
+        reps_tup = tuple(reps)
+    if len(reps_tup) < output_ndim:
+        reps_tup = (1,) * (output_ndim - len(reps_tup)) + reps_tup
+    return reps_tup
 
 
 def broadcast_group(

--- a/src/flopscope/errors.py
+++ b/src/flopscope/errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings as _warnings
 
 _DEFAULT_DOCS_ROOT = "https://aicrowd.github.io/flopscope/docs"
 _BUDGET_DOCS_PATH = "/guides/budget-planning"
@@ -153,13 +154,12 @@ class CostFallbackWarning(FlopscopeWarning):
     """
 
 
-import os as _os
 import sys as _sys
 import warnings as _warnings
 
 
 # Used by _user_stacklevel() to skip frames inside the flopscope package.
-_FLOPSCOPE_PKG_DIR = _os.path.dirname(_os.path.abspath(__file__))
+_FLOPSCOPE_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def _user_stacklevel() -> int:

--- a/src/flopscope/errors.py
+++ b/src/flopscope/errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys as _sys
 import warnings as _warnings
 
 _DEFAULT_DOCS_ROOT = "https://aicrowd.github.io/flopscope/docs"
@@ -152,10 +153,6 @@ class CostFallbackWarning(FlopscopeWarning):
     flag with :class:`SymmetryLossWarning` since both are
     symmetry-related diagnostics).
     """
-
-
-import sys as _sys
-import warnings as _warnings
 
 
 # Used by _user_stacklevel() to skip frames inside the flopscope package.

--- a/src/flopscope/errors.py
+++ b/src/flopscope/errors.py
@@ -151,3 +151,49 @@ class CostFallbackWarning(FlopscopeWarning):
     flag with :class:`SymmetryLossWarning` since both are
     symmetry-related diagnostics).
     """
+
+
+import os as _os
+import sys as _sys
+import warnings as _warnings
+
+
+# Used by _user_stacklevel() to skip frames inside the flopscope package.
+_FLOPSCOPE_PKG_DIR = _os.path.dirname(_os.path.abspath(__file__))
+
+
+def _user_stacklevel() -> int:
+    """Stacklevel for :func:`warnings.warn` that points to the first frame
+    outside the ``flopscope`` package — i.e. the user's call site.
+
+    Walks the active call stack starting from the caller of
+    :func:`_warn_symmetry_loss`. Robust to changes in the number of
+    decorator/wrapper layers between user code and the warn site.
+    """
+    frame = _sys._getframe(2)
+    level = 2
+    while frame is not None:
+        if not frame.f_code.co_filename.startswith(_FLOPSCOPE_PKG_DIR):
+            return level
+        frame = frame.f_back
+        level += 1
+    return 3
+
+
+def _warn_symmetry_loss(
+    lost_dims: list[tuple[int, ...]],
+    reason: str,
+) -> None:
+    """Emit a :class:`SymmetryLossWarning` if warnings are enabled."""
+    from flopscope._config import get_setting
+
+    if not get_setting("symmetry_warnings"):
+        return
+    dim_str = ", ".join(str(g) for g in lost_dims)
+    _warnings.warn(
+        f"Symmetry lost along dims {dim_str}: {reason}. "
+        "Use as_symmetric() to re-tag if you know the result is symmetric. "
+        "Suppress with flops.configure(symmetry_warnings=False).",
+        SymmetryLossWarning,
+        stacklevel=_user_stacklevel(),
+    )

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -16,6 +16,7 @@ import pytest
 import flopscope as flops
 import flopscope.numpy as fnp
 from flopscope._ndarray import FlopscopeArray
+from flopscope.errors import SymmetryLossWarning
 
 # ----- __array_ufunc__: ufunc.__call__ -----
 
@@ -695,7 +696,8 @@ def test_diagonal_of_3sym_downgrades_when_no_tensor_axis_symmetry_remains():
         symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1, 2)),
     )
     with flops.BudgetContext(flop_budget=int(1e9)):
-        d = fnp.diagonal(A)
+        with pytest.warns(SymmetryLossWarning):
+            d = fnp.diagonal(A)
     assert not isinstance(d, flops.SymmetricTensor)
     assert isinstance(d, fnp.ndarray)
 

--- a/tests/test_free_ops_extended.py
+++ b/tests/test_free_ops_extended.py
@@ -11,6 +11,7 @@ import flopscope as flops
 import flopscope._free_ops as ops
 import flopscope.numpy as fnp
 from flopscope._symmetric import SymmetricTensor
+from flopscope.errors import SymmetryLossWarning
 
 # ---------------------------------------------------------------------------
 # Helper
@@ -190,7 +191,8 @@ def test_ravel():
 
 def test_ravel_drops_symmetry():
     a = flops.as_symmetric(numpy.eye(3), symmetry=(0, 1))
-    r = ops.ravel(a)
+    with pytest.warns(SymmetryLossWarning):
+        r = ops.ravel(a)
     assert r.shape == (9,)
     assert not isinstance(r, SymmetricTensor)
 

--- a/tests/test_method_tracking.py
+++ b/tests/test_method_tracking.py
@@ -14,6 +14,7 @@ import pytest
 
 import flopscope as flops
 import flopscope.numpy as fnp
+from flopscope.errors import SymmetryLossWarning
 
 # ----- #58: ndarray method calls on FlopscopeArray must track FLOPs -----
 
@@ -324,7 +325,8 @@ def test_no_symmetry_downgrades_to_whest_array_via_diagonal():
         symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
     )
     with flops.BudgetContext(flop_budget=int(1e9)):
-        d = fnp.diagonal(A)
+        with pytest.warns(SymmetryLossWarning):
+            d = fnp.diagonal(A)
     assert not isinstance(d, flops.SymmetricTensor), (
         f"got {type(d).__name__} with empty symmetry; expected FlopscopeArray"
     )
@@ -338,7 +340,8 @@ def test_no_symmetry_downgrades_via_full_reduction():
         symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
     )
     with flops.BudgetContext(flop_budget=int(1e9)):
-        s = A.sum()  # scalar — but if returned as array, must be FlopscopeArray
+        with pytest.warns(SymmetryLossWarning):
+            s = A.sum()  # scalar — but if returned as array, must be FlopscopeArray
     assert not isinstance(s, flops.SymmetricTensor)
 
 
@@ -366,7 +369,8 @@ def test_symmetric_getitem_full_reduction_via_indexing_returns_whest_array():
         symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
     )
     with flops.BudgetContext(flop_budget=int(1e9)):
-        row = A[0]
+        with pytest.warns(SymmetryLossWarning):
+            row = A[0]
     assert not isinstance(row, flops.SymmetricTensor)
     assert isinstance(row, fnp.ndarray)
     assert row.shape == (4,)
@@ -427,6 +431,7 @@ def test_issue_62_reproducer():
         symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
     )
     with flops.BudgetContext(flop_budget=int(1e9)):
-        d = fnp.diagonal(A)
+        with pytest.warns(SymmetryLossWarning):
+            d = fnp.diagonal(A)
     assert not isinstance(d, flops.SymmetricTensor)
     assert isinstance(d, fnp.ndarray)

--- a/tests/test_pointwise_coverage.py
+++ b/tests/test_pointwise_coverage.py
@@ -201,7 +201,8 @@ class TestBinarySymmetric:
         plain = numpy.ones((4, 4)) * numpy.arange(4)  # Not symmetric
         with BudgetContext(flop_budget=10**6):
             # intersect_symmetry gets called; one operand has no symmetry
-            result = multiply(st, plain)
+            with pytest.warns(SymmetryLossWarning):
+                result = multiply(st, plain)
         # intersect_symmetry returns None when one has no groups
         # so result should not be SymmetricTensor
         assert not isinstance(result, SymmetricTensor)

--- a/tests/test_pointwise_extended.py
+++ b/tests/test_pointwise_extended.py
@@ -11,6 +11,7 @@ import pytest
 import flopscope._pointwise as ops
 from flopscope._budget import BudgetContext
 from flopscope._symmetric import SymmetricTensor, as_symmetric
+from flopscope.errors import SymmetryLossWarning
 
 # ---------------------------------------------------------------------------
 # Multi-output unary ops
@@ -268,7 +269,8 @@ def test_binary_op_mismatched_symmetry_returns_plain():
     x = as_symmetric(d1, symmetry=(0, 1))
     # y is a plain ndarray (no symmetry_info)
     with BudgetContext(flop_budget=10**6):
-        result = ops.add(x, d2)
+        with pytest.warns(SymmetryLossWarning):
+            result = ops.add(x, d2)
     # Plain array — no SymmetricTensor wrapping
     assert not isinstance(result, SymmetricTensor)
 

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -361,3 +361,84 @@ class TestTransportVHColumnStack:
             [G, G], output_ndim=2, input_ndims=[2, 2],
         )
         assert result is None
+
+
+class TestTransportReshape:
+    def test_identity_reshape_preserves(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(0, 1)
+        result = transport_reshape(G, input_shape=(3, 3), output_shape=(3, 3))
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_identity_with_interior_length_1_preserves(self):
+        # The bug found by math-olympiad review: (3,1,3) -> (3,1,3) with S_2 on (0,2).
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(0, 2)
+        result = transport_reshape(G, input_shape=(3, 1, 3), output_shape=(3, 1, 3))
+        assert result is not None and set(result.axes) == {0, 2}
+
+    def test_suffix_split_off_block_preserves(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(1, 2)
+        # (2, 3, 3, 4) -> (2, 3, 3, 2, 2): last axis 4 splits to (2,2), block intact.
+        result = transport_reshape(
+            G, input_shape=(2, 3, 3, 4), output_shape=(2, 3, 3, 2, 2),
+        )
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_merge_inside_block_drops(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(1, 2)
+        # (2, 3, 3, 4) -> (2, 9, 4): merges two block axes -> drop.
+        result = transport_reshape(
+            G, input_shape=(2, 3, 3, 4), output_shape=(2, 9, 4),
+        )
+        assert result is None
+
+    def test_merge_block_with_prefix_drops(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(1, 2)
+        # (2, 3, 3, 4) -> (6, 3, 4): merges axis 0 with axis 1 (block).
+        result = transport_reshape(
+            G, input_shape=(2, 3, 3, 4), output_shape=(6, 3, 4),
+        )
+        assert result is None
+
+    def test_prepend_length_1(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(0, 1)
+        # (3, 3) -> (1, 3, 3): block shifts to (1, 2).
+        result = transport_reshape(
+            G, input_shape=(3, 3), output_shape=(1, 3, 3),
+        )
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_non_contiguous_block_preserved(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(0, 2)
+        # (3, 5, 3) -> (1, 3, 5, 3): non-contig block preserved at (1, 3).
+        result = transport_reshape(
+            G, input_shape=(3, 5, 3), output_shape=(1, 3, 5, 3),
+        )
+        assert result is not None and set(result.axes) == {1, 3}
+
+    def test_swap_block_with_non_block_drops(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(0, 2)
+        # (3, 5, 3) -> (3, 3, 5): cannot be done by reshape; segment match fails.
+        result = transport_reshape(
+            G, input_shape=(3, 5, 3), output_shape=(3, 3, 5),
+        )
+        assert result is None
+
+
+class TestTransportRavel:
+    def test_ravel_drops_for_nondegenerate(self):
+        from flopscope._symmetry_transport import transport_ravel
+        G = _sym(0, 1)
+        result = transport_ravel(G, input_shape=(3, 3))
+        assert result is None  # Block of size 3 can't fit in 1-axis output of size 9.
+
+    def test_ravel_for_none_input(self):
+        from flopscope._symmetry_transport import transport_ravel
+        assert transport_ravel(None, input_shape=(3, 3)) is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -69,3 +69,40 @@ class TestTransportSqueeze:
     def test_squeeze_none_input_returns_none(self):
         from flopscope._symmetry_transport import transport_squeeze
         assert transport_squeeze(None, input_shape=(1, 3, 3), axis=0) is None
+
+
+class TestTransportAtleast:
+    def test_atleast_1d_noop_on_2d(self):
+        from flopscope._symmetry_transport import transport_atleast_1d
+        G = _sym(0, 1)
+        result = transport_atleast_1d(G, input_shape=(3, 3))
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_atleast_2d_noop_on_2d(self):
+        from flopscope._symmetry_transport import transport_atleast_2d
+        G = _sym(0, 1)
+        result = transport_atleast_2d(G, input_shape=(3, 3))
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_atleast_3d_appends_trailing_axis_for_2d(self):
+        from flopscope._symmetry_transport import transport_atleast_3d
+        G = _sym(0, 1)
+        # NumPy: (M, N) -> (M, N, 1). Block axes unchanged.
+        result = transport_atleast_3d(G, input_shape=(3, 3))
+        assert result is not None
+        assert set(result.axes) == {0, 1}
+        assert result.order() == 2
+
+    def test_atleast_3d_noop_on_3d(self):
+        from flopscope._symmetry_transport import transport_atleast_3d
+        G = _sym(1, 2)
+        result = transport_atleast_3d(G, input_shape=(4, 3, 3))
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_atleast_kd_none_input(self):
+        from flopscope._symmetry_transport import (
+            transport_atleast_1d, transport_atleast_2d, transport_atleast_3d,
+        )
+        assert transport_atleast_1d(None, input_shape=(3, 3)) is None
+        assert transport_atleast_2d(None, input_shape=(3, 3)) is None
+        assert transport_atleast_3d(None, input_shape=(3, 3)) is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -673,3 +673,17 @@ class TestOutOfScopeOpsWarn:
         with pytest.warns(SymmetryLossWarning):
             result = fnp.block([T, np.eye(3)])
         assert not isinstance(result, SymmetricTensor)
+
+
+class TestZeroSizeDefensive:
+    def test_reshape_zero_size_input_drops(self):
+        from flopscope._symmetry_transport import transport_reshape
+        G = _sym(0, 1)
+        result = transport_reshape(G, input_shape=(0, 3), output_shape=(0, 3))
+        assert result is None
+
+    def test_split_zero_size_input_drops(self):
+        from flopscope._symmetry_transport import transport_split
+        G = _sym(1, 2)
+        result = transport_split(G, input_shape=(0, 3, 3), axis=0)
+        assert result is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -316,3 +316,48 @@ class TestTransportStack:
         result = transport_stack([G, G], output_ndim=3, axis=2)
         assert result is not None
         assert set(result.axes) == {0, 1}
+
+
+class TestTransportVHColumnStack:
+    def test_vstack_two_2d_concat_along_0(self):
+        from flopscope._symmetry_transport import transport_vstack
+        G = _sym(0, 1)
+        # vstack of two (3,3) S_2 along axis 0; restrict to {1} -> degree-1 -> drop.
+        result = transport_vstack(
+            [G, G], output_ndim=2, input_ndims=[2, 2],
+        )
+        assert result is None
+
+    def test_vstack_two_3d_along_0(self):
+        from flopscope._symmetry_transport import transport_vstack
+        G = _sym(1, 2)
+        # vstack of two (2,3,3) S_2(1,2) along axis 0 (outside block).
+        result = transport_vstack(
+            [G, G], output_ndim=3, input_ndims=[3, 3],
+        )
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_hstack_2d_along_1(self):
+        from flopscope._symmetry_transport import transport_hstack
+        G = _sym(0, 1)
+        # hstack of two (3,3) S_2; axis=1 in block -> drop.
+        result = transport_hstack(
+            [G, G], output_ndim=2, input_ndims=[2, 2],
+        )
+        assert result is None
+
+    def test_hstack_1d_all(self):
+        from flopscope._symmetry_transport import transport_hstack
+        # All 1-D inputs -> concat axis 0. 1-D inputs have no multi-axis group.
+        assert transport_hstack(
+            [None, None], output_ndim=1, input_ndims=[1, 1],
+        ) is None
+
+    def test_column_stack_2d_inputs(self):
+        from flopscope._symmetry_transport import transport_column_stack
+        G = _sym(0, 1)
+        # Two (3,3) S_2 inputs concat along axis 1; axis 1 in block -> drop.
+        result = transport_column_stack(
+            [G, G], output_ndim=2, input_ndims=[2, 2],
+        )
+        assert result is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -98,7 +98,7 @@ class TestTransportSqueeze:
         result = transport_squeeze(G, input_shape=(1, 3, 3), axis=0)
         # After squeeze, block axes (1, 2) shift to (0, 1).
         assert result is not None
-        assert set(result.axes) == {0, 1}
+        assert set(result.axes or ()) == {0, 1}
         assert result.order() == 2
 
     def test_squeeze_inside_block_drops(self):
@@ -116,7 +116,7 @@ class TestTransportSqueeze:
         G = _sym(1, 2)
         result = transport_squeeze(G, input_shape=(1, 3, 3, 1), axis=None)
         assert result is not None
-        assert set(result.axes) == {0, 1}
+        assert set(result.axes or ()) == {0, 1}
 
     def test_squeeze_none_input_returns_none(self):
         from flopscope._symmetry_transport import transport_squeeze
@@ -130,14 +130,14 @@ class TestTransportAtleast:
 
         G = _sym(0, 1)
         result = transport_atleast_1d(G, input_shape=(3, 3))
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_atleast_2d_noop_on_2d(self):
         from flopscope._symmetry_transport import transport_atleast_2d
 
         G = _sym(0, 1)
         result = transport_atleast_2d(G, input_shape=(3, 3))
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_atleast_3d_appends_trailing_axis_for_2d(self):
         from flopscope._symmetry_transport import transport_atleast_3d
@@ -146,7 +146,7 @@ class TestTransportAtleast:
         # NumPy: (M, N) -> (M, N, 1). Block axes unchanged.
         result = transport_atleast_3d(G, input_shape=(3, 3))
         assert result is not None
-        assert set(result.axes) == {0, 1}
+        assert set(result.axes or ()) == {0, 1}
         assert result.order() == 2
 
     def test_atleast_3d_noop_on_3d(self):
@@ -154,7 +154,7 @@ class TestTransportAtleast:
 
         G = _sym(1, 2)
         result = transport_atleast_3d(G, input_shape=(4, 3, 3))
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_atleast_kd_none_input(self):
         from flopscope._symmetry_transport import (
@@ -176,7 +176,7 @@ class TestTransportSplit:
         G = _sym(1, 2)
         result = transport_split(G, input_shape=(4, 3, 3), axis=0)
         assert result is not None
-        assert set(result.axes) == {1, 2}
+        assert set(result.axes or ()) == {1, 2}
         assert result.order() == 2
 
     def test_split_in_block_drops_for_degree2(self):
@@ -193,7 +193,7 @@ class TestTransportSplit:
         G = _sym(0, 1, 2)
         result = transport_split(G, input_shape=(3, 3, 3), axis=0)
         assert result is not None
-        assert set(result.axes) == {1, 2}
+        assert set(result.axes or ()) == {1, 2}
         assert result.order() == 2
 
     def test_hsplit_for_1d(self):
@@ -215,7 +215,7 @@ class TestTransportSplit:
         G = _sym(1, 2)
         # vsplit on (4, 3, 3) splits along axis 0 (outside block) -> preserves.
         result = transport_vsplit(G, input_shape=(4, 3, 3))
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_dsplit_uses_axis_2(self):
         from flopscope._symmetry_transport import transport_dsplit
@@ -223,7 +223,7 @@ class TestTransportSplit:
         G = _sym(0, 1)
         # dsplit on (3, 3, 6) splits along axis 2 (outside block) -> preserves.
         result = transport_dsplit(G, input_shape=(3, 3, 6))
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
 
 class TestTransportRepeatRoll:
@@ -232,7 +232,7 @@ class TestTransportRepeatRoll:
 
         G = _sym(0, 1)
         result = transport_repeat(G, input_shape=(3, 3, 4), axis=2)
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_repeat_inside_block_drops(self):
         from flopscope._symmetry_transport import transport_repeat
@@ -253,7 +253,7 @@ class TestTransportRepeatRoll:
 
         G = _sym(0, 1)
         result = transport_roll(G, input_shape=(3, 3, 4), axis=2)
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_roll_inside_block_drops(self):
         from flopscope._symmetry_transport import transport_roll
@@ -276,7 +276,7 @@ class TestTransportAxisPermutation:
         G = _sym(0, 1)
         # transpose with axes=None reverses all axes.
         result = transport_transpose(G, ndim=2, axes=None)
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_transpose_explicit_perm(self):
         from flopscope._symmetry_transport import transport_transpose
@@ -285,7 +285,7 @@ class TestTransportAxisPermutation:
         # transpose with axes=(1, 0) swaps; S_2 still on (0, 1) but generators relabeled.
         result = transport_transpose(G, ndim=2, axes=(1, 0))
         assert result is not None
-        assert set(result.axes) == {0, 1}
+        assert set(result.axes or ()) == {0, 1}
 
     def test_swapaxes(self):
         from flopscope._symmetry_transport import transport_swapaxes
@@ -295,7 +295,7 @@ class TestTransportAxisPermutation:
         # axis 0 -> 2, axis 1 -> 1, axis 2 -> 0. So new block axes are (2, 1).
         result = transport_swapaxes(G, ndim=3, axis1=0, axis2=2)
         assert result is not None
-        assert set(result.axes) == {1, 2}
+        assert set(result.axes or ()) == {1, 2}
 
     def test_moveaxis(self):
         from flopscope._symmetry_transport import transport_moveaxis
@@ -306,7 +306,7 @@ class TestTransportAxisPermutation:
         result = transport_moveaxis(G, ndim=3, source=0, destination=2)
         assert result is not None
         # Original axes (0, 1) -> new positions (2, 0).
-        assert set(result.axes) == {0, 2}
+        assert set(result.axes or ()) == {0, 2}
 
     def test_matrix_transpose_swaps_last_two(self):
         from flopscope._symmetry_transport import transport_matrix_transpose
@@ -315,7 +315,7 @@ class TestTransportAxisPermutation:
         # matrix_transpose = swapaxes(-2, -1) on rank-3: swap axes 1 and 2.
         result = transport_matrix_transpose(G, ndim=3)
         # Block (1, 2) under swap(1, 2) -> still (1, 2) (set unchanged).
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
 
 class TestTransportConcatenate:
@@ -329,7 +329,7 @@ class TestTransportConcatenate:
             output_ndim=3,
             axis=2,
         )
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_plain_input_forces_drop(self):
         from flopscope._symmetry_transport import transport_concatenate
@@ -359,7 +359,7 @@ class TestTransportConcatenate:
         # Restrict S_3 to {1, 2} -> S_2.
         result = transport_concatenate([G1, G2], output_ndim=3, axis=0)
         assert result is not None
-        assert set(result.axes) == {1, 2}
+        assert set(result.axes or ()) == {1, 2}
         assert result.order() == 2
 
     def test_concat_axis_none_drops(self):
@@ -378,7 +378,7 @@ class TestTransportStack:
         # New axis at position 0; existing block axes (0, 1) shift to (1, 2).
         result = transport_stack([G, G], output_ndim=3, axis=0)
         assert result is not None
-        assert set(result.axes) == {1, 2}
+        assert set(result.axes or ()) == {1, 2}
 
     def test_stack_S3_and_C3_intersect_to_C3(self):
         from flopscope._symmetry_transport import transport_stack
@@ -389,7 +389,7 @@ class TestTransportStack:
         # Intersect S_3 ∩ C_3 = C_3.
         result = transport_stack([gS, gC], output_ndim=4, axis=0)
         assert result is not None
-        assert set(result.axes) == {1, 2, 3}
+        assert set(result.axes or ()) == {1, 2, 3}
         # C_3 has order 3.
         assert result.order() == 3
 
@@ -406,7 +406,7 @@ class TestTransportStack:
         # New axis at position 2 (end). Block axes 0,1 don't shift.
         result = transport_stack([G, G], output_ndim=3, axis=2)
         assert result is not None
-        assert set(result.axes) == {0, 1}
+        assert set(result.axes or ()) == {0, 1}
 
 
 class TestTransportVHColumnStack:
@@ -432,7 +432,7 @@ class TestTransportVHColumnStack:
             output_ndim=3,
             input_ndims=[3, 3],
         )
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_hstack_2d_along_1(self):
         from flopscope._symmetry_transport import transport_hstack
@@ -478,7 +478,7 @@ class TestTransportReshape:
 
         G = _sym(0, 1)
         result = transport_reshape(G, input_shape=(3, 3), output_shape=(3, 3))
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_identity_with_interior_length_1_preserves(self):
         # The bug found by math-olympiad review: (3,1,3) -> (3,1,3) with S_2 on (0,2).
@@ -486,7 +486,7 @@ class TestTransportReshape:
 
         G = _sym(0, 2)
         result = transport_reshape(G, input_shape=(3, 1, 3), output_shape=(3, 1, 3))
-        assert result is not None and set(result.axes) == {0, 2}
+        assert result is not None and set(result.axes or ()) == {0, 2}
 
     def test_suffix_split_off_block_preserves(self):
         from flopscope._symmetry_transport import transport_reshape
@@ -498,7 +498,7 @@ class TestTransportReshape:
             input_shape=(2, 3, 3, 4),
             output_shape=(2, 3, 3, 2, 2),
         )
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_merge_inside_block_drops(self):
         from flopscope._symmetry_transport import transport_reshape
@@ -534,7 +534,7 @@ class TestTransportReshape:
             input_shape=(3, 3),
             output_shape=(1, 3, 3),
         )
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_non_contiguous_block_preserved(self):
         from flopscope._symmetry_transport import transport_reshape
@@ -546,7 +546,7 @@ class TestTransportReshape:
             input_shape=(3, 5, 3),
             output_shape=(1, 3, 5, 3),
         )
-        assert result is not None and set(result.axes) == {1, 3}
+        assert result is not None and set(result.axes or ()) == {1, 3}
 
     def test_swap_block_with_non_block_drops(self):
         from flopscope._symmetry_transport import transport_reshape
@@ -581,14 +581,14 @@ class TestTransportFlip:
 
         G = _sym(0, 1)
         result = transport_flip(G, ndim=2, axes_flipped=())
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_all_block_axes_flipped_preserves(self):
         from flopscope._symmetry_transport import transport_flip
 
         G = _sym(0, 1)
         result = transport_flip(G, ndim=2, axes_flipped=(0, 1))
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_partial_S3_flip_yields_S2(self):
         from flopscope._symmetry_transport import transport_flip
@@ -631,7 +631,7 @@ class TestTransportFlip:
         G = _sym(0, 1)
         # Flipping axis 2 (outside block) doesn't affect the block.
         result = transport_flip(G, ndim=3, axes_flipped=(2,))
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_negative_axis_normalized(self):
         from flopscope._symmetry_transport import transport_flip
@@ -639,7 +639,7 @@ class TestTransportFlip:
         G = _sym(0, 1)
         # axis=-1 on ndim=3 means axis 2 (outside block).
         result = transport_flip(G, ndim=3, axes_flipped=(-1,))
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
 
 class TestTransportTile:
@@ -654,7 +654,7 @@ class TestTransportTile:
             output_shape=(4, 4),
             reps=(2, 2),
         )
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_non_constant_reps_drops(self):
         from flopscope._symmetry_transport import transport_tile
@@ -680,7 +680,7 @@ class TestTransportTile:
             output_shape=(3, 3, 6),
             reps=(1, 1, 2),
         )
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
     def test_C3_constant_reps_preserves(self):
         from flopscope._symmetry_transport import transport_tile
@@ -706,7 +706,7 @@ class TestTransportTile:
             output_shape=(1, 3, 3),
             reps=(1, 1, 1),
         )
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_none_input_returns_none(self):
         from flopscope._symmetry_transport import transport_tile
@@ -733,7 +733,7 @@ class TestTransportBroadcastExpand:
             input_shape=(3, 3),
             output_shape=(4, 3, 3),
         )
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_broadcast_to_length_1_expanded_drops(self):
         from flopscope._symmetry_transport import transport_broadcast_to
@@ -753,14 +753,14 @@ class TestTransportBroadcastExpand:
 
         G = _sym(0, 1)
         result = transport_expand_dims(G, input_ndim=2, axis=0)
-        assert result is not None and set(result.axes) == {1, 2}
+        assert result is not None and set(result.axes or ()) == {1, 2}
 
     def test_expand_dims_at_end(self):
         from flopscope._symmetry_transport import transport_expand_dims
 
         G = _sym(0, 1)
         result = transport_expand_dims(G, input_ndim=2, axis=2)
-        assert result is not None and set(result.axes) == {0, 1}
+        assert result is not None and set(result.axes or ()) == {0, 1}
 
 
 class TestOutOfScopeOpsWarn:
@@ -918,7 +918,7 @@ class TestReshapeSegmentMatchingDeep:
         )
         result = fnp.reshape(T, (3, 1, 3))
         assert isinstance(result, SymmetricTensor)
-        assert set(result.symmetry.axes) == {0, 2}
+        assert set(result.symmetry.axes or ()) == {0, 2}
 
     def test_suffix_split_preserves(self):
         T = as_symmetric(
@@ -929,7 +929,7 @@ class TestReshapeSegmentMatchingDeep:
         np.asarray(T)[1, 0, 1, 2] = np.asarray(T)[1, 1, 0, 2] = 5.0
         result = fnp.reshape(T, (2, 3, 3, 2, 2))
         assert isinstance(result, SymmetricTensor)
-        assert set(result.symmetry.axes) == {1, 2}
+        assert set(result.symmetry.axes or ()) == {1, 2}
 
     def test_merge_in_block_drops_with_warning(self):
         from flopscope.errors import SymmetryLossWarning
@@ -951,7 +951,7 @@ class TestTileOrbitConstantDeep:
         )
         result = fnp.tile(T, (2, 2))  # output (4, 4)
         assert isinstance(result, SymmetricTensor)
-        assert set(result.symmetry.axes) == {0, 1}
+        assert set(result.symmetry.axes or ()) == {0, 1}
         # Verify symmetry of output data.
         out_arr = np.asarray(result)
         assert np.allclose(out_arr, out_arr.T)
@@ -1040,7 +1040,7 @@ def test_reshape_soundness_property(
         return  # No claim, nothing to verify.
 
     out_arr = sym.reshape(output_shape)
-    out_axes = out_group.axes
+    out_axes = out_group.axes or tuple(range(out_group.degree))
     for p in out_group.elements():
         perm = list(range(len(output_shape)))
         for i, ba in enumerate(out_axes):
@@ -1080,7 +1080,7 @@ def test_flip_soundness_property(n, flip_subset_size):
         return
 
     for p in out_group.elements():
-        out_axes = out_group.axes
+        out_axes = out_group.axes or tuple(range(out_group.degree))
         perm = list(range(n))
         for i, ba in enumerate(out_axes):
             perm[ba] = out_axes[p.array_form[i]]
@@ -1115,7 +1115,7 @@ def test_tile_soundness_property(block_size, rep_factor):
         return
 
     for p in out_group.elements():
-        out_axes = out_group.axes
+        out_axes = out_group.axes or tuple(range(out_group.degree))
         perm = list(range(2))
         for i, ba in enumerate(out_axes):
             perm[ba] = out_axes[p.array_form[i]]

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -194,3 +194,47 @@ class TestTransportRepeatRoll:
         G = _sym(0, 1)
         # Even one block axis rolled => drop.
         assert transport_roll(G, input_shape=(3, 3, 4), axis=(0, 2)) is None
+
+
+class TestTransportAxisPermutation:
+    def test_transpose_reverses_block_axes(self):
+        from flopscope._symmetry_transport import transport_transpose
+        G = _sym(0, 1)
+        # transpose with axes=None reverses all axes.
+        result = transport_transpose(G, ndim=2, axes=None)
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_transpose_explicit_perm(self):
+        from flopscope._symmetry_transport import transport_transpose
+        G = _sym(0, 1)
+        # transpose with axes=(1, 0) swaps; S_2 still on (0, 1) but generators relabeled.
+        result = transport_transpose(G, ndim=2, axes=(1, 0))
+        assert result is not None
+        assert set(result.axes) == {0, 1}
+
+    def test_swapaxes(self):
+        from flopscope._symmetry_transport import transport_swapaxes
+        G = _sym(0, 1)
+        # On a (3,3,4) tensor with S_2 on (0,1), swapaxes(0, 2) sends:
+        # axis 0 -> 2, axis 1 -> 1, axis 2 -> 0. So new block axes are (2, 1).
+        result = transport_swapaxes(G, ndim=3, axis1=0, axis2=2)
+        assert result is not None
+        assert set(result.axes) == {1, 2}
+
+    def test_moveaxis(self):
+        from flopscope._symmetry_transport import transport_moveaxis
+        G = _sym(0, 1)
+        # moveaxis source=0, destination=2 on rank-3: axis 0 moves to position 2.
+        # After move: original axis 0 is now at position 2, axes 1,2 shift down.
+        result = transport_moveaxis(G, ndim=3, source=0, destination=2)
+        assert result is not None
+        # Original axes (0, 1) -> new positions (2, 0).
+        assert set(result.axes) == {0, 2}
+
+    def test_matrix_transpose_swaps_last_two(self):
+        from flopscope._symmetry_transport import transport_matrix_transpose
+        G = _sym(1, 2)
+        # matrix_transpose = swapaxes(-2, -1) on rank-3: swap axes 1 and 2.
+        result = transport_matrix_transpose(G, ndim=3)
+        # Block (1, 2) under swap(1, 2) -> still (1, 2) (set unchanged).
+        assert result is not None and set(result.axes) == {1, 2}

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -238,3 +238,46 @@ class TestTransportAxisPermutation:
         result = transport_matrix_transpose(G, ndim=3)
         # Block (1, 2) under swap(1, 2) -> still (1, 2) (set unchanged).
         assert result is not None and set(result.axes) == {1, 2}
+
+
+class TestTransportConcatenate:
+    def test_identical_groups_off_block_axis_preserves(self):
+        from flopscope._symmetry_transport import transport_concatenate
+        G1 = _sym(0, 1)
+        G2 = _sym(0, 1)
+        result = transport_concatenate(
+            [G1, G2], output_ndim=3, axis=2,
+        )
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_plain_input_forces_drop(self):
+        from flopscope._symmetry_transport import transport_concatenate
+        G1 = _sym(0, 1)
+        result = transport_concatenate(
+            [G1, None], output_ndim=3, axis=2,
+        )
+        assert result is None
+
+    def test_concat_on_block_axis_for_degree2_drops(self):
+        from flopscope._symmetry_transport import transport_concatenate
+        G1 = _sym(0, 1)
+        G2 = _sym(0, 1)
+        # Concat along axis 0 (in block); restriction to {1} is degree-1 -> drop.
+        result = transport_concatenate([G1, G2], output_ndim=2, axis=0)
+        assert result is None
+
+    def test_concat_S3_along_block_axis_yields_S2(self):
+        from flopscope._symmetry_transport import transport_concatenate
+        G1 = _sym(0, 1, 2)
+        G2 = _sym(0, 1, 2)
+        # Restrict S_3 to {1, 2} -> S_2.
+        result = transport_concatenate([G1, G2], output_ndim=3, axis=0)
+        assert result is not None
+        assert set(result.axes) == {1, 2}
+        assert result.order() == 2
+
+    def test_concat_axis_none_drops(self):
+        from flopscope._symmetry_transport import transport_concatenate
+        G1 = _sym(0, 1)
+        # axis=None ravels first -> always drops.
+        assert transport_concatenate([G1, G1], output_ndim=1, axis=None) is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -947,3 +947,20 @@ def test_tile_soundness_property(block_size, rep_factor):
         for i, ba in enumerate(out_axes):
             perm[ba] = out_axes[p.array_form[i]]
         assert np.allclose(out_arr, out_arr.transpose(perm))
+
+
+class TestSuppression:
+    def test_symmetry_warnings_off_silences_all_drops(self, recwarn):
+        flops.configure(symmetry_warnings=False)
+        try:
+            T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+            _ = fnp.reshape(T, -1)  # would normally warn
+            _ = fnp.ravel(T)
+            _ = fnp.flip(T, axis=0)  # partial flip drops
+            from flopscope.errors import SymmetryLossWarning
+            sym_warnings = [
+                w for w in recwarn.list if issubclass(w.category, SymmetryLossWarning)
+            ]
+            assert sym_warnings == []
+        finally:
+            flops.configure(symmetry_warnings=True)

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -106,3 +106,54 @@ class TestTransportAtleast:
         assert transport_atleast_1d(None, input_shape=(3, 3)) is None
         assert transport_atleast_2d(None, input_shape=(3, 3)) is None
         assert transport_atleast_3d(None, input_shape=(3, 3)) is None
+
+
+class TestTransportSplit:
+    def test_split_non_block_axis_preserves(self):
+        from flopscope._symmetry_transport import transport_split
+        # (4, 3, 3) with S_2 on (1, 2), split along axis 0.
+        G = _sym(1, 2)
+        result = transport_split(G, input_shape=(4, 3, 3), axis=0)
+        assert result is not None
+        assert set(result.axes) == {1, 2}
+        assert result.order() == 2
+
+    def test_split_in_block_drops_for_degree2(self):
+        from flopscope._symmetry_transport import transport_split
+        G = _sym(0, 1)
+        result = transport_split(G, input_shape=(3, 3), axis=0)
+        assert result is None
+
+    def test_split_in_block_preserves_subgroup_for_S3(self):
+        from flopscope._symmetry_transport import transport_split
+        # S_3 on (0, 1, 2), split along axis 0 -> pieces carry S_2 on (1, 2).
+        G = _sym(0, 1, 2)
+        result = transport_split(G, input_shape=(3, 3, 3), axis=0)
+        assert result is not None
+        assert set(result.axes) == {1, 2}
+        assert result.order() == 2
+
+    def test_hsplit_for_1d(self):
+        from flopscope._symmetry_transport import transport_hsplit
+        # hsplit on 1-D uses axis=0, and 1-D inputs can't carry multi-axis groups.
+        assert transport_hsplit(None, input_shape=(6,)) is None
+
+    def test_hsplit_for_2d_uses_axis_1(self):
+        from flopscope._symmetry_transport import transport_hsplit
+        G = _sym(0, 1)
+        # hsplit on (3, 6) splits along axis 1 - which IS in block; degree 2 -> drops.
+        assert transport_hsplit(G, input_shape=(3, 6)) is None
+
+    def test_vsplit_uses_axis_0(self):
+        from flopscope._symmetry_transport import transport_vsplit
+        G = _sym(1, 2)
+        # vsplit on (4, 3, 3) splits along axis 0 (outside block) -> preserves.
+        result = transport_vsplit(G, input_shape=(4, 3, 3))
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_dsplit_uses_axis_2(self):
+        from flopscope._symmetry_transport import transport_dsplit
+        G = _sym(0, 1)
+        # dsplit on (3, 3, 6) splits along axis 2 (outside block) -> preserves.
+        result = transport_dsplit(G, input_shape=(3, 3, 6))
+        assert result is not None and set(result.axes) == {0, 1}

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -442,3 +442,62 @@ class TestTransportRavel:
     def test_ravel_for_none_input(self):
         from flopscope._symmetry_transport import transport_ravel
         assert transport_ravel(None, input_shape=(3, 3)) is None
+
+
+class TestTransportFlip:
+    def test_no_axes_flipped_preserves(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _sym(0, 1)
+        result = transport_flip(G, ndim=2, axes_flipped=())
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_all_block_axes_flipped_preserves(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _sym(0, 1)
+        result = transport_flip(G, ndim=2, axes_flipped=(0, 1))
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_partial_S3_flip_yields_S2(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _sym(0, 1, 2)
+        # Flip axis 1 only: setwise stab of {1} in S_3 = perms fixing 1 = S_2 on {0,2}.
+        result = transport_flip(G, ndim=3, axes_flipped=(1,))
+        assert result is not None
+        assert result.order() == 2
+
+    def test_partial_C3_flip_drops(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _cyc(0, 1, 2)
+        # C_3 has no element fixing a singleton -> drops.
+        result = transport_flip(G, ndim=3, axes_flipped=(0,))
+        assert result is None
+
+    def test_partial_C4_flip_pair_yields_Z2(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _cyc(0, 1, 2, 3)
+        # C_4 with F_A = {0, 2}: element (0 2)(1 3) survives -> Z_2.
+        result = transport_flip(G, ndim=4, axes_flipped=(0, 2))
+        assert result is not None
+        assert result.order() == 2
+
+    def test_partial_D3_flip_yields_Z2(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _dih(0, 1, 2)
+        # D_3 with F_A = {1}: the reflection fixing axis 1 survives -> Z_2.
+        result = transport_flip(G, ndim=3, axes_flipped=(1,))
+        assert result is not None
+        assert result.order() == 2
+
+    def test_axes_outside_block_flipped_preserves(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _sym(0, 1)
+        # Flipping axis 2 (outside block) doesn't affect the block.
+        result = transport_flip(G, ndim=3, axes_flipped=(2,))
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_negative_axis_normalized(self):
+        from flopscope._symmetry_transport import transport_flip
+        G = _sym(0, 1)
+        # axis=-1 on ndim=3 means axis 2 (outside block).
+        result = transport_flip(G, ndim=3, axes_flipped=(-1,))
+        assert result is not None and set(result.axes) == {0, 1}

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -1,0 +1,40 @@
+"""Tests for shape-op symmetry transport. See issue #68."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import flopscope as flops
+import flopscope.numpy as fnp
+from flopscope._perm_group import SymmetryGroup
+from flopscope._symmetric import SymmetricTensor, as_symmetric
+
+
+def _sym(*axes):
+    return SymmetryGroup.symmetric(axes=axes)
+
+
+def _cyc(*axes):
+    return SymmetryGroup.cyclic(axes=axes)
+
+
+def _dih(*axes):
+    return SymmetryGroup.dihedral(axes=axes)
+
+
+def test_every_issue_68_op_has_transport():
+    """Coverage assertion: every shape op in issue #68 has a transport function."""
+    from flopscope import _symmetry_transport as st
+
+    required = {
+        "reshape", "concatenate", "stack", "vstack", "hstack", "column_stack",
+        "split", "hsplit", "vsplit", "dsplit",
+        "atleast_1d", "atleast_2d", "atleast_3d",
+        "broadcast_to", "expand_dims", "squeeze",
+        "flip", "roll", "tile", "repeat",
+        "transpose", "swapaxes", "moveaxis", "matrix_transpose",
+        "ravel",
+    }
+    for op in required:
+        assert hasattr(st, f"transport_{op}"), f"missing transport_{op}"

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -157,3 +157,40 @@ class TestTransportSplit:
         # dsplit on (3, 3, 6) splits along axis 2 (outside block) -> preserves.
         result = transport_dsplit(G, input_shape=(3, 3, 6))
         assert result is not None and set(result.axes) == {0, 1}
+
+
+class TestTransportRepeatRoll:
+    def test_repeat_outside_block_preserves(self):
+        from flopscope._symmetry_transport import transport_repeat
+        G = _sym(0, 1)
+        result = transport_repeat(G, input_shape=(3, 3, 4), axis=2)
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_repeat_inside_block_drops(self):
+        from flopscope._symmetry_transport import transport_repeat
+        G = _sym(0, 1)
+        assert transport_repeat(G, input_shape=(3, 3), axis=1) is None
+
+    def test_repeat_axis_negative_normalized(self):
+        from flopscope._symmetry_transport import transport_repeat
+        G = _sym(0, 1)
+        # axis=-1 on (3, 3, 4) -> axis 2, outside block.
+        result = transport_repeat(G, input_shape=(3, 3, 4), axis=-1)
+        assert result is not None
+
+    def test_roll_outside_block_preserves(self):
+        from flopscope._symmetry_transport import transport_roll
+        G = _sym(0, 1)
+        result = transport_roll(G, input_shape=(3, 3, 4), axis=2)
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_roll_inside_block_drops(self):
+        from flopscope._symmetry_transport import transport_roll
+        G = _sym(0, 1)
+        assert transport_roll(G, input_shape=(3, 3), axis=0) is None
+
+    def test_roll_multi_axis_any_in_block_drops(self):
+        from flopscope._symmetry_transport import transport_roll
+        G = _sym(0, 1)
+        # Even one block axis rolled => drop.
+        assert transport_roll(G, input_shape=(3, 3, 4), axis=(0, 2)) is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -38,3 +38,34 @@ def test_every_issue_68_op_has_transport():
     }
     for op in required:
         assert hasattr(st, f"transport_{op}"), f"missing transport_{op}"
+
+
+class TestTransportSqueeze:
+    def test_squeeze_outside_block_shifts_block_axes(self):
+        from flopscope._symmetry_transport import transport_squeeze
+        # input shape (1, 3, 3), S_2 on (1, 2)
+        G = _sym(1, 2)
+        result = transport_squeeze(G, input_shape=(1, 3, 3), axis=0)
+        # After squeeze, block axes (1, 2) shift to (0, 1).
+        assert result is not None
+        assert set(result.axes) == {0, 1}
+        assert result.order() == 2
+
+    def test_squeeze_inside_block_drops(self):
+        from flopscope._symmetry_transport import transport_squeeze
+        # input shape (1, 1), S_2 on (0, 1). Squeeze axis 0 (in block).
+        G = _sym(0, 1)
+        result = transport_squeeze(G, input_shape=(1, 1), axis=0)
+        assert result is None
+
+    def test_squeeze_axis_none_removes_all_length_1(self):
+        from flopscope._symmetry_transport import transport_squeeze
+        # input shape (1, 3, 3, 1), S_2 on (1, 2). axis=None removes axes 0 and 3.
+        G = _sym(1, 2)
+        result = transport_squeeze(G, input_shape=(1, 3, 3, 1), axis=None)
+        assert result is not None
+        assert set(result.axes) == {0, 1}
+
+    def test_squeeze_none_input_returns_none(self):
+        from flopscope._symmetry_transport import transport_squeeze
+        assert transport_squeeze(None, input_shape=(1, 3, 3), axis=0) is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -587,3 +587,89 @@ class TestTransportBroadcastExpand:
         G = _sym(0, 1)
         result = transport_expand_dims(G, input_ndim=2, axis=2)
         assert result is not None and set(result.axes) == {0, 1}
+
+
+class TestOutOfScopeOpsWarn:
+    @pytest.fixture(autouse=True)
+    def _enable_warnings(self):
+        flops.configure(symmetry_warnings=True)
+        yield
+        flops.configure(symmetry_warnings=True)
+
+    def test_pad_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.pad(T, 1)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_diagonal_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.diagonal(T)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_triu_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.triu(T)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_tril_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.tril(T)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_array_split_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.array_split(T, 3)
+        assert not any(isinstance(r, SymmetricTensor) for r in result)
+
+    def test_append_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.append(T, np.zeros((1, 3)), axis=0)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_dstack_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.dstack([T, np.eye(3)])
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_compress_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.compress([True, False, True], T, axis=0)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_delete_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.delete(T, 0, axis=0)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_choose_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        indices = as_symmetric(np.zeros((3, 3), dtype=int), symmetry=_sym(0, 1))
+        choices = [np.eye(3), np.ones((3, 3))]
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.choose(indices, choices)
+        assert not isinstance(result, SymmetricTensor)
+
+    def test_block_warns_and_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.block([T, np.eye(3)])
+        assert not isinstance(result, SymmetricTensor)

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -281,3 +281,38 @@ class TestTransportConcatenate:
         G1 = _sym(0, 1)
         # axis=None ravels first -> always drops.
         assert transport_concatenate([G1, G1], output_ndim=1, axis=None) is None
+
+
+class TestTransportStack:
+    def test_stack_two_identical_S2_along_axis_0(self):
+        from flopscope._symmetry_transport import transport_stack
+        G = _sym(0, 1)
+        # New axis at position 0; existing block axes (0, 1) shift to (1, 2).
+        result = transport_stack([G, G], output_ndim=3, axis=0)
+        assert result is not None
+        assert set(result.axes) == {1, 2}
+
+    def test_stack_S3_and_C3_intersect_to_C3(self):
+        from flopscope._symmetry_transport import transport_stack
+        gS = _sym(0, 1, 2)
+        gC = _cyc(0, 1, 2)
+        # New axis at position 0; block axes shift to (1, 2, 3).
+        # Intersect S_3 ∩ C_3 = C_3.
+        result = transport_stack([gS, gC], output_ndim=4, axis=0)
+        assert result is not None
+        assert set(result.axes) == {1, 2, 3}
+        # C_3 has order 3.
+        assert result.order() == 3
+
+    def test_stack_plain_input_drops(self):
+        from flopscope._symmetry_transport import transport_stack
+        G = _sym(0, 1)
+        assert transport_stack([G, None], output_ndim=3, axis=0) is None
+
+    def test_stack_at_end(self):
+        from flopscope._symmetry_transport import transport_stack
+        G = _sym(0, 1)
+        # New axis at position 2 (end). Block axes 0,1 don't shift.
+        result = transport_stack([G, G], output_ndim=3, axis=2)
+        assert result is not None
+        assert set(result.axes) == {0, 1}

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -501,3 +501,56 @@ class TestTransportFlip:
         # axis=-1 on ndim=3 means axis 2 (outside block).
         result = transport_flip(G, ndim=3, axes_flipped=(-1,))
         assert result is not None and set(result.axes) == {0, 1}
+
+
+class TestTransportTile:
+    def test_constant_reps_on_orbit_preserves(self):
+        from flopscope._symmetry_transport import transport_tile
+        G = _sym(0, 1)
+        # reps (2, 2) is constant on the S_2 orbit {0, 1}; output (4, 4).
+        result = transport_tile(
+            G, input_shape=(2, 2), output_shape=(4, 4), reps=(2, 2),
+        )
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_non_constant_reps_drops(self):
+        from flopscope._symmetry_transport import transport_tile
+        G = _sym(0, 1)
+        # reps (2, 1) NOT constant on orbit {0, 1}; output (4, 2).
+        result = transport_tile(
+            G, input_shape=(2, 2), output_shape=(4, 2), reps=(2, 1),
+        )
+        assert result is None
+
+    def test_reps_outside_block_preserves(self):
+        from flopscope._symmetry_transport import transport_tile
+        G = _sym(0, 1)
+        # reps (1, 1, 2) on (3, 3, 3): axis 2 outside block; constant on orbit {0,1}.
+        result = transport_tile(
+            G, input_shape=(3, 3, 3), output_shape=(3, 3, 6), reps=(1, 1, 2),
+        )
+        assert result is not None and set(result.axes) == {0, 1}
+
+    def test_C3_constant_reps_preserves(self):
+        from flopscope._symmetry_transport import transport_tile
+        G = _cyc(0, 1, 2)
+        result = transport_tile(
+            G, input_shape=(3, 3, 3), output_shape=(6, 6, 6), reps=(2, 2, 2),
+        )
+        assert result is not None and result.order() == 3
+
+    def test_reps_longer_than_input_shifts_block(self):
+        from flopscope._symmetry_transport import transport_tile
+        G = _sym(0, 1)
+        # Input (3, 3), reps=(1, 1, 1) -> output rank 3, input prepended with 1 axis.
+        # Block axes shift from (0, 1) to (1, 2).
+        result = transport_tile(
+            G, input_shape=(3, 3), output_shape=(1, 3, 3), reps=(1, 1, 1),
+        )
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_none_input_returns_none(self):
+        from flopscope._symmetry_transport import transport_tile
+        assert transport_tile(
+            None, input_shape=(3, 3), output_shape=(6, 6), reps=(2, 2),
+        ) is None

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -23,6 +23,35 @@ def _dih(*axes):
     return SymmetryGroup.dihedral(axes=axes)
 
 
+def _make_S4_symmetric_tensor(N=3):
+    """Build a fully S_4-symmetric (N,N,N,N) tensor by averaging over perms."""
+    from itertools import permutations
+    rng = np.random.default_rng(0)
+    T = rng.standard_normal((N, N, N, N))
+    out = np.zeros_like(T)
+    for p in permutations(range(4)):
+        out += T.transpose(p)
+    return out / 24
+
+
+def _make_D3_symmetric_tensor(N=4):
+    """Build a fully S_3-symmetric (N,N,N) tensor (which is also D_3-symmetric)."""
+    from itertools import permutations
+    rng = np.random.default_rng(1)
+    T = rng.standard_normal((N, N, N))
+    out = np.zeros_like(T)
+    for p in permutations(range(3)):
+        out += T.transpose(p)
+    return out / 6
+
+
+def _make_C3_symmetric_tensor(N=3):
+    """Build a C_3-symmetric (N,N,N) tensor (cyclic 3-fold)."""
+    rng = np.random.default_rng(2)
+    T = rng.standard_normal((N, N, N))
+    return (T + T.transpose([1, 2, 0]) + T.transpose([2, 0, 1])) / 3
+
+
 def test_every_issue_68_op_has_transport():
     """Coverage assertion: every shape op in issue #68 has a transport function."""
     from flopscope import _symmetry_transport as st
@@ -687,3 +716,92 @@ class TestZeroSizeDefensive:
         G = _sym(1, 2)
         result = transport_split(G, input_shape=(0, 3, 3), axis=0)
         assert result is None
+
+
+class TestFlipSetwiseStabilizerDeep:
+    """Layer-2: pin the corrected setwise-stabilizer rule from math-olympiad review."""
+
+    def test_S4_partial_flip_yields_Klein_4(self):
+        T = as_symmetric(
+            _make_S4_symmetric_tensor(N=3),
+            symmetry=_sym(0, 1, 2, 3),
+        )
+        result = fnp.flip(T, axis=(0, 1))
+        # Klein-4 stabilizer of {0,1} in S_4 = {e, (01), (23), (01)(23)}.
+        assert isinstance(result, SymmetricTensor)
+        assert result.symmetry.order() == 4
+
+    def test_D3_partial_flip_yields_Z2(self):
+        T = as_symmetric(
+            _make_D3_symmetric_tensor(N=4),
+            symmetry=_dih(0, 1, 2),
+        )
+        result = fnp.flip(T, axis=1)
+        assert isinstance(result, SymmetricTensor)
+        assert result.symmetry.order() == 2
+
+    def test_C3_partial_flip_drops_with_warning(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(
+            _make_C3_symmetric_tensor(N=3),
+            symmetry=_cyc(0, 1, 2),
+        )
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.flip(T, axis=0)
+        assert not isinstance(result, SymmetricTensor)
+
+
+class TestReshapeSegmentMatchingDeep:
+    def test_identity_with_interior_length_1(self):
+        T = as_symmetric(
+            np.eye(3).reshape(3, 1, 3),
+            symmetry=_sym(0, 2),
+        )
+        result = fnp.reshape(T, (3, 1, 3))
+        assert isinstance(result, SymmetricTensor)
+        assert set(result.symmetry.axes) == {0, 2}
+
+    def test_suffix_split_preserves(self):
+        T = as_symmetric(
+            np.zeros((2, 3, 3, 4)),
+            symmetry=_sym(1, 2),
+        )
+        # Set some non-zero entries to make symmetry checking meaningful.
+        np.asarray(T)[1, 0, 1, 2] = np.asarray(T)[1, 1, 0, 2] = 5.0
+        result = fnp.reshape(T, (2, 3, 3, 2, 2))
+        assert isinstance(result, SymmetricTensor)
+        assert set(result.symmetry.axes) == {1, 2}
+
+    def test_merge_in_block_drops_with_warning(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(
+            np.zeros((2, 3, 3, 4)),
+            symmetry=_sym(1, 2),
+        )
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.reshape(T, (2, 9, 4))
+        assert not isinstance(result, SymmetricTensor)
+
+
+class TestTileOrbitConstantDeep:
+    def test_constant_reps_on_S2_orbit_preserves(self):
+        T = as_symmetric(
+            np.array([[1.0, 2.0], [2.0, 3.0]]),
+            symmetry=_sym(0, 1),
+        )
+        result = fnp.tile(T, (2, 2))  # output (4, 4)
+        assert isinstance(result, SymmetricTensor)
+        assert set(result.symmetry.axes) == {0, 1}
+        # Verify symmetry of output data.
+        out_arr = np.asarray(result)
+        assert np.allclose(out_arr, out_arr.T)
+
+    def test_non_constant_reps_drops(self):
+        from flopscope.errors import SymmetryLossWarning
+        T = as_symmetric(
+            np.array([[1.0, 2.0], [2.0, 3.0]]),
+            symmetry=_sym(0, 1),
+        )
+        with pytest.warns(SymmetryLossWarning):
+            result = fnp.tile(T, (2, 1))
+        assert not isinstance(result, SymmetricTensor)

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -26,6 +26,7 @@ def _dih(*axes):
 def _make_S4_symmetric_tensor(N=3):
     """Build a fully S_4-symmetric (N,N,N,N) tensor by averaging over perms."""
     from itertools import permutations
+
     rng = np.random.default_rng(0)
     T = rng.standard_normal((N, N, N, N))
     out = np.zeros_like(T)
@@ -37,6 +38,7 @@ def _make_S4_symmetric_tensor(N=3):
 def _make_D3_symmetric_tensor(N=4):
     """Build a fully S_3-symmetric (N,N,N) tensor (which is also D_3-symmetric)."""
     from itertools import permutations
+
     rng = np.random.default_rng(1)
     T = rng.standard_normal((N, N, N))
     out = np.zeros_like(T)
@@ -57,12 +59,30 @@ def test_every_issue_68_op_has_transport():
     from flopscope import _symmetry_transport as st
 
     required = {
-        "reshape", "concatenate", "stack", "vstack", "hstack", "column_stack",
-        "split", "hsplit", "vsplit", "dsplit",
-        "atleast_1d", "atleast_2d", "atleast_3d",
-        "broadcast_to", "expand_dims", "squeeze",
-        "flip", "roll", "tile", "repeat",
-        "transpose", "swapaxes", "moveaxis", "matrix_transpose",
+        "reshape",
+        "concatenate",
+        "stack",
+        "vstack",
+        "hstack",
+        "column_stack",
+        "split",
+        "hsplit",
+        "vsplit",
+        "dsplit",
+        "atleast_1d",
+        "atleast_2d",
+        "atleast_3d",
+        "broadcast_to",
+        "expand_dims",
+        "squeeze",
+        "flip",
+        "roll",
+        "tile",
+        "repeat",
+        "transpose",
+        "swapaxes",
+        "moveaxis",
+        "matrix_transpose",
         "ravel",
     }
     for op in required:
@@ -72,6 +92,7 @@ def test_every_issue_68_op_has_transport():
 class TestTransportSqueeze:
     def test_squeeze_outside_block_shifts_block_axes(self):
         from flopscope._symmetry_transport import transport_squeeze
+
         # input shape (1, 3, 3), S_2 on (1, 2)
         G = _sym(1, 2)
         result = transport_squeeze(G, input_shape=(1, 3, 3), axis=0)
@@ -82,6 +103,7 @@ class TestTransportSqueeze:
 
     def test_squeeze_inside_block_drops(self):
         from flopscope._symmetry_transport import transport_squeeze
+
         # input shape (1, 1), S_2 on (0, 1). Squeeze axis 0 (in block).
         G = _sym(0, 1)
         result = transport_squeeze(G, input_shape=(1, 1), axis=0)
@@ -89,6 +111,7 @@ class TestTransportSqueeze:
 
     def test_squeeze_axis_none_removes_all_length_1(self):
         from flopscope._symmetry_transport import transport_squeeze
+
         # input shape (1, 3, 3, 1), S_2 on (1, 2). axis=None removes axes 0 and 3.
         G = _sym(1, 2)
         result = transport_squeeze(G, input_shape=(1, 3, 3, 1), axis=None)
@@ -97,24 +120,28 @@ class TestTransportSqueeze:
 
     def test_squeeze_none_input_returns_none(self):
         from flopscope._symmetry_transport import transport_squeeze
+
         assert transport_squeeze(None, input_shape=(1, 3, 3), axis=0) is None
 
 
 class TestTransportAtleast:
     def test_atleast_1d_noop_on_2d(self):
         from flopscope._symmetry_transport import transport_atleast_1d
+
         G = _sym(0, 1)
         result = transport_atleast_1d(G, input_shape=(3, 3))
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_atleast_2d_noop_on_2d(self):
         from flopscope._symmetry_transport import transport_atleast_2d
+
         G = _sym(0, 1)
         result = transport_atleast_2d(G, input_shape=(3, 3))
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_atleast_3d_appends_trailing_axis_for_2d(self):
         from flopscope._symmetry_transport import transport_atleast_3d
+
         G = _sym(0, 1)
         # NumPy: (M, N) -> (M, N, 1). Block axes unchanged.
         result = transport_atleast_3d(G, input_shape=(3, 3))
@@ -124,14 +151,18 @@ class TestTransportAtleast:
 
     def test_atleast_3d_noop_on_3d(self):
         from flopscope._symmetry_transport import transport_atleast_3d
+
         G = _sym(1, 2)
         result = transport_atleast_3d(G, input_shape=(4, 3, 3))
         assert result is not None and set(result.axes) == {1, 2}
 
     def test_atleast_kd_none_input(self):
         from flopscope._symmetry_transport import (
-            transport_atleast_1d, transport_atleast_2d, transport_atleast_3d,
+            transport_atleast_1d,
+            transport_atleast_2d,
+            transport_atleast_3d,
         )
+
         assert transport_atleast_1d(None, input_shape=(3, 3)) is None
         assert transport_atleast_2d(None, input_shape=(3, 3)) is None
         assert transport_atleast_3d(None, input_shape=(3, 3)) is None
@@ -140,6 +171,7 @@ class TestTransportAtleast:
 class TestTransportSplit:
     def test_split_non_block_axis_preserves(self):
         from flopscope._symmetry_transport import transport_split
+
         # (4, 3, 3) with S_2 on (1, 2), split along axis 0.
         G = _sym(1, 2)
         result = transport_split(G, input_shape=(4, 3, 3), axis=0)
@@ -149,12 +181,14 @@ class TestTransportSplit:
 
     def test_split_in_block_drops_for_degree2(self):
         from flopscope._symmetry_transport import transport_split
+
         G = _sym(0, 1)
         result = transport_split(G, input_shape=(3, 3), axis=0)
         assert result is None
 
     def test_split_in_block_preserves_subgroup_for_S3(self):
         from flopscope._symmetry_transport import transport_split
+
         # S_3 on (0, 1, 2), split along axis 0 -> pieces carry S_2 on (1, 2).
         G = _sym(0, 1, 2)
         result = transport_split(G, input_shape=(3, 3, 3), axis=0)
@@ -164,17 +198,20 @@ class TestTransportSplit:
 
     def test_hsplit_for_1d(self):
         from flopscope._symmetry_transport import transport_hsplit
+
         # hsplit on 1-D uses axis=0, and 1-D inputs can't carry multi-axis groups.
         assert transport_hsplit(None, input_shape=(6,)) is None
 
     def test_hsplit_for_2d_uses_axis_1(self):
         from flopscope._symmetry_transport import transport_hsplit
+
         G = _sym(0, 1)
         # hsplit on (3, 6) splits along axis 1 - which IS in block; degree 2 -> drops.
         assert transport_hsplit(G, input_shape=(3, 6)) is None
 
     def test_vsplit_uses_axis_0(self):
         from flopscope._symmetry_transport import transport_vsplit
+
         G = _sym(1, 2)
         # vsplit on (4, 3, 3) splits along axis 0 (outside block) -> preserves.
         result = transport_vsplit(G, input_shape=(4, 3, 3))
@@ -182,6 +219,7 @@ class TestTransportSplit:
 
     def test_dsplit_uses_axis_2(self):
         from flopscope._symmetry_transport import transport_dsplit
+
         G = _sym(0, 1)
         # dsplit on (3, 3, 6) splits along axis 2 (outside block) -> preserves.
         result = transport_dsplit(G, input_shape=(3, 3, 6))
@@ -191,17 +229,20 @@ class TestTransportSplit:
 class TestTransportRepeatRoll:
     def test_repeat_outside_block_preserves(self):
         from flopscope._symmetry_transport import transport_repeat
+
         G = _sym(0, 1)
         result = transport_repeat(G, input_shape=(3, 3, 4), axis=2)
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_repeat_inside_block_drops(self):
         from flopscope._symmetry_transport import transport_repeat
+
         G = _sym(0, 1)
         assert transport_repeat(G, input_shape=(3, 3), axis=1) is None
 
     def test_repeat_axis_negative_normalized(self):
         from flopscope._symmetry_transport import transport_repeat
+
         G = _sym(0, 1)
         # axis=-1 on (3, 3, 4) -> axis 2, outside block.
         result = transport_repeat(G, input_shape=(3, 3, 4), axis=-1)
@@ -209,17 +250,20 @@ class TestTransportRepeatRoll:
 
     def test_roll_outside_block_preserves(self):
         from flopscope._symmetry_transport import transport_roll
+
         G = _sym(0, 1)
         result = transport_roll(G, input_shape=(3, 3, 4), axis=2)
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_roll_inside_block_drops(self):
         from flopscope._symmetry_transport import transport_roll
+
         G = _sym(0, 1)
         assert transport_roll(G, input_shape=(3, 3), axis=0) is None
 
     def test_roll_multi_axis_any_in_block_drops(self):
         from flopscope._symmetry_transport import transport_roll
+
         G = _sym(0, 1)
         # Even one block axis rolled => drop.
         assert transport_roll(G, input_shape=(3, 3, 4), axis=(0, 2)) is None
@@ -228,6 +272,7 @@ class TestTransportRepeatRoll:
 class TestTransportAxisPermutation:
     def test_transpose_reverses_block_axes(self):
         from flopscope._symmetry_transport import transport_transpose
+
         G = _sym(0, 1)
         # transpose with axes=None reverses all axes.
         result = transport_transpose(G, ndim=2, axes=None)
@@ -235,6 +280,7 @@ class TestTransportAxisPermutation:
 
     def test_transpose_explicit_perm(self):
         from flopscope._symmetry_transport import transport_transpose
+
         G = _sym(0, 1)
         # transpose with axes=(1, 0) swaps; S_2 still on (0, 1) but generators relabeled.
         result = transport_transpose(G, ndim=2, axes=(1, 0))
@@ -243,6 +289,7 @@ class TestTransportAxisPermutation:
 
     def test_swapaxes(self):
         from flopscope._symmetry_transport import transport_swapaxes
+
         G = _sym(0, 1)
         # On a (3,3,4) tensor with S_2 on (0,1), swapaxes(0, 2) sends:
         # axis 0 -> 2, axis 1 -> 1, axis 2 -> 0. So new block axes are (2, 1).
@@ -252,6 +299,7 @@ class TestTransportAxisPermutation:
 
     def test_moveaxis(self):
         from flopscope._symmetry_transport import transport_moveaxis
+
         G = _sym(0, 1)
         # moveaxis source=0, destination=2 on rank-3: axis 0 moves to position 2.
         # After move: original axis 0 is now at position 2, axes 1,2 shift down.
@@ -262,6 +310,7 @@ class TestTransportAxisPermutation:
 
     def test_matrix_transpose_swaps_last_two(self):
         from flopscope._symmetry_transport import transport_matrix_transpose
+
         G = _sym(1, 2)
         # matrix_transpose = swapaxes(-2, -1) on rank-3: swap axes 1 and 2.
         result = transport_matrix_transpose(G, ndim=3)
@@ -272,23 +321,30 @@ class TestTransportAxisPermutation:
 class TestTransportConcatenate:
     def test_identical_groups_off_block_axis_preserves(self):
         from flopscope._symmetry_transport import transport_concatenate
+
         G1 = _sym(0, 1)
         G2 = _sym(0, 1)
         result = transport_concatenate(
-            [G1, G2], output_ndim=3, axis=2,
+            [G1, G2],
+            output_ndim=3,
+            axis=2,
         )
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_plain_input_forces_drop(self):
         from flopscope._symmetry_transport import transport_concatenate
+
         G1 = _sym(0, 1)
         result = transport_concatenate(
-            [G1, None], output_ndim=3, axis=2,
+            [G1, None],
+            output_ndim=3,
+            axis=2,
         )
         assert result is None
 
     def test_concat_on_block_axis_for_degree2_drops(self):
         from flopscope._symmetry_transport import transport_concatenate
+
         G1 = _sym(0, 1)
         G2 = _sym(0, 1)
         # Concat along axis 0 (in block); restriction to {1} is degree-1 -> drop.
@@ -297,6 +353,7 @@ class TestTransportConcatenate:
 
     def test_concat_S3_along_block_axis_yields_S2(self):
         from flopscope._symmetry_transport import transport_concatenate
+
         G1 = _sym(0, 1, 2)
         G2 = _sym(0, 1, 2)
         # Restrict S_3 to {1, 2} -> S_2.
@@ -307,6 +364,7 @@ class TestTransportConcatenate:
 
     def test_concat_axis_none_drops(self):
         from flopscope._symmetry_transport import transport_concatenate
+
         G1 = _sym(0, 1)
         # axis=None ravels first -> always drops.
         assert transport_concatenate([G1, G1], output_ndim=1, axis=None) is None
@@ -315,6 +373,7 @@ class TestTransportConcatenate:
 class TestTransportStack:
     def test_stack_two_identical_S2_along_axis_0(self):
         from flopscope._symmetry_transport import transport_stack
+
         G = _sym(0, 1)
         # New axis at position 0; existing block axes (0, 1) shift to (1, 2).
         result = transport_stack([G, G], output_ndim=3, axis=0)
@@ -323,6 +382,7 @@ class TestTransportStack:
 
     def test_stack_S3_and_C3_intersect_to_C3(self):
         from flopscope._symmetry_transport import transport_stack
+
         gS = _sym(0, 1, 2)
         gC = _cyc(0, 1, 2)
         # New axis at position 0; block axes shift to (1, 2, 3).
@@ -335,11 +395,13 @@ class TestTransportStack:
 
     def test_stack_plain_input_drops(self):
         from flopscope._symmetry_transport import transport_stack
+
         G = _sym(0, 1)
         assert transport_stack([G, None], output_ndim=3, axis=0) is None
 
     def test_stack_at_end(self):
         from flopscope._symmetry_transport import transport_stack
+
         G = _sym(0, 1)
         # New axis at position 2 (end). Block axes 0,1 don't shift.
         result = transport_stack([G, G], output_ndim=3, axis=2)
@@ -350,44 +412,62 @@ class TestTransportStack:
 class TestTransportVHColumnStack:
     def test_vstack_two_2d_concat_along_0(self):
         from flopscope._symmetry_transport import transport_vstack
+
         G = _sym(0, 1)
         # vstack of two (3,3) S_2 along axis 0; restrict to {1} -> degree-1 -> drop.
         result = transport_vstack(
-            [G, G], output_ndim=2, input_ndims=[2, 2],
+            [G, G],
+            output_ndim=2,
+            input_ndims=[2, 2],
         )
         assert result is None
 
     def test_vstack_two_3d_along_0(self):
         from flopscope._symmetry_transport import transport_vstack
+
         G = _sym(1, 2)
         # vstack of two (2,3,3) S_2(1,2) along axis 0 (outside block).
         result = transport_vstack(
-            [G, G], output_ndim=3, input_ndims=[3, 3],
+            [G, G],
+            output_ndim=3,
+            input_ndims=[3, 3],
         )
         assert result is not None and set(result.axes) == {1, 2}
 
     def test_hstack_2d_along_1(self):
         from flopscope._symmetry_transport import transport_hstack
+
         G = _sym(0, 1)
         # hstack of two (3,3) S_2; axis=1 in block -> drop.
         result = transport_hstack(
-            [G, G], output_ndim=2, input_ndims=[2, 2],
+            [G, G],
+            output_ndim=2,
+            input_ndims=[2, 2],
         )
         assert result is None
 
     def test_hstack_1d_all(self):
         from flopscope._symmetry_transport import transport_hstack
+
         # All 1-D inputs -> concat axis 0. 1-D inputs have no multi-axis group.
-        assert transport_hstack(
-            [None, None], output_ndim=1, input_ndims=[1, 1],
-        ) is None
+        assert (
+            transport_hstack(
+                [None, None],
+                output_ndim=1,
+                input_ndims=[1, 1],
+            )
+            is None
+        )
 
     def test_column_stack_2d_inputs(self):
         from flopscope._symmetry_transport import transport_column_stack
+
         G = _sym(0, 1)
         # Two (3,3) S_2 inputs concat along axis 1; axis 1 in block -> drop.
         result = transport_column_stack(
-            [G, G], output_ndim=2, input_ndims=[2, 2],
+            [G, G],
+            output_ndim=2,
+            input_ndims=[2, 2],
         )
         assert result is None
 
@@ -395,6 +475,7 @@ class TestTransportVHColumnStack:
 class TestTransportReshape:
     def test_identity_reshape_preserves(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(0, 1)
         result = transport_reshape(G, input_shape=(3, 3), output_shape=(3, 3))
         assert result is not None and set(result.axes) == {0, 1}
@@ -402,61 +483,80 @@ class TestTransportReshape:
     def test_identity_with_interior_length_1_preserves(self):
         # The bug found by math-olympiad review: (3,1,3) -> (3,1,3) with S_2 on (0,2).
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(0, 2)
         result = transport_reshape(G, input_shape=(3, 1, 3), output_shape=(3, 1, 3))
         assert result is not None and set(result.axes) == {0, 2}
 
     def test_suffix_split_off_block_preserves(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(1, 2)
         # (2, 3, 3, 4) -> (2, 3, 3, 2, 2): last axis 4 splits to (2,2), block intact.
         result = transport_reshape(
-            G, input_shape=(2, 3, 3, 4), output_shape=(2, 3, 3, 2, 2),
+            G,
+            input_shape=(2, 3, 3, 4),
+            output_shape=(2, 3, 3, 2, 2),
         )
         assert result is not None and set(result.axes) == {1, 2}
 
     def test_merge_inside_block_drops(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(1, 2)
         # (2, 3, 3, 4) -> (2, 9, 4): merges two block axes -> drop.
         result = transport_reshape(
-            G, input_shape=(2, 3, 3, 4), output_shape=(2, 9, 4),
+            G,
+            input_shape=(2, 3, 3, 4),
+            output_shape=(2, 9, 4),
         )
         assert result is None
 
     def test_merge_block_with_prefix_drops(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(1, 2)
         # (2, 3, 3, 4) -> (6, 3, 4): merges axis 0 with axis 1 (block).
         result = transport_reshape(
-            G, input_shape=(2, 3, 3, 4), output_shape=(6, 3, 4),
+            G,
+            input_shape=(2, 3, 3, 4),
+            output_shape=(6, 3, 4),
         )
         assert result is None
 
     def test_prepend_length_1(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(0, 1)
         # (3, 3) -> (1, 3, 3): block shifts to (1, 2).
         result = transport_reshape(
-            G, input_shape=(3, 3), output_shape=(1, 3, 3),
+            G,
+            input_shape=(3, 3),
+            output_shape=(1, 3, 3),
         )
         assert result is not None and set(result.axes) == {1, 2}
 
     def test_non_contiguous_block_preserved(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(0, 2)
         # (3, 5, 3) -> (1, 3, 5, 3): non-contig block preserved at (1, 3).
         result = transport_reshape(
-            G, input_shape=(3, 5, 3), output_shape=(1, 3, 5, 3),
+            G,
+            input_shape=(3, 5, 3),
+            output_shape=(1, 3, 5, 3),
         )
         assert result is not None and set(result.axes) == {1, 3}
 
     def test_swap_block_with_non_block_drops(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(0, 2)
         # (3, 5, 3) -> (3, 3, 5): cannot be done by reshape; segment match fails.
         result = transport_reshape(
-            G, input_shape=(3, 5, 3), output_shape=(3, 3, 5),
+            G,
+            input_shape=(3, 5, 3),
+            output_shape=(3, 3, 5),
         )
         assert result is None
 
@@ -464,30 +564,35 @@ class TestTransportReshape:
 class TestTransportRavel:
     def test_ravel_drops_for_nondegenerate(self):
         from flopscope._symmetry_transport import transport_ravel
+
         G = _sym(0, 1)
         result = transport_ravel(G, input_shape=(3, 3))
         assert result is None  # Block of size 3 can't fit in 1-axis output of size 9.
 
     def test_ravel_for_none_input(self):
         from flopscope._symmetry_transport import transport_ravel
+
         assert transport_ravel(None, input_shape=(3, 3)) is None
 
 
 class TestTransportFlip:
     def test_no_axes_flipped_preserves(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _sym(0, 1)
         result = transport_flip(G, ndim=2, axes_flipped=())
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_all_block_axes_flipped_preserves(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _sym(0, 1)
         result = transport_flip(G, ndim=2, axes_flipped=(0, 1))
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_partial_S3_flip_yields_S2(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _sym(0, 1, 2)
         # Flip axis 1 only: setwise stab of {1} in S_3 = perms fixing 1 = S_2 on {0,2}.
         result = transport_flip(G, ndim=3, axes_flipped=(1,))
@@ -496,6 +601,7 @@ class TestTransportFlip:
 
     def test_partial_C3_flip_drops(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _cyc(0, 1, 2)
         # C_3 has no element fixing a singleton -> drops.
         result = transport_flip(G, ndim=3, axes_flipped=(0,))
@@ -503,6 +609,7 @@ class TestTransportFlip:
 
     def test_partial_C4_flip_pair_yields_Z2(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _cyc(0, 1, 2, 3)
         # C_4 with F_A = {0, 2}: element (0 2)(1 3) survives -> Z_2.
         result = transport_flip(G, ndim=4, axes_flipped=(0, 2))
@@ -511,6 +618,7 @@ class TestTransportFlip:
 
     def test_partial_D3_flip_yields_Z2(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _dih(0, 1, 2)
         # D_3 with F_A = {1}: the reflection fixing axis 1 survives -> Z_2.
         result = transport_flip(G, ndim=3, axes_flipped=(1,))
@@ -519,6 +627,7 @@ class TestTransportFlip:
 
     def test_axes_outside_block_flipped_preserves(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _sym(0, 1)
         # Flipping axis 2 (outside block) doesn't affect the block.
         result = transport_flip(G, ndim=3, axes_flipped=(2,))
@@ -526,6 +635,7 @@ class TestTransportFlip:
 
     def test_negative_axis_normalized(self):
         from flopscope._symmetry_transport import transport_flip
+
         G = _sym(0, 1)
         # axis=-1 on ndim=3 means axis 2 (outside block).
         result = transport_flip(G, ndim=3, axes_flipped=(-1,))
@@ -535,84 +645,119 @@ class TestTransportFlip:
 class TestTransportTile:
     def test_constant_reps_on_orbit_preserves(self):
         from flopscope._symmetry_transport import transport_tile
+
         G = _sym(0, 1)
         # reps (2, 2) is constant on the S_2 orbit {0, 1}; output (4, 4).
         result = transport_tile(
-            G, input_shape=(2, 2), output_shape=(4, 4), reps=(2, 2),
+            G,
+            input_shape=(2, 2),
+            output_shape=(4, 4),
+            reps=(2, 2),
         )
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_non_constant_reps_drops(self):
         from flopscope._symmetry_transport import transport_tile
+
         G = _sym(0, 1)
         # reps (2, 1) NOT constant on orbit {0, 1}; output (4, 2).
         result = transport_tile(
-            G, input_shape=(2, 2), output_shape=(4, 2), reps=(2, 1),
+            G,
+            input_shape=(2, 2),
+            output_shape=(4, 2),
+            reps=(2, 1),
         )
         assert result is None
 
     def test_reps_outside_block_preserves(self):
         from flopscope._symmetry_transport import transport_tile
+
         G = _sym(0, 1)
         # reps (1, 1, 2) on (3, 3, 3): axis 2 outside block; constant on orbit {0,1}.
         result = transport_tile(
-            G, input_shape=(3, 3, 3), output_shape=(3, 3, 6), reps=(1, 1, 2),
+            G,
+            input_shape=(3, 3, 3),
+            output_shape=(3, 3, 6),
+            reps=(1, 1, 2),
         )
         assert result is not None and set(result.axes) == {0, 1}
 
     def test_C3_constant_reps_preserves(self):
         from flopscope._symmetry_transport import transport_tile
+
         G = _cyc(0, 1, 2)
         result = transport_tile(
-            G, input_shape=(3, 3, 3), output_shape=(6, 6, 6), reps=(2, 2, 2),
+            G,
+            input_shape=(3, 3, 3),
+            output_shape=(6, 6, 6),
+            reps=(2, 2, 2),
         )
         assert result is not None and result.order() == 3
 
     def test_reps_longer_than_input_shifts_block(self):
         from flopscope._symmetry_transport import transport_tile
+
         G = _sym(0, 1)
         # Input (3, 3), reps=(1, 1, 1) -> output rank 3, input prepended with 1 axis.
         # Block axes shift from (0, 1) to (1, 2).
         result = transport_tile(
-            G, input_shape=(3, 3), output_shape=(1, 3, 3), reps=(1, 1, 1),
+            G,
+            input_shape=(3, 3),
+            output_shape=(1, 3, 3),
+            reps=(1, 1, 1),
         )
         assert result is not None and set(result.axes) == {1, 2}
 
     def test_none_input_returns_none(self):
         from flopscope._symmetry_transport import transport_tile
-        assert transport_tile(
-            None, input_shape=(3, 3), output_shape=(6, 6), reps=(2, 2),
-        ) is None
+
+        assert (
+            transport_tile(
+                None,
+                input_shape=(3, 3),
+                output_shape=(6, 6),
+                reps=(2, 2),
+            )
+            is None
+        )
 
 
 class TestTransportBroadcastExpand:
     def test_broadcast_to_prepended_axes(self):
         from flopscope._symmetry_transport import transport_broadcast_to
+
         G = _sym(0, 1)
         # (3, 3) -> (4, 3, 3): prepend axis of size 4.
         result = transport_broadcast_to(
-            G, input_shape=(3, 3), output_shape=(4, 3, 3),
+            G,
+            input_shape=(3, 3),
+            output_shape=(4, 3, 3),
         )
         assert result is not None and set(result.axes) == {1, 2}
 
     def test_broadcast_to_length_1_expanded_drops(self):
         from flopscope._symmetry_transport import transport_broadcast_to
+
         # (1, 1) S_2(0,1) broadcast to (3, 3): block axes expanded -> drop block.
         G = _sym(0, 1)
         result = transport_broadcast_to(
-            G, input_shape=(1, 1), output_shape=(3, 3),
+            G,
+            input_shape=(1, 1),
+            output_shape=(3, 3),
         )
         # Existing broadcast_group implementation drops both length-1 block axes -> None.
         assert result is None
 
     def test_expand_dims_at_position_0(self):
         from flopscope._symmetry_transport import transport_expand_dims
+
         G = _sym(0, 1)
         result = transport_expand_dims(G, input_ndim=2, axis=0)
         assert result is not None and set(result.axes) == {1, 2}
 
     def test_expand_dims_at_end(self):
         from flopscope._symmetry_transport import transport_expand_dims
+
         G = _sym(0, 1)
         result = transport_expand_dims(G, input_ndim=2, axis=2)
         assert result is not None and set(result.axes) == {0, 1}
@@ -627,6 +772,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_pad_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.pad(T, 1)
@@ -634,6 +780,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_diagonal_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.diagonal(T)
@@ -641,6 +788,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_triu_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.triu(T)
@@ -648,6 +796,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_tril_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.tril(T)
@@ -655,6 +804,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_array_split_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.array_split(T, 3)
@@ -662,6 +812,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_append_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.append(T, np.zeros((1, 3)), axis=0)
@@ -669,6 +820,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_dstack_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.dstack([T, np.eye(3)])
@@ -676,6 +828,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_compress_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.compress([True, False, True], T, axis=0)
@@ -683,6 +836,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_delete_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.delete(T, 0, axis=0)
@@ -690,6 +844,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_choose_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         indices = as_symmetric(np.zeros((3, 3), dtype=int), symmetry=_sym(0, 1))
         choices = [np.eye(3), np.ones((3, 3))]
         with pytest.warns(SymmetryLossWarning):
@@ -698,6 +853,7 @@ class TestOutOfScopeOpsWarn:
 
     def test_block_warns_and_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(np.eye(3), symmetry=_sym(0, 1))
         with pytest.warns(SymmetryLossWarning):
             result = fnp.block([T, np.eye(3)])
@@ -707,12 +863,14 @@ class TestOutOfScopeOpsWarn:
 class TestZeroSizeDefensive:
     def test_reshape_zero_size_input_drops(self):
         from flopscope._symmetry_transport import transport_reshape
+
         G = _sym(0, 1)
         result = transport_reshape(G, input_shape=(0, 3), output_shape=(0, 3))
         assert result is None
 
     def test_split_zero_size_input_drops(self):
         from flopscope._symmetry_transport import transport_split
+
         G = _sym(1, 2)
         result = transport_split(G, input_shape=(0, 3, 3), axis=0)
         assert result is None
@@ -742,6 +900,7 @@ class TestFlipSetwiseStabilizerDeep:
 
     def test_C3_partial_flip_drops_with_warning(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(
             _make_C3_symmetric_tensor(N=3),
             symmetry=_cyc(0, 1, 2),
@@ -774,6 +933,7 @@ class TestReshapeSegmentMatchingDeep:
 
     def test_merge_in_block_drops_with_warning(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(
             np.zeros((2, 3, 3, 4)),
             symmetry=_sym(1, 2),
@@ -798,6 +958,7 @@ class TestTileOrbitConstantDeep:
 
     def test_non_constant_reps_drops(self):
         from flopscope.errors import SymmetryLossWarning
+
         T = as_symmetric(
             np.array([[1.0, 2.0], [2.0, 3.0]]),
             symmetry=_sym(0, 1),
@@ -811,8 +972,10 @@ class TestTileOrbitConstantDeep:
 # Layer-3: Hypothesis property tests (soundness fuzzing)
 # ---------------------------------------------------------------------------
 
-from hypothesis import given, settings, strategies as st
 import math
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 
 def _apply_perm_to_tensor(arr, perm, axes):
@@ -836,7 +999,11 @@ def _apply_perm_to_tensor(arr, perm, axes):
     interior_length_1=st.booleans(),
 )
 def test_reshape_soundness_property(
-    n_block_axes, block_size, prefix_size, suffix_size, interior_length_1,
+    n_block_axes,
+    block_size,
+    prefix_size,
+    suffix_size,
+    interior_length_1,
 ):
     """If transport_reshape claims G survives, the data actually satisfies G."""
     from flopscope._symmetry_transport import transport_reshape
@@ -853,6 +1020,7 @@ def test_reshape_soundness_property(
     rng = np.random.default_rng(0)
     T = rng.standard_normal(input_shape)
     from itertools import permutations
+
     sym = np.zeros_like(T)
     for p in permutations(range(n_block_axes)):
         perm = list(range(len(input_shape)))
@@ -877,8 +1045,9 @@ def test_reshape_soundness_property(
         perm = list(range(len(output_shape)))
         for i, ba in enumerate(out_axes):
             perm[ba] = out_axes[p.array_form[i]]
-        assert np.allclose(out_arr, out_arr.transpose(perm)), \
+        assert np.allclose(out_arr, out_arr.transpose(perm)), (
             f"reshape transport claimed perm {p.array_form} survives but data disagrees"
+        )
 
 
 @settings(max_examples=200, deadline=None)
@@ -896,6 +1065,7 @@ def test_flip_soundness_property(n, flip_subset_size):
     rng = np.random.default_rng(0)
     T = rng.standard_normal((4,) * n)
     from itertools import permutations
+
     sym = np.zeros_like(T)
     for p in permutations(range(n)):
         sym += T.transpose(p)
@@ -936,7 +1106,10 @@ def test_tile_soundness_property(block_size, rep_factor):
     out_arr = np.tile(T, reps)
 
     out_group = transport_tile(
-        G, input_shape=T.shape, output_shape=output_shape, reps=reps,
+        G,
+        input_shape=T.shape,
+        output_shape=output_shape,
+        reps=reps,
     )
     if out_group is None:
         return
@@ -958,6 +1131,7 @@ class TestSuppression:
             _ = fnp.ravel(T)
             _ = fnp.flip(T, axis=0)  # partial flip drops
             from flopscope.errors import SymmetryLossWarning
+
             sym_warnings = [
                 w for w in recwarn.list if issubclass(w.category, SymmetryLossWarning)
             ]

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -554,3 +554,36 @@ class TestTransportTile:
         assert transport_tile(
             None, input_shape=(3, 3), output_shape=(6, 6), reps=(2, 2),
         ) is None
+
+
+class TestTransportBroadcastExpand:
+    def test_broadcast_to_prepended_axes(self):
+        from flopscope._symmetry_transport import transport_broadcast_to
+        G = _sym(0, 1)
+        # (3, 3) -> (4, 3, 3): prepend axis of size 4.
+        result = transport_broadcast_to(
+            G, input_shape=(3, 3), output_shape=(4, 3, 3),
+        )
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_broadcast_to_length_1_expanded_drops(self):
+        from flopscope._symmetry_transport import transport_broadcast_to
+        # (1, 1) S_2(0,1) broadcast to (3, 3): block axes expanded -> drop block.
+        G = _sym(0, 1)
+        result = transport_broadcast_to(
+            G, input_shape=(1, 1), output_shape=(3, 3),
+        )
+        # Existing broadcast_group implementation drops both length-1 block axes -> None.
+        assert result is None
+
+    def test_expand_dims_at_position_0(self):
+        from flopscope._symmetry_transport import transport_expand_dims
+        G = _sym(0, 1)
+        result = transport_expand_dims(G, input_ndim=2, axis=0)
+        assert result is not None and set(result.axes) == {1, 2}
+
+    def test_expand_dims_at_end(self):
+        from flopscope._symmetry_transport import transport_expand_dims
+        G = _sym(0, 1)
+        result = transport_expand_dims(G, input_ndim=2, axis=2)
+        assert result is not None and set(result.axes) == {0, 1}

--- a/tests/test_shape_op_symmetry.py
+++ b/tests/test_shape_op_symmetry.py
@@ -805,3 +805,145 @@ class TestTileOrbitConstantDeep:
         with pytest.warns(SymmetryLossWarning):
             result = fnp.tile(T, (2, 1))
         assert not isinstance(result, SymmetricTensor)
+
+
+# ---------------------------------------------------------------------------
+# Layer-3: Hypothesis property tests (soundness fuzzing)
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings, strategies as st
+import math
+
+
+def _apply_perm_to_tensor(arr, perm, axes):
+    """Apply a permutation acting on `axes` to a tensor's data."""
+    ndim = arr.ndim
+    new_order = list(range(ndim))
+    axis_list = list(axes)
+    perm_arr = perm.array_form
+    # perm is a permutation of (0..len(axes)-1); for each i, axes[i] -> axes[perm[i]].
+    for i, _ in enumerate(axis_list):
+        new_order[axis_list[i]] = axis_list[perm_arr[i]]
+    return arr.transpose(new_order)
+
+
+@settings(max_examples=200, deadline=None)
+@given(
+    n_block_axes=st.integers(min_value=2, max_value=3),
+    block_size=st.integers(min_value=2, max_value=4),
+    prefix_size=st.integers(min_value=1, max_value=3),
+    suffix_size=st.integers(min_value=1, max_value=3),
+    interior_length_1=st.booleans(),
+)
+def test_reshape_soundness_property(
+    n_block_axes, block_size, prefix_size, suffix_size, interior_length_1,
+):
+    """If transport_reshape claims G survives, the data actually satisfies G."""
+    from flopscope._symmetry_transport import transport_reshape
+
+    block_axes = tuple(range(1, 1 + n_block_axes))
+    # Build input shape with optional interior length-1.
+    input_shape = [prefix_size] + [block_size] * n_block_axes + [suffix_size]
+    if interior_length_1:
+        input_shape.insert(2, 1)
+        block_axes = tuple(b if b < 2 else b + 1 for b in block_axes)
+    input_shape = tuple(input_shape)
+
+    # Build an S_n-symmetric tensor on those block axes.
+    rng = np.random.default_rng(0)
+    T = rng.standard_normal(input_shape)
+    from itertools import permutations
+    sym = np.zeros_like(T)
+    for p in permutations(range(n_block_axes)):
+        perm = list(range(len(input_shape)))
+        for i, ba in enumerate(block_axes):
+            perm[ba] = block_axes[p[i]]
+        sym += T.transpose(perm)
+    sym /= math.factorial(n_block_axes)
+
+    G = _sym(*block_axes)
+
+    # Pick a target output shape: split suffix into (suffix_size, 1).
+    output_shape = list(input_shape) + [1]
+    output_shape = tuple(output_shape)
+
+    out_group = transport_reshape(G, input_shape=input_shape, output_shape=output_shape)
+    if out_group is None:
+        return  # No claim, nothing to verify.
+
+    out_arr = sym.reshape(output_shape)
+    out_axes = out_group.axes
+    for p in out_group.elements():
+        perm = list(range(len(output_shape)))
+        for i, ba in enumerate(out_axes):
+            perm[ba] = out_axes[p.array_form[i]]
+        assert np.allclose(out_arr, out_arr.transpose(perm)), \
+            f"reshape transport claimed perm {p.array_form} survives but data disagrees"
+
+
+@settings(max_examples=200, deadline=None)
+@given(
+    n=st.integers(min_value=3, max_value=4),
+    flip_subset_size=st.integers(min_value=0, max_value=4),
+)
+def test_flip_soundness_property(n, flip_subset_size):
+    """If transport_flip claims G' survives, flipped data actually satisfies G'."""
+    from flopscope._symmetry_transport import transport_flip
+
+    flip_subset_size = min(flip_subset_size, n)
+    block_axes = tuple(range(n))
+    # Build S_n-symmetric tensor.
+    rng = np.random.default_rng(0)
+    T = rng.standard_normal((4,) * n)
+    from itertools import permutations
+    sym = np.zeros_like(T)
+    for p in permutations(range(n)):
+        sym += T.transpose(p)
+    sym /= math.factorial(n)
+
+    G = _sym(*block_axes)
+    flipped_axes = tuple(range(flip_subset_size))
+    out_arr = np.flip(sym, axis=flipped_axes) if flipped_axes else sym
+
+    out_group = transport_flip(G, ndim=n, axes_flipped=flipped_axes)
+    if out_group is None:
+        return
+
+    for p in out_group.elements():
+        out_axes = out_group.axes
+        perm = list(range(n))
+        for i, ba in enumerate(out_axes):
+            perm[ba] = out_axes[p.array_form[i]]
+        assert np.allclose(out_arr, out_arr.transpose(perm))
+
+
+@settings(max_examples=200, deadline=None)
+@given(
+    block_size=st.integers(min_value=2, max_value=4),
+    rep_factor=st.integers(min_value=1, max_value=3),
+)
+def test_tile_soundness_property(block_size, rep_factor):
+    """tile with constant reps on the block preserves S_2-symmetry."""
+    from flopscope._symmetry_transport import transport_tile
+
+    rng = np.random.default_rng(0)
+    T = rng.standard_normal((block_size, block_size))
+    T = (T + T.T) / 2  # S_2-symmetric
+    G = _sym(0, 1)
+
+    reps = (rep_factor, rep_factor)
+    output_shape = (block_size * rep_factor, block_size * rep_factor)
+    out_arr = np.tile(T, reps)
+
+    out_group = transport_tile(
+        G, input_shape=T.shape, output_shape=output_shape, reps=reps,
+    )
+    if out_group is None:
+        return
+
+    for p in out_group.elements():
+        out_axes = out_group.axes
+        perm = list(range(2))
+        for i, ba in enumerate(out_axes):
+            perm[ba] = out_axes[p.array_form[i]]
+        assert np.allclose(out_arr, out_arr.transpose(perm))

--- a/tests/test_symmetric.py
+++ b/tests/test_symmetric.py
@@ -31,10 +31,12 @@ def test_array_finalize_is_conservative():
     assert finalized.symmetry is None
 
 
-def test_copy_preserves_symmetry_but_shape_changing_views_drop_it():
+def test_copy_preserves_symmetry_and_shape_methods_now_transport(recwarn):
+    """After issue #68, shape methods either transport symmetry or warn on drop."""
     tensor = as_symmetric(np.eye(3), symmetry=_s2(0, 1))
 
     copied = tensor.copy()
+    # reshape((-1,)) collapses S_2 on (0,1) of (3,3) into a 1-D shape — drops with warning.
     reshaped = tensor.reshape(-1)
     raveled = tensor.ravel()
     flattened = tensor.flatten()
@@ -42,10 +44,25 @@ def test_copy_preserves_symmetry_but_shape_changing_views_drop_it():
 
     assert isinstance(copied, SymmetricTensor)
     assert copied.symmetry == tensor.symmetry
+    # reshape/ravel/flatten to 1-D drop the multi-axis group.
     assert not isinstance(reshaped, SymmetricTensor)
     assert not isinstance(raveled, SymmetricTensor)
     assert not isinstance(flattened, SymmetricTensor)
+    # astype is not in the shape-op transport scope; remains as-is.
     assert not isinstance(cast, SymmetricTensor)
+    # The three shape ops should have emitted SymmetryLossWarning.
+    from flopscope.errors import SymmetryLossWarning
+    sym_warnings = [w for w in recwarn.list if issubclass(w.category, SymmetryLossWarning)]
+    assert len(sym_warnings) >= 3  # reshape, ravel, flatten each warn
+
+
+def test_symmetric_tensor_squeeze_preserves_block(recwarn):
+    """Squeezing an axis outside the block now preserves symmetry."""
+    data = np.eye(3).reshape(1, 3, 3)
+    tensor = as_symmetric(data, symmetry=_s2(1, 2))
+    squeezed = tensor.squeeze(axis=0)
+    assert isinstance(squeezed, SymmetricTensor)
+    assert set(squeezed.symmetry.axes) == {0, 1}
 
 
 def test_transpose_remaps_symmetry():

--- a/tests/test_symmetric.py
+++ b/tests/test_symmetric.py
@@ -65,7 +65,7 @@ def test_symmetric_tensor_squeeze_preserves_block(recwarn):
     tensor = as_symmetric(data, symmetry=_s2(1, 2))
     squeezed = tensor.squeeze(axis=0)
     assert isinstance(squeezed, SymmetricTensor)
-    assert set(squeezed.symmetry.axes) == {0, 1}
+    assert set(squeezed.symmetry.axes or ()) == {0, 1}
 
 
 def test_transpose_remaps_symmetry():

--- a/tests/test_symmetric.py
+++ b/tests/test_symmetric.py
@@ -52,7 +52,10 @@ def test_copy_preserves_symmetry_and_shape_methods_now_transport(recwarn):
     assert not isinstance(cast, SymmetricTensor)
     # The three shape ops should have emitted SymmetryLossWarning.
     from flopscope.errors import SymmetryLossWarning
-    sym_warnings = [w for w in recwarn.list if issubclass(w.category, SymmetryLossWarning)]
+
+    sym_warnings = [
+        w for w in recwarn.list if issubclass(w.category, SymmetryLossWarning)
+    ]
     assert len(sym_warnings) == 3  # reshape, ravel, flatten each warn once
 
 

--- a/tests/test_symmetric.py
+++ b/tests/test_symmetric.py
@@ -10,7 +10,7 @@ import flopscope.numpy as fnp
 from flopscope._budget import BudgetContext
 from flopscope._ndarray import FlopscopeArray
 from flopscope._symmetric import SymmetricTensor, as_symmetric, is_symmetric, symmetrize
-from flopscope.errors import SymmetryError
+from flopscope.errors import SymmetryError, SymmetryLossWarning
 
 
 def _s2(*axes):
@@ -81,10 +81,14 @@ def test_swapaxes_remaps_symmetry():
 
 def test_plain_slices_drop_symmetry():
     tensor = as_symmetric(np.eye(4), symmetry=_s2(0, 1))
-    assert isinstance(tensor[1:, 1:], FlopscopeArray)
-    assert not isinstance(tensor[1:, 1:], SymmetricTensor)
-    assert isinstance(tensor[::-1, ::-1], FlopscopeArray)
-    assert not isinstance(tensor[::-1, ::-1], SymmetricTensor)
+    with pytest.warns(SymmetryLossWarning):
+        sliced_fwd = tensor[1:, 1:]
+    assert isinstance(sliced_fwd, FlopscopeArray)
+    assert not isinstance(sliced_fwd, SymmetricTensor)
+    with pytest.warns(SymmetryLossWarning):
+        sliced_rev = tensor[::-1, ::-1]
+    assert isinstance(sliced_rev, FlopscopeArray)
+    assert not isinstance(sliced_rev, SymmetricTensor)
 
 
 def test_is_symmetric_checks_declared_group():

--- a/tests/test_symmetric.py
+++ b/tests/test_symmetric.py
@@ -53,7 +53,7 @@ def test_copy_preserves_symmetry_and_shape_methods_now_transport(recwarn):
     # The three shape ops should have emitted SymmetryLossWarning.
     from flopscope.errors import SymmetryLossWarning
     sym_warnings = [w for w in recwarn.list if issubclass(w.category, SymmetryLossWarning)]
-    assert len(sym_warnings) >= 3  # reshape, ravel, flatten each warn
+    assert len(sym_warnings) == 3  # reshape, ravel, flatten each warn once
 
 
 def test_symmetric_tensor_squeeze_preserves_block(recwarn):

--- a/tests/test_symmetric_pointwise.py
+++ b/tests/test_symmetric_pointwise.py
@@ -1,11 +1,13 @@
 """Tests for symmetry-aware pointwise operations."""
 
 import numpy
+import pytest
 
 import flopscope as flops
 import flopscope.numpy as fnp
 from flopscope._budget import BudgetContext
 from flopscope._symmetric import SymmetricTensor, as_symmetric
+from flopscope.errors import SymmetryLossWarning
 
 
 class TestUnarySymmetry:
@@ -58,7 +60,8 @@ class TestBinarySymmetry:
         )
         B = numpy.ones((5, 5))
         with BudgetContext(flop_budget=10**6, quiet=True) as budget:
-            result = fnp.add(A, B)
+            with pytest.warns(SymmetryLossWarning):
+                result = fnp.add(A, B)
             assert budget.flops_used == 25
             assert not isinstance(result, SymmetricTensor)
 
@@ -77,9 +80,11 @@ class TestBinarySymmetry:
         )
         B = numpy.arange(25.0).reshape(5, 5)
         with BudgetContext(flop_budget=10**6, quiet=True) as function_budget:
-            expected = fnp.multiply(A, B)
+            with pytest.warns(SymmetryLossWarning):
+                expected = fnp.multiply(A, B)
         with BudgetContext(flop_budget=10**6, quiet=True) as dunder_budget:
-            result = A * B
+            with pytest.warns(SymmetryLossWarning):
+                result = A * B
         assert function_budget.flops_used == dunder_budget.flops_used
         assert not isinstance(expected, SymmetricTensor)
         assert not isinstance(result, SymmetricTensor)
@@ -100,5 +105,6 @@ class TestReductionSymmetry:
         data = numpy.eye(4)
         S = as_symmetric(data, symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)))
         with BudgetContext(flop_budget=10**6, quiet=True):
-            result = fnp.sum(S)
+            with pytest.warns(SymmetryLossWarning):
+                result = fnp.sum(S)
             assert not isinstance(result, SymmetricTensor)

--- a/tests/test_symmetry_transport_helpers.py
+++ b/tests/test_symmetry_transport_helpers.py
@@ -1,0 +1,58 @@
+"""Tests for the new low-level helpers in _symmetry_utils that back transport_*."""
+
+from __future__ import annotations
+
+import pytest
+
+import flopscope as flops
+from flopscope._perm_group import SymmetryGroup
+from flopscope._symmetry_utils import (
+    setwise_stabilizer,
+    group_orbits_on_axes,
+    _normalize_reps_for_output,
+)
+
+
+class TestSetwiseStabilizer:
+    def test_S3_with_singleton_fixed_set_returns_S2(self):
+        G = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        result = setwise_stabilizer(G, fixed_set={1})
+        assert result is not None
+        # Stabilizer of {1} in S_3 = perms mapping 1->1 = S_2 on {0, 2}
+        assert result.order() == 2
+        assert set(result.axes) == {0, 1, 2}
+
+    def test_full_set_returns_full_group(self):
+        G = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        result = setwise_stabilizer(G, fixed_set={0, 1, 2})
+        assert result is not None
+        assert result.order() == G.order()
+
+    def test_empty_set_returns_full_group(self):
+        G = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        result = setwise_stabilizer(G, fixed_set=set())
+        assert result is not None
+        assert result.order() == G.order()
+
+    def test_cyclic_C3_singleton_drops(self):
+        G = SymmetryGroup.cyclic(axes=(0, 1, 2))
+        result = setwise_stabilizer(G, fixed_set={0})
+        # C_3 has no element other than identity that fixes {0}
+        assert result is None
+
+    def test_cyclic_C4_pair_yields_Z2(self):
+        G = SymmetryGroup.cyclic(axes=(0, 1, 2, 3))
+        result = setwise_stabilizer(G, fixed_set={0, 2})
+        # C_4 element (0 2)(1 3) maps {0, 2} -> {0, 2} setwise. Z_2 survives.
+        assert result is not None
+        assert result.order() == 2
+
+    def test_returns_none_for_input_None(self):
+        assert setwise_stabilizer(None, fixed_set={0}) is None
+
+    def test_filters_out_of_block_axes(self):
+        G = SymmetryGroup.symmetric(axes=(0, 1))
+        # fixed_set contains axis 5 which is NOT in G.axes — should be filtered.
+        result = setwise_stabilizer(G, fixed_set={0, 5})
+        # Effective fixed = {0}; stabilizer of {0} in S_2 = trivial -> None.
+        assert result is None

--- a/tests/test_symmetry_transport_helpers.py
+++ b/tests/test_symmetry_transport_helpers.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import pytest
-
-import flopscope as flops
 from flopscope._perm_group import SymmetryGroup
 from flopscope._symmetry_utils import (
-    setwise_stabilizer,
-    group_orbits_on_axes,
     _normalize_reps_for_output,
+    group_orbits_on_axes,
+    setwise_stabilizer,
 )
 
 
@@ -76,6 +73,7 @@ class TestGroupOrbitsOnAxes:
         gA = SymmetryGroup.symmetric(axes=(0, 1))
         gB = SymmetryGroup.symmetric(axes=(3, 4))
         from flopscope._symmetry_utils import direct_product_groups
+
         G = direct_product_groups(gA, gB)
         orbits = group_orbits_on_axes(G, [0, 1, 3, 4])
         # Order may vary; compare as set of frozensets.

--- a/tests/test_symmetry_transport_helpers.py
+++ b/tests/test_symmetry_transport_helpers.py
@@ -17,7 +17,7 @@ class TestSetwiseStabilizer:
         assert result is not None
         # Stabilizer of {1} in S_3 = perms mapping 1->1 = S_2 on {0, 2}
         assert result.order() == 2
-        assert set(result.axes) == {0, 1, 2}
+        assert set(result.axes or ()) == {0, 1, 2}
 
     def test_full_set_returns_full_group(self):
         G = SymmetryGroup.symmetric(axes=(0, 1, 2))
@@ -75,6 +75,7 @@ class TestGroupOrbitsOnAxes:
         from flopscope._symmetry_utils import direct_product_groups
 
         G = direct_product_groups(gA, gB)
+        assert G is not None  # both inputs are non-None, so result is non-None
         orbits = group_orbits_on_axes(G, [0, 1, 3, 4])
         # Order may vary; compare as set of frozensets.
         as_sets = {frozenset(o) for o in orbits}

--- a/tests/test_symmetry_transport_helpers.py
+++ b/tests/test_symmetry_transport_helpers.py
@@ -56,3 +56,35 @@ class TestSetwiseStabilizer:
         result = setwise_stabilizer(G, fixed_set={0, 5})
         # Effective fixed = {0}; stabilizer of {0} in S_2 = trivial -> None.
         assert result is None
+
+
+class TestGroupOrbitsOnAxes:
+    def test_S3_single_orbit_on_all_axes(self):
+        G = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        orbits = group_orbits_on_axes(G, [0, 1, 2])
+        assert len(orbits) == 1
+        assert orbits[0] == {0, 1, 2}
+
+    def test_C3_single_orbit(self):
+        G = SymmetryGroup.cyclic(axes=(0, 1, 2))
+        orbits = group_orbits_on_axes(G, [0, 1, 2])
+        assert len(orbits) == 1
+        assert orbits[0] == {0, 1, 2}
+
+    def test_two_disjoint_S2_orbits_via_direct_product(self):
+        # S_2 on (0,1) direct-product S_2 on (3,4): two separate orbits.
+        gA = SymmetryGroup.symmetric(axes=(0, 1))
+        gB = SymmetryGroup.symmetric(axes=(3, 4))
+        from flopscope._symmetry_utils import direct_product_groups
+        G = direct_product_groups(gA, gB)
+        orbits = group_orbits_on_axes(G, [0, 1, 3, 4])
+        # Order may vary; compare as set of frozensets.
+        as_sets = {frozenset(o) for o in orbits}
+        assert as_sets == {frozenset({0, 1}), frozenset({3, 4})}
+
+    def test_singleton_orbit_for_axis_outside_group(self):
+        # Axis 5 isn't acted on by G, so it's its own orbit.
+        G = SymmetryGroup.symmetric(axes=(0, 1))
+        orbits = group_orbits_on_axes(G, [0, 1, 5])
+        as_sets = {frozenset(o) for o in orbits}
+        assert as_sets == {frozenset({0, 1}), frozenset({5})}

--- a/tests/test_symmetry_transport_helpers.py
+++ b/tests/test_symmetry_transport_helpers.py
@@ -88,3 +88,24 @@ class TestGroupOrbitsOnAxes:
         orbits = group_orbits_on_axes(G, [0, 1, 5])
         as_sets = {frozenset(o) for o in orbits}
         assert as_sets == {frozenset({0, 1}), frozenset({5})}
+
+
+class TestNormalizeRepsForOutput:
+    def test_scalar_reps(self):
+        # tile(arr, 2) with output_ndim=3 -> (1, 1, 2)? No - scalar reps means
+        # replicate every axis by that count. NumPy behavior: scalar => (reps,)
+        # then right-align. For output_ndim=3 with reps=2: output rank stays
+        # max(1, ndim)=3 so reps padded to (1, 1, 2).
+        assert _normalize_reps_for_output(2, output_ndim=3) == (1, 1, 2)
+
+    def test_tuple_shorter_than_output(self):
+        assert _normalize_reps_for_output((2, 3), output_ndim=4) == (1, 1, 2, 3)
+
+    def test_tuple_equal_length(self):
+        assert _normalize_reps_for_output((2, 3, 4), output_ndim=3) == (2, 3, 4)
+
+    def test_tuple_already_padded(self):
+        assert _normalize_reps_for_output((1, 2, 3), output_ndim=3) == (1, 2, 3)
+
+    def test_list_input(self):
+        assert _normalize_reps_for_output([2, 3], output_ndim=3) == (1, 2, 3)


### PR DESCRIPTION
## Summary

Closes [#68](https://github.com/AIcrowd/flopscope/issues/68). For every shape op listed in the issue, `SymmetricTensor`'s `SymmetryGroup` is now correctly transported to the output when survival is provable, and dropped with a `SymmetryLossWarning` otherwise. No more silent downgrades.

New module `src/flopscope/_symmetry_transport.py` contains one `transport_<op>(...)` per shape op (25 in total). `_free_ops.py` callers follow a uniform pattern: NumPy call → transport → warn-on-drop → wrap or `_asplainflopscope`. `SymmetricTensor.reshape/.ravel/.flatten/.squeeze` method overrides now delegate to the free functions so the method-form gets the same treatment.


Highlights:

- **reshape** uses a segment-matching algorithm — preserves symmetry whenever the input/output shapes admit matching "skeleton segments" around the block axes. Handles non-contiguous blocks (e.g. `(3,1,3)` with S₂ on `(0,2)`) and identity reshapes through interior length-1 axes.
- **flip** uses the *setwise stabilizer* of `F ∩ A` in `G` — not the conservative all-or-none rule. This means S₃ flipped on axis 1 correctly yields Z₂ on `(0,2)`, D_n yields surviving reflections, and C_4 with `F={0,2}` yields Z₂ — all empirically verified.
- **tile** uses the orbit-constant rule: preserves G iff `reps` is constant across each G-orbit of A. So S₂(0,1) tile`(2,2)` → S₂(0,1), where the original "reps==1 on block" rule would have dropped.
- **concat / stack / split** intersect groups across multi-input operations, with sensible composition for `vstack` / `hstack` / `column_stack`.
- Out-of-scope ops (`pad`, `triu`, `diagonal`, `fliplr`/`flipud`, etc.) emit a `SymmetryLossWarning` instead of silently stripping.

Test coverage:

- 95+ new tests in `tests/test_shape_op_symmetry.py` across three layers (unit, edge-case, hypothesis property tests with 200 examples each for reshape, flip, tile)
- Coverage assertion test verifies every op in #68 has a `transport_<op>` function
- 14 existing tests updated to match the new transport behavior (drop-and-warn instead of silent drop)
- Full suite: 0 failed, 0 errored

Two new helpers in `_symmetry_utils.py`: `setwise_stabilizer` (thin wrapper over the existing `SymmetryGroup.setwise_stabilizer` method) and `group_orbits_on_axes` (BFS through generators). `_warn_symmetry_loss` relocated from `_symmetric.py` to `flopscope.errors`, next to `SymmetryLossWarning`.

## Test plan

- [x] `uv run pytest tests/test_shape_op_symmetry.py -v` — all green (95+ tests)
- [x] `uv run pytest tests/ --ignore=tests/test_stats_derived.py` — full suite green
- [x] `make lint` — ruff check + format clean
- [x] Issue #68 reproducer (preserved/dropped behavior matches expectations across all 23 listed ops)
- [x] `flops.configure(symmetry_warnings=False)` cleanly suppresses all new warnings