### PR TITLE
Closed-form SymmetryGroup.order() and instance interning

### DIFF
--- a/benchmarks/_perm_group_calibration.py
+++ b/benchmarks/_perm_group_calibration.py
@@ -1,0 +1,175 @@
+"""Calibration script for the dimino_budget setting.
+
+Measures cold ``_dimino`` enumeration time plus ``burnside_unique_count``
+time across representative permutation groups, then prints a
+recommendation for ``dimino_budget``.
+
+Run with::
+
+    python -m benchmarks._perm_group_calibration
+    python -m benchmarks._perm_group_calibration --budget-ms 50 \\
+        --output benchmarks/_perm_group_calibration.json
+
+Output is informational. Users on faster/slower machines run this and
+``flops.configure(dimino_budget=<recommended>)``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import time
+from dataclasses import dataclass
+
+from flopscope._perm_group import SymmetryGroup, _dimino
+
+
+@dataclass(frozen=True)
+class Measurement:
+    label: str
+    group_order: int
+    degree: int
+    dimino_ms: float
+    burnside_ms: float
+
+    @property
+    def total_ms(self) -> float:
+        return self.dimino_ms + self.burnside_ms
+
+
+def _measure_one(group: SymmetryGroup, label: str) -> Measurement:
+    """Time cold ``_dimino`` + Burnside enumeration on one group."""
+    # Cold dimino: bypass the cache by calling _dimino directly.
+    t = time.perf_counter()
+    _dimino(group._generators)
+    dimino_ms = (time.perf_counter() - t) * 1000.0
+
+    # Burnside: realistic size_dict (uniform 4-dim across all axes).
+    size_dict = dict.fromkeys(range(group.degree), 4)
+    t = time.perf_counter()
+    group.burnside_unique_count(size_dict)
+    burnside_ms = (time.perf_counter() - t) * 1000.0
+
+    return Measurement(
+        label=label,
+        group_order=group.order(),
+        degree=group.degree,
+        dimino_ms=dimino_ms,
+        burnside_ms=burnside_ms,
+    )
+
+
+def _sample_groups() -> list[tuple[str, SymmetryGroup]]:
+    """Return the representative group sample for calibration."""
+    samples: list[tuple[str, SymmetryGroup]] = []
+    for n in (3, 4, 5, 6, 7, 8, 9):
+        samples.append((f"S_{n}", SymmetryGroup.symmetric(axes=tuple(range(n)))))
+    for n in (4, 8, 16, 32, 64):
+        samples.append((f"C_{n}", SymmetryGroup.cyclic(axes=tuple(range(n)))))
+    for n in (4, 8, 16, 32, 64):
+        samples.append((f"D_{n}", SymmetryGroup.dihedral(axes=tuple(range(n)))))
+    samples.append(
+        (
+            "S_3 x S_3",
+            SymmetryGroup.direct_product(
+                SymmetryGroup.symmetric(axes=(0, 1, 2)),
+                SymmetryGroup.symmetric(axes=(3, 4, 5)),
+            ),
+        )
+    )
+    samples.append(
+        (
+            "S_4 x S_4",
+            SymmetryGroup.direct_product(
+                SymmetryGroup.symmetric(axes=(0, 1, 2, 3)),
+                SymmetryGroup.symmetric(axes=(4, 5, 6, 7)),
+            ),
+        )
+    )
+    samples.append(
+        (
+            "C_5 x C_5 x C_5",
+            SymmetryGroup.direct_product(
+                SymmetryGroup.cyclic(axes=(0, 1, 2, 3, 4)),
+                SymmetryGroup.cyclic(axes=(5, 6, 7, 8, 9)),
+                SymmetryGroup.cyclic(axes=(10, 11, 12, 13, 14)),
+            ),
+        )
+    )
+    return samples
+
+
+def _print_table(measurements: list[Measurement]) -> None:
+    header = f"{'group':<22}{'|G|':>12}{'dimino':>12}{'burnside':>12}{'total':>12}"
+    print(header)
+    print("-" * len(header))
+    for m in measurements:
+        print(
+            f"{m.label:<22}"
+            f"{m.group_order:>12}"
+            f"{m.dimino_ms:>10.2f}ms"
+            f"{m.burnside_ms:>10.2f}ms"
+            f"{m.total_ms:>10.2f}ms"
+        )
+
+
+def _recommend_budget(measurements: list[Measurement], budget_ms: float) -> int:
+    """Largest |G| whose total cold cost stays under ``budget_ms``."""
+    under_budget = [m for m in measurements if m.total_ms <= budget_ms]
+    if not under_budget:
+        return 1  # nothing fits; degenerate machine
+    return max(m.group_order for m in under_budget)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--budget-ms",
+        type=float,
+        default=100.0,
+        help="Wall-clock budget per group construction (default: 100ms)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Optional JSON output path",
+    )
+    args = parser.parse_args()
+
+    samples = _sample_groups()
+    measurements = [_measure_one(g, label) for label, g in samples]
+
+    _print_table(measurements)
+    recommended = _recommend_budget(measurements, args.budget_ms)
+    print()
+    print(
+        f"Recommended dimino_budget: {recommended}   "
+        f"(group_order_budget_ms={args.budget_ms}, machine: {platform.platform()})"
+    )
+
+    if args.output:
+        payload = {
+            "machine": platform.platform(),
+            "budget_ms": args.budget_ms,
+            "recommended_dimino_budget": recommended,
+            "measurements": [
+                {
+                    "label": m.label,
+                    "group_order": m.group_order,
+                    "degree": m.degree,
+                    "dimino_ms": m.dimino_ms,
+                    "burnside_ms": m.burnside_ms,
+                    "total_ms": m.total_ms,
+                }
+                for m in measurements
+            ],
+        }
+        with open(args.output, "w") as f:
+            json.dump(payload, f, indent=2)
+        print(f"Wrote calibration data to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flopscope-client/src/flopscope/_perm_group.py
+++ b/flopscope-client/src/flopscope/_perm_group.py
@@ -16,10 +16,15 @@ Core algorithms:
 from __future__ import annotations
 
 import math
+import weakref
 from functools import reduce
 from typing import Any
 
 __all__ = ["SymmetryGroup"]
+
+_GROUP_INTERN: weakref.WeakValueDictionary[tuple, SymmetryGroup] = (
+    weakref.WeakValueDictionary()
+)
 
 
 class _Cycle:
@@ -234,10 +239,33 @@ def _normalize_generator_literal(
     return _Permutation(arr)
 
 
+def _closed_form_order(kind: tuple) -> int:
+    """Compute ``|G|`` for a known-kind structural fingerprint.
+
+    The tag layout is recursive: leaf kinds are ``(name, axes_tuple)``
+    where ``name`` is one of ``"identity" | "symmetric" | "cyclic" |
+    "dihedral"``; ``"direct_product"`` carries ``(name, children_tuple)``
+    where each child is itself a kind tuple.
+    """
+    name = kind[0]
+    if name == "identity":
+        return 1
+    if name == "symmetric":
+        return math.factorial(len(kind[1]))
+    if name == "cyclic":
+        return len(kind[1])
+    if name == "dihedral":
+        return 2 * len(kind[1])
+    if name == "direct_product":
+        return math.prod(_closed_form_order(child) for child in kind[1])
+    raise AssertionError(f"unknown kind {kind!r}")
+
+
 class SymmetryGroup:
     """A finite symmetry group defined by explicit generators."""
 
     __slots__ = (
+        "__weakref__",
         "_generators",
         "_degree",
         "_axes",
@@ -245,6 +273,7 @@ class SymmetryGroup:
         "_order",
         "_labels",
         "_canonical_action_cache",
+        "_known_kind",
     )
 
     def __init__(
@@ -270,6 +299,7 @@ class SymmetryGroup:
         self._axes = axes
         self._elements: list[_Permutation] | None = None
         self._order: int | None = None
+        self._known_kind: tuple | None = None
         self._labels: tuple[str, ...] | None = None
         self._canonical_action_cache: (
             tuple[
@@ -330,6 +360,9 @@ class SymmetryGroup:
 
     def order(self) -> int:
         if self._order is not None:
+            return self._order
+        if self._known_kind is not None:
+            self._order = _closed_form_order(self._known_kind)
             return self._order
         self._order = len(self.elements())
         return self._order
@@ -493,22 +526,30 @@ class SymmetryGroup:
         norm_axes = _normalize_axes(axes)
         k = len(norm_axes)
         if k == 1:
-            return cls(_Permutation.identity(1), axes=norm_axes)
+            g = cls(_Permutation.identity(1), axes=norm_axes)
+            g._known_kind = ("identity", norm_axes)
+            return cls._intern(g)
         gens = []
         for i in range(k - 1):
             arr = list(range(k))
             arr[i], arr[i + 1] = arr[i + 1], arr[i]
             gens.append(_Permutation(arr))
-        return cls(*gens, axes=norm_axes)
+        g = cls(*gens, axes=norm_axes)
+        g._known_kind = ("symmetric", norm_axes)
+        return cls._intern(g)
 
     @classmethod
     def cyclic(cls, *, axes: tuple[Any, ...] | list[Any]) -> SymmetryGroup:
         norm_axes = _normalize_axes(axes)
         k = len(norm_axes)
         if k == 1:
-            return cls(_Permutation.identity(1), axes=norm_axes)
+            g = cls(_Permutation.identity(1), axes=norm_axes)
+            g._known_kind = ("identity", norm_axes)
+            return cls._intern(g)
         gen = _Permutation(list(range(1, k)) + [0])
-        return cls(gen, axes=norm_axes)
+        g = cls(gen, axes=norm_axes)
+        g._known_kind = ("cyclic", norm_axes)
+        return cls._intern(g)
 
     @classmethod
     def dihedral(cls, *, axes: tuple[Any, ...] | list[Any]) -> SymmetryGroup:
@@ -518,7 +559,9 @@ class SymmetryGroup:
             return cls.symmetric(axes=norm_axes)
         rotation = _Permutation(list(range(1, k)) + [0])
         reflection = _Permutation([0] + list(range(k - 1, 0, -1)))
-        return cls(rotation, reflection, axes=norm_axes)
+        g = cls(rotation, reflection, axes=norm_axes)
+        g._known_kind = ("dihedral", norm_axes)
+        return cls._intern(g)
 
     @classmethod
     def young(
@@ -565,7 +608,31 @@ class SymmetryGroup:
 
         if not generators:
             generators.append(_Permutation.identity(total_degree))
-        return cls(*generators, axes=tuple(merged_axes))
+        g = cls(*generators, axes=tuple(merged_axes))
+        child_kinds = tuple(group._known_kind for group in groups)
+        if all(kind is not None for kind in child_kinds):
+            g._known_kind = ("direct_product", tuple(sorted(child_kinds, key=repr)))
+        return cls._intern(g)
+
+    @classmethod
+    def _intern(cls, group: SymmetryGroup) -> SymmetryGroup:
+        """Return the canonical instance for ``group``'s known kind.
+
+        Unknown-kind groups (``_known_kind is None``) are returned as-is
+        without registry interaction. Known-kind groups participate in
+        process-wide interning by ``_known_kind`` — the first construction
+        wins the registry slot; subsequent equivalent constructions return
+        the same Python object so caches (``_order``, ``_elements``,
+        ``_canonical_action_cache``) are shared across the equivalence
+        class.
+        """
+        if group._known_kind is None:
+            return group
+        existing = _GROUP_INTERN.get(group._known_kind)
+        if existing is not None:
+            return existing
+        _GROUP_INTERN[group._known_kind] = group
+        return group
 
     def as_sympy(self):
         try:
@@ -612,7 +679,7 @@ class _DiminoBudgetExceeded(Exception):
 def _dimino(generators: tuple[_Permutation, ...]) -> list[_Permutation]:
     """Enumerate all group elements via Dimino's algorithm.
 
-    Consults the configured ``dimino_budget`` setting (default 500_000); if the
+    Consults the configured ``dimino_budget`` setting (default 50_000); if the
     seen-set size exceeds the budget, raises :class:`_DiminoBudgetExceeded`
     instead of running indefinitely. Callers should catch and fall back to a
     dense (no-symmetry) cost via :class:`flopscope.errors.CostFallbackWarning`.

--- a/src/flopscope/_config.py
+++ b/src/flopscope/_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 _SETTINGS: dict[str, object] = {
     "check_nan_inf": False,
-    "dimino_budget": 500_000,
+    "dimino_budget": 50_000,
     "einsum_path_cache_size": 4096,
     "partition_budget": 100_000,
     "symmetry_warnings": True,
@@ -43,7 +43,11 @@ def configure(**kwargs: object) -> None:
     dimino_budget : int
         Maximum number of group elements during whole-expression G_pt closure.
         Pathological declared-symmetry cases that exceed this budget fall back
-        to dense cost with a CostFallbackWarning.  Default ``500_000``.
+        to dense cost with a CostFallbackWarning.  Default ``50_000`` — accepts
+        groups up to ``|S_8| = 40_320`` with a small margin; rejects ``|S_9|``
+        and larger.  Tune via ``flops.configure(dimino_budget=...)``;
+        ``benchmarks/_perm_group_calibration.py`` recommends a value for the
+        host machine.
     einsum_path_cache_size : int
         Maximum number of entries in the einsum path cache.
         Changing this rebuilds the cache (old entries are discarded).

--- a/src/flopscope/_perm_group.py
+++ b/src/flopscope/_perm_group.py
@@ -351,6 +351,9 @@ class SymmetryGroup:
     def order(self) -> int:
         if self._order is not None:
             return self._order
+        if self._known_kind is not None:
+            self._order = _closed_form_order(self._known_kind)
+            return self._order
         self._order = len(self.elements())
         return self._order
 

--- a/src/flopscope/_perm_group.py
+++ b/src/flopscope/_perm_group.py
@@ -241,6 +241,7 @@ class SymmetryGroup:
         "_order",
         "_labels",
         "_canonical_action_cache",
+        "_known_kind",
     )
 
     def __init__(
@@ -266,6 +267,7 @@ class SymmetryGroup:
         self._axes = axes
         self._elements: list[_Permutation] | None = None
         self._order: int | None = None
+        self._known_kind: tuple | None = None
         self._labels: tuple[str, ...] | None = None
         self._canonical_action_cache: (
             tuple[

--- a/src/flopscope/_perm_group.py
+++ b/src/flopscope/_perm_group.py
@@ -675,7 +675,7 @@ class _DiminoBudgetExceeded(Exception):
 def _dimino(generators: tuple[_Permutation, ...]) -> list[_Permutation]:
     """Enumerate all group elements via Dimino's algorithm.
 
-    Consults the configured ``dimino_budget`` setting (default 500_000); if the
+    Consults the configured ``dimino_budget`` setting (default 50_000); if the
     seen-set size exceeds the budget, raises :class:`_DiminoBudgetExceeded`
     instead of running indefinitely. Callers should catch and fall back to a
     dense (no-symmetry) cost via :class:`flopscope.errors.CostFallbackWarning`.

--- a/src/flopscope/_perm_group.py
+++ b/src/flopscope/_perm_group.py
@@ -12,10 +12,15 @@ Core algorithms:
 from __future__ import annotations
 
 import math
+import weakref
 from functools import reduce
 from typing import Any
 
 __all__ = ["SymmetryGroup"]
+
+_GROUP_INTERN: weakref.WeakValueDictionary[tuple, SymmetryGroup] = (
+    weakref.WeakValueDictionary()
+)
 
 
 class _Cycle:
@@ -256,6 +261,7 @@ class SymmetryGroup:
     """A finite symmetry group defined by explicit generators."""
 
     __slots__ = (
+        "__weakref__",
         "_generators",
         "_degree",
         "_axes",
@@ -518,7 +524,7 @@ class SymmetryGroup:
         if k == 1:
             g = cls(_Permutation.identity(1), axes=norm_axes)
             g._known_kind = ("identity", norm_axes)
-            return g
+            return cls._intern(g)
         gens = []
         for i in range(k - 1):
             arr = list(range(k))
@@ -526,7 +532,7 @@ class SymmetryGroup:
             gens.append(_Permutation(arr))
         g = cls(*gens, axes=norm_axes)
         g._known_kind = ("symmetric", norm_axes)
-        return g
+        return cls._intern(g)
 
     @classmethod
     def cyclic(cls, *, axes: tuple[Any, ...] | list[Any]) -> SymmetryGroup:
@@ -535,11 +541,11 @@ class SymmetryGroup:
         if k == 1:
             g = cls(_Permutation.identity(1), axes=norm_axes)
             g._known_kind = ("identity", norm_axes)
-            return g
+            return cls._intern(g)
         gen = _Permutation(list(range(1, k)) + [0])
         g = cls(gen, axes=norm_axes)
         g._known_kind = ("cyclic", norm_axes)
-        return g
+        return cls._intern(g)
 
     @classmethod
     def dihedral(cls, *, axes: tuple[Any, ...] | list[Any]) -> SymmetryGroup:
@@ -551,7 +557,7 @@ class SymmetryGroup:
         reflection = _Permutation([0] + list(range(k - 1, 0, -1)))
         g = cls(rotation, reflection, axes=norm_axes)
         g._known_kind = ("dihedral", norm_axes)
-        return g
+        return cls._intern(g)
 
     @classmethod
     def young(
@@ -602,7 +608,27 @@ class SymmetryGroup:
         child_kinds = tuple(group._known_kind for group in groups)
         if all(kind is not None for kind in child_kinds):
             g._known_kind = ("direct_product", tuple(sorted(child_kinds, key=repr)))
-        return g
+        return cls._intern(g)
+
+    @classmethod
+    def _intern(cls, group: SymmetryGroup) -> SymmetryGroup:
+        """Return the canonical instance for ``group``'s known kind.
+
+        Unknown-kind groups (``_known_kind is None``) are returned as-is
+        without registry interaction. Known-kind groups participate in
+        process-wide interning by ``_known_kind`` — the first construction
+        wins the registry slot; subsequent equivalent constructions return
+        the same Python object so caches (``_order``, ``_elements``,
+        ``_canonical_action_cache``) are shared across the equivalence
+        class.
+        """
+        if group._known_kind is None:
+            return group
+        existing = _GROUP_INTERN.get(group._known_kind)
+        if existing is not None:
+            return existing
+        _GROUP_INTERN[group._known_kind] = group
+        return group
 
     def as_sympy(self):
         try:

--- a/src/flopscope/_perm_group.py
+++ b/src/flopscope/_perm_group.py
@@ -516,22 +516,30 @@ class SymmetryGroup:
         norm_axes = _normalize_axes(axes)
         k = len(norm_axes)
         if k == 1:
-            return cls(_Permutation.identity(1), axes=norm_axes)
+            g = cls(_Permutation.identity(1), axes=norm_axes)
+            g._known_kind = ("identity", norm_axes)
+            return g
         gens = []
         for i in range(k - 1):
             arr = list(range(k))
             arr[i], arr[i + 1] = arr[i + 1], arr[i]
             gens.append(_Permutation(arr))
-        return cls(*gens, axes=norm_axes)
+        g = cls(*gens, axes=norm_axes)
+        g._known_kind = ("symmetric", norm_axes)
+        return g
 
     @classmethod
     def cyclic(cls, *, axes: tuple[Any, ...] | list[Any]) -> SymmetryGroup:
         norm_axes = _normalize_axes(axes)
         k = len(norm_axes)
         if k == 1:
-            return cls(_Permutation.identity(1), axes=norm_axes)
+            g = cls(_Permutation.identity(1), axes=norm_axes)
+            g._known_kind = ("identity", norm_axes)
+            return g
         gen = _Permutation(list(range(1, k)) + [0])
-        return cls(gen, axes=norm_axes)
+        g = cls(gen, axes=norm_axes)
+        g._known_kind = ("cyclic", norm_axes)
+        return g
 
     @classmethod
     def dihedral(cls, *, axes: tuple[Any, ...] | list[Any]) -> SymmetryGroup:
@@ -541,7 +549,9 @@ class SymmetryGroup:
             return cls.symmetric(axes=norm_axes)
         rotation = _Permutation(list(range(1, k)) + [0])
         reflection = _Permutation([0] + list(range(k - 1, 0, -1)))
-        return cls(rotation, reflection, axes=norm_axes)
+        g = cls(rotation, reflection, axes=norm_axes)
+        g._known_kind = ("dihedral", norm_axes)
+        return g
 
     @classmethod
     def young(
@@ -588,7 +598,11 @@ class SymmetryGroup:
 
         if not generators:
             generators.append(_Permutation.identity(total_degree))
-        return cls(*generators, axes=tuple(merged_axes))
+        g = cls(*generators, axes=tuple(merged_axes))
+        child_kinds = tuple(group._known_kind for group in groups)
+        if all(kind is not None for kind in child_kinds):
+            g._known_kind = ("direct_product", tuple(sorted(child_kinds, key=repr)))
+        return g
 
     def as_sympy(self):
         try:

--- a/src/flopscope/_perm_group.py
+++ b/src/flopscope/_perm_group.py
@@ -230,6 +230,28 @@ def _normalize_generator_literal(
     return _Permutation(arr)
 
 
+def _closed_form_order(kind: tuple) -> int:
+    """Compute ``|G|`` for a known-kind structural fingerprint.
+
+    The tag layout is recursive: leaf kinds are ``(name, axes_tuple)``
+    where ``name`` is one of ``"identity" | "symmetric" | "cyclic" |
+    "dihedral"``; ``"direct_product"`` carries ``(name, children_tuple)``
+    where each child is itself a kind tuple.
+    """
+    name = kind[0]
+    if name == "identity":
+        return 1
+    if name == "symmetric":
+        return math.factorial(len(kind[1]))
+    if name == "cyclic":
+        return len(kind[1])
+    if name == "dihedral":
+        return 2 * len(kind[1])
+    if name == "direct_product":
+        return math.prod(_closed_form_order(child) for child in kind[1])
+    raise AssertionError(f"unknown kind {kind!r}")
+
+
 class SymmetryGroup:
     """A finite symmetry group defined by explicit generators."""
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -28,6 +28,7 @@ from flopscope._ndarray import (
     _to_base_ndarray,
     _to_base_ndarray_tree,
 )
+from flopscope._perm_group import _DiminoBudgetExceeded
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetric import is_symmetric as _is_symmetric
 from flopscope._symmetry_utils import (
@@ -99,47 +100,42 @@ def _validate_result_symmetry(result, symmetry):
         raise SymmetryError(axes=tuple(axes), max_deviation=float("inf"))
 
 
-# Permutation groups with degree above this threshold are skipped from
-# symmetry-aware cost adjustment. ``SymmetryGroup.order()`` enumerates
-# the group's elements; for ``S_n`` that's ``n!`` work, which already
-# blows past Python's recursion / memory limits at ``n ≈ 20``.
-# ``np.ones((1,)*33)`` produces an S_33 auto-inferred symmetry — the
-# cost adjustment is irrelevant for length-1 axes anyway. Above this
-# rank we bail out and charge dense cost.
-_MAX_SYMMETRY_DEGREE_FOR_COST = 12
-
-
 def _is_oversized_for_cost_model(group):
-    """``True`` if walking ``group``'s elements would be prohibitively slow."""
+    """``True`` if walking ``group``'s elements would be prohibitively slow.
+
+    Uses ``group.order()`` against the configured ``dimino_budget``.
+    For known-kind groups, ``order()`` is O(1) closed form (#71) — the
+    check is cheap. For unknown-kind groups, ``order()`` runs ``_dimino``;
+    if it exceeds the budget mid-enumeration, ``_DiminoBudgetExceeded``
+    raises and we treat the group as oversized.
+    """
     if group is None:
         return False
-    return group.degree > _MAX_SYMMETRY_DEGREE_FOR_COST
+    budget = int(_get_setting("dimino_budget"))
+    try:
+        return group.order() > budget
+    except _DiminoBudgetExceeded:
+        return True
 
 
 @_functools.cache
-def _seen_oversized(op_name: str, degree: int) -> bool:
-    """Return ``True`` once per ``(op, degree)`` pair, ``False`` thereafter.
+def _seen_oversized(op_name: str, group_order: int) -> bool:
+    """Return ``True`` once per ``(op, |G|)`` pair, ``False`` thereafter.
 
-    The ``lru_cache`` deduplicates: the first call for a given
-    ``(op_name, degree)`` returns ``True`` (and the cache stores it);
-    subsequent identical calls hit the cache and return the stored
-    ``True`` — but we use the *miss-vs-hit* discipline at the call
-    site (``if cache_clear() is None`` style) instead of relying on
-    the value. The simpler pattern is to just call the function and
-    let ``lru_cache`` track which keys we've already seen, then
-    actually emit the warning at the call site only when we know
-    we're on a fresh key. See :func:`_warn_oversized_once`.
+    Used by :func:`_warn_oversized_once` to dedup warnings per
+    process. The ``lru_cache`` does the deduplication; we use the
+    miss-vs-hit discipline at the call site (see that function).
     """
     return True
 
 
-def _warn_oversized_once(op_name: str, degree: int) -> None:
-    """Emit :class:`CostFallbackWarning` once per ``(op_name, degree)``.
+def _warn_oversized_once(op_name: str, group_order: int) -> None:
+    """Emit :class:`CostFallbackWarning` once per ``(op_name, |G|)``.
 
     Hot paths (e.g. numpy compat tests doing thousands of ufunc calls
     on the same auto-inferred ``S_n`` symmetry) would otherwise spam
     one warning per call. The warning fires once per process for each
-    ``(op, degree)`` pair so users get the diagnostic without log
+    ``(op, |G|)`` pair so users get the diagnostic without log
     flooding.
 
     Honours ``flops.configure(symmetry_warnings=False)`` — shares the
@@ -148,20 +144,16 @@ def _warn_oversized_once(op_name: str, degree: int) -> None:
     """
     if not _get_setting("symmetry_warnings"):
         return
-    # The miss-vs-hit trick: ``cache_info().hits`` increments only on
-    # a cache hit. We snapshot before, call the cached function (which
-    # is cheap — just returns True), and check whether ``hits`` rose.
-    # If it didn't, this is the first call for this key.
     info_before = _seen_oversized.cache_info()
-    _seen_oversized(op_name, degree)
+    _seen_oversized(op_name, group_order)
     if _seen_oversized.cache_info().hits > info_before.hits:
-        return  # already warned for this (op, degree) pair
+        return  # already warned for this (op, |G|) pair
+    budget = int(_get_setting("dimino_budget"))
     _warnings.warn(
         f"{op_name}: skipping symmetry-aware cost adjustment for a "
-        f"SymmetryGroup of degree {degree} (threshold "
-        f"{_MAX_SYMMETRY_DEGREE_FOR_COST}); charging dense cost. "
-        f"Burnside enumeration on |S_{degree}| = {degree}! is "
-        f"infeasible. Suppress with flops.configure(symmetry_warnings=False).",
+        f"SymmetryGroup of order {group_order} (budget {budget}); "
+        f"charging dense cost. Group enumeration would exceed the budget. "
+        f"Suppress with flops.configure(symmetry_warnings=False).",
         CostFallbackWarning,
         stacklevel=4,
     )
@@ -602,16 +594,16 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
     b_sym = _symmetry_of(b)
     output_shape = tuple(a.shape) + tuple(b.shape)
     dense = _builtins.max(a.size * b.size, 1)
-    # Bail on the symmetry composition for high-degree groups: the
-    # direct-product call enumerates ``|a_sym| * |b_sym|`` group
-    # elements, which explodes for auto-inferred S_n on (1,)*n shapes
-    # (np.ones((1,)*33) → S_33 with 33! elements). The cost adjustment
-    # is irrelevant when the output is trivially small anyway.
+    # The cost-model branch below enumerates |output_symmetry| group
+    # elements; if either input group's |G| exceeds dimino_budget the
+    # enumeration would be infeasible (np.ones((1,)*33) → S_33 with
+    # 33! ≈ 8.7e36 elements). The cost adjustment is irrelevant when
+    # the output is trivially small anyway.
     if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
-        oversized_degree = (
-            a_sym.degree if _is_oversized_for_cost_model(a_sym) else b_sym.degree  # type: ignore[union-attr]
+        oversized_order = (
+            a_sym.order() if _is_oversized_for_cost_model(a_sym) else b_sym.order()  # type: ignore[union-attr]
         )
-        _warn_oversized_once(f"{ufunc.__name__}.outer", oversized_degree)
+        _warn_oversized_once(f"{ufunc.__name__}.outer", oversized_order)
         out_sym = None
         cost = dense
     else:
@@ -2072,15 +2064,16 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
     dense = _builtins.max(a.size * b.size // contracted, 1) if contracted > 0 else 1
     # Compose output symmetry from each input's surviving symmetry, with
     # b's axes lifted past a's surviving count so they refer to their
-    # final slots in the combined output. Bail on the composition for
-    # high-degree groups (see ``_is_oversized_for_cost_model``).
+    # final slots in the combined output. Bail on the composition when
+    # either group's |G| exceeds dimino_budget (see
+    # ``_is_oversized_for_cost_model``).
     a_sym = _symmetry_of(a)
     b_sym = _symmetry_of(b)
     if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
-        oversized_degree = (
-            a_sym.degree if _is_oversized_for_cost_model(a_sym) else b_sym.degree  # type: ignore[union-attr]
+        oversized_order = (
+            a_sym.order() if _is_oversized_for_cost_model(a_sym) else b_sym.order()  # type: ignore[union-attr]
         )
-        _warn_oversized_once("tensordot", oversized_degree)
+        _warn_oversized_once("tensordot", oversized_order)
         out_sym = None
         cost = dense
     else:

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -600,9 +600,15 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
     # 33! ≈ 8.7e36 elements). The cost adjustment is irrelevant when
     # the output is trivially small anyway.
     if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
-        oversized_order = (
-            a_sym.order() if _is_oversized_for_cost_model(a_sym) else b_sym.order()  # type: ignore[union-attr]
-        )
+        try:
+            oversized_order = (
+                a_sym.order() if _is_oversized_for_cost_model(a_sym) else b_sym.order()  # type: ignore[union-attr]
+            )
+        except _DiminoBudgetExceeded:
+            # Unknown-kind group exceeds budget mid-enumeration; can't
+            # compute exact |G|. Use sentinel so all such groups share
+            # one dedup slot for the warning.
+            oversized_order = -1
         _warn_oversized_once(f"{ufunc.__name__}.outer", oversized_order)
         out_sym = None
         cost = dense
@@ -2070,9 +2076,15 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
     a_sym = _symmetry_of(a)
     b_sym = _symmetry_of(b)
     if _is_oversized_for_cost_model(a_sym) or _is_oversized_for_cost_model(b_sym):
-        oversized_order = (
-            a_sym.order() if _is_oversized_for_cost_model(a_sym) else b_sym.order()  # type: ignore[union-attr]
-        )
+        try:
+            oversized_order = (
+                a_sym.order() if _is_oversized_for_cost_model(a_sym) else b_sym.order()  # type: ignore[union-attr]
+            )
+        except _DiminoBudgetExceeded:
+            # Unknown-kind group exceeds budget mid-enumeration; can't
+            # compute exact |G|. Use sentinel so all such groups share
+            # one dedup slot for the warning.
+            oversized_order = -1
         _warn_oversized_once("tensordot", oversized_order)
         out_sym = None
         cost = dense

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -111,7 +111,7 @@ def _is_oversized_for_cost_model(group):
     """
     if group is None:
         return False
-    budget = int(_get_setting("dimino_budget"))
+    budget = int(_get_setting("dimino_budget"))  # type: ignore[arg-type]
     try:
         return group.order() > budget
     except _DiminoBudgetExceeded:
@@ -148,7 +148,7 @@ def _warn_oversized_once(op_name: str, group_order: int) -> None:
     _seen_oversized(op_name, group_order)
     if _seen_oversized.cache_info().hits > info_before.hits:
         return  # already warned for this (op, |G|) pair
-    budget = int(_get_setting("dimino_budget"))
+    budget = int(_get_setting("dimino_budget"))  # type: ignore[arg-type]
     _warnings.warn(
         f"{op_name}: skipping symmetry-aware cost adjustment for a "
         f"SymmetryGroup of order {group_order} (budget {budget}); "

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -152,7 +152,14 @@ def restrict_group_to_axes(
     group: SymmetryGroup | None,
     axes: Iterable[int],
 ) -> SymmetryGroup | None:
-    """Restrict a group to a specific ordered subset of its tensor axes."""
+    """Restrict a group to a specific ordered subset of its tensor axes.
+
+    Precondition (inherited from :meth:`SymmetryGroup.restrict`): every
+    element of ``group`` must setwise-preserve ``axes``. For free-permuting
+    groups like ``symmetric(A)`` this is only satisfied when
+    ``axes == group.axes`` — see ``reduce_group`` for the
+    setwise-stabilizer+restrict composition that handles strict subsets.
+    """
     if group is None:
         return None
     validate_symmetry_group(group)
@@ -160,6 +167,9 @@ def restrict_group_to_axes(
     if group_axes is None:
         group_axes = tuple(range(group.degree))
     wanted_axes = _normalize_axis_tuple(axes, what="restricted axes")
+    if wanted_axes == group_axes:
+        # No-op: kind passes through via the interned original.
+        return group
     local_indices = []
     for axis in wanted_axes:
         if axis not in group_axes:

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -181,11 +181,12 @@ def restrict_group_to_axes(
 ) -> SymmetryGroup | None:
     """Restrict a group to a specific ordered subset of its tensor axes.
 
-    Precondition (inherited from :meth:`SymmetryGroup.restrict`): every
-    element of ``group`` must setwise-preserve ``axes``. For free-permuting
-    groups like ``symmetric(A)`` this is only satisfied when
-    ``axes == group.axes`` — see ``reduce_group`` for the
-    setwise-stabilizer+restrict composition that handles strict subsets.
+    The helper composes :meth:`SymmetryGroup.setwise_stabilizer` and
+    :meth:`SymmetryGroup.restrict` so strict subsets of free-permuting groups
+    (e.g. ``symmetric(A)``) project cleanly to a sub-action. Provenance is
+    preserved only in the no-op case (``axes == group.axes``); strict-subset
+    results carry ``_known_kind=None`` — the "sub-symmetric is still symmetric"
+    rule lives in ``reduce_group``, not here.
     """
     if group is None:
         return None

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -179,6 +179,28 @@ def restrict_group_to_axes(
     return restricted
 
 
+def _remap_kind(kind: tuple | None, axis_map: Mapping[Any, Any]) -> tuple | None:
+    """Apply ``axis_map`` to the axes inside a ``_known_kind`` tag.
+
+    Returns ``None`` if any leaf axis is missing from the map (caller's
+    responsibility to ensure full coverage).
+    """
+    if kind is None:
+        return None
+    name = kind[0]
+    if name in ("identity", "symmetric", "cyclic", "dihedral"):
+        try:
+            return (name, tuple(axis_map[a] for a in kind[1]))
+        except KeyError:
+            return None
+    if name == "direct_product":
+        children = tuple(_remap_kind(child, axis_map) for child in kind[1])
+        if any(child is None for child in children):
+            return None
+        return ("direct_product", tuple(sorted(children, key=repr)))
+    return None
+
+
 def remap_group_axes(
     group: SymmetryGroup | None,
     axis_map: Mapping[int, int],
@@ -196,10 +218,15 @@ def remap_group_axes(
             raise ValueError(f"missing remap for axis {axis}")
         remapped_axes.append(axis_map[axis])
     _normalize_axis_tuple(remapped_axes, what="remapped axes")
-    return SymmetryGroup.from_generators(
+    remapped = SymmetryGroup.from_generators(
         group.generator_literals,  # pyright: ignore[reportArgumentType]
         axes=tuple(remapped_axes),  # type: ignore[arg-type]
     )
+    new_kind = _remap_kind(group._known_kind, axis_map)
+    if new_kind is not None:
+        remapped._known_kind = new_kind
+        remapped = SymmetryGroup._intern(remapped)
+    return remapped
 
 
 def remap_group_for_expand_dims(

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -289,6 +289,16 @@ def intersect_groups(
     """Intersect two groups after embedding them into the same tensor rank."""
     if a is None or b is None:
         return None
+    # Easy known-kind case — same group ∩ itself = itself. Preserve
+    # provenance without enumeration. Skip trivial groups (order <= 1)
+    # so the existing "None means no symmetry" convention holds.
+    if (
+        a._known_kind is not None
+        and a._known_kind == b._known_kind
+    ):
+        if a.order() <= 1:
+            return None
+        return a
     if a.axes is not None and b.axes is not None and a.axes == b.axes:
         common = sorted(
             set(a.elements()) & set(b.elements()),

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -127,6 +127,33 @@ def _unique_elements_for_shape_cached(
     return result
 
 
+def _build_from_kind(kind: tuple) -> SymmetryGroup | None:
+    """Construct an interned SymmetryGroup from a ``_known_kind`` tag.
+
+    Routes through the public factory matching the kind name. Returns
+    ``None`` for trivial (identity) kinds, since callers expect ``None``
+    to represent "no non-trivial symmetry."
+    """
+    name = kind[0]
+    if name == "identity":
+        return None
+    if name == "symmetric":
+        return SymmetryGroup.symmetric(axes=kind[1])
+    if name == "cyclic":
+        return SymmetryGroup.cyclic(axes=kind[1])
+    if name == "dihedral":
+        return SymmetryGroup.dihedral(axes=kind[1])
+    if name == "direct_product":
+        children = [_build_from_kind(child) for child in kind[1]]
+        non_trivial = [c for c in children if c is not None]
+        if not non_trivial:
+            return None
+        if len(non_trivial) == 1:
+            return non_trivial[0]
+        return SymmetryGroup.direct_product(*non_trivial)
+    raise AssertionError(f"unknown kind {kind!r}")
+
+
 def embed_group(group: SymmetryGroup | None, ndim: int) -> SymmetryGroup | None:
     """Embed a group acting on selected tensor axes into full rank ``ndim``."""
     if group is None:
@@ -208,6 +235,62 @@ def _remap_kind(kind: tuple | None, axis_map: Mapping[Any, Any]) -> tuple | None
         if any(child is None for child in children):
             return None
         return ("direct_product", tuple(sorted(children, key=repr)))
+    return None
+
+
+def _reduced_kind(
+    kind: tuple | None,
+    *,
+    reduced_axes: set[int],
+    axis_map: Mapping[Any, Any],
+) -> tuple | None:
+    """Compute the reduced kind tag for a known-kind group.
+
+    ``reduced_axes`` is the set of tensor axes being reduced over (in the
+    parent group's axis space). ``axis_map`` is the surviving-axes mapping
+    from old tensor axes to new tensor positions (post-reduction layout).
+
+    Returns ``None`` if the result is trivial or can't be expressed in
+    closed form.
+    """
+    if kind is None:
+        return None
+    name = kind[0]
+    if name == "identity":
+        kept = tuple(axis_map[a] for a in kind[1] if a not in reduced_axes)
+        if not kept:
+            return None
+        return ("identity", kept)
+    if name == "symmetric":
+        kept = tuple(axis_map[a] for a in kind[1] if a not in reduced_axes)
+        if len(kept) < 2:
+            return None
+        return ("symmetric", kept)
+    if name == "cyclic":
+        # Cyclic only survives if NONE of its axes are reduced (the cycle
+        # would otherwise no longer be a closed orbit on the kept axes).
+        if any(a in reduced_axes for a in kind[1]):
+            return None
+        kept = tuple(axis_map[a] for a in kind[1])
+        return ("cyclic", kept)
+    if name == "dihedral":
+        if any(a in reduced_axes for a in kind[1]):
+            return None
+        kept = tuple(axis_map[a] for a in kind[1])
+        return ("dihedral", kept)
+    if name == "direct_product":
+        new_children = []
+        for child in kind[1]:
+            new_child = _reduced_kind(
+                child, reduced_axes=reduced_axes, axis_map=axis_map
+            )
+            if new_child is not None:
+                new_children.append(new_child)
+        if not new_children:
+            return None
+        if len(new_children) == 1:
+            return new_children[0]
+        return ("direct_product", tuple(sorted(new_children, key=repr)))
     return None
 
 
@@ -491,6 +574,18 @@ def reduce_group(
             if dim not in axes_set:
                 old_to_new[dim] = new_idx
                 new_idx += 1
+
+    # Fast path for known-kind groups: compute the reduced kind directly
+    # and route through the appropriate factory. Avoids _dimino entirely.
+    if group._known_kind is not None:
+        reduced_kind = _reduced_kind(
+            group._known_kind, reduced_axes=axes_set, axis_map=old_to_new
+        )
+        if reduced_kind is not None:
+            return _build_from_kind(reduced_kind)
+        # Fall through to the generic path if the kind can't be reduced
+        # in closed form (e.g. partial reduction of a direct_product child
+        # whose own kind doesn't survive).
 
     group_axes = group.axes
     if group_axes is None:

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -375,10 +375,7 @@ def intersect_groups(
     # Easy known-kind case — same group ∩ itself = itself. Preserve
     # provenance without enumeration. Skip trivial groups (order <= 1)
     # so the existing "None means no symmetry" convention holds.
-    if (
-        a._known_kind is not None
-        and a._known_kind == b._known_kind
-    ):
+    if a._known_kind is not None and a._known_kind == b._known_kind:
         if a.order() <= 1:
             return None
         return a

--- a/src/flopscope/errors.py
+++ b/src/flopscope/errors.py
@@ -143,14 +143,15 @@ class CostFallbackWarning(FlopscopeWarning):
     """Warning issued when flopscope skips its symmetry-aware cost adjustment.
 
     The output's symmetry group is too large for the placeholder cost
-    model's Burnside enumeration (degree above the per-call threshold,
-    typically 12). The op runs correctly with the dense cost charged
+    model's Burnside enumeration — its order ``|G|`` exceeds the configured
+    ``dimino_budget``. The op runs correctly with the dense cost charged
     instead — only the FLOP accounting is conservative; the data is
     unaffected. Common trigger: ``np.ones((1,)*n)`` for large ``n`` or
     other auto-inferred ``S_n`` symmetries on degenerate shapes.
 
-    Suppress with ``flops.configure(symmetry_warnings=False)`` (shares the
-    flag with :class:`SymmetryLossWarning` since both are
+    Tune the threshold with ``flops.configure(dimino_budget=...)``. Suppress
+    the warning with ``flops.configure(symmetry_warnings=False)`` (shares
+    the flag with :class:`SymmetryLossWarning` since both are
     symmetry-related diagnostics).
     """
 

--- a/tests/accumulation/test_config_budgets.py
+++ b/tests/accumulation/test_config_budgets.py
@@ -9,8 +9,11 @@ def test_partition_budget_default_is_100k():
     assert get_setting("partition_budget") == 100_000
 
 
-def test_dimino_budget_default_is_500k():
-    assert get_setting("dimino_budget") == 500_000
+def test_dimino_budget_default_is_50k():
+    # Lowered from 500_000 to 50_000 alongside the order-based gate from #71.
+    # |S_8| = 40_320 fits with margin; |S_9| = 362_880 does not.
+    # See benchmarks/_perm_group_calibration.py for the empirical justification.
+    assert get_setting("dimino_budget") == 50_000
 
 
 def test_partition_budget_can_be_overridden():

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -350,7 +350,7 @@ def test_np_add_outer_warns_and_bails_on_oversized_symmetry():
     """High-degree symmetry groups (e.g. ``S_n`` from ``np.ones((1,)*n)``
     for large ``n``) would require Burnside enumeration on ``n!``
     elements, which is infeasible. The wrapper bails to dense cost and
-    emits :class:`CostFallbackWarning` once per ``(op, degree)``."""
+    emits :class:`CostFallbackWarning` once per ``(op, |G|)``."""
     import warnings as _warnings
 
     from flopscope.errors import CostFallbackWarning

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -367,7 +367,8 @@ def test_np_add_outer_warns_and_bails_on_oversized_symmetry():
                 np.add.outer(deep, deep)
     cost_warnings = [w for w in caught if issubclass(w.category, CostFallbackWarning)]
     assert len(cost_warnings) == 1, [str(w.message) for w in caught]
-    assert "degree 33" in str(cost_warnings[0].message)
+    assert "order " in str(cost_warnings[0].message)
+    assert "budget " in str(cost_warnings[0].message)
 
 
 def test_cost_fallback_warning_suppressed_by_configure():

--- a/tests/test_perm_group_closed_form_order.py
+++ b/tests/test_perm_group_closed_form_order.py
@@ -6,7 +6,7 @@ import math
 
 import pytest
 
-from flopscope._perm_group import _closed_form_order
+from flopscope._perm_group import SymmetryGroup, _closed_form_order
 
 
 class TestClosedFormOrder:
@@ -43,3 +43,23 @@ class TestClosedFormOrder:
     def test_unknown_kind_raises(self):
         with pytest.raises(AssertionError):
             _closed_form_order(("nonsense", (0, 1, 2)))
+
+
+class TestOrderDispatch:
+    def test_order_dispatches_to_closed_form_when_kind_set(self):
+        # If _known_kind is set, order() must not enumerate elements.
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
+        g._order = None
+        g._elements = None
+        g._known_kind = ("symmetric", (0, 1, 2, 3))
+        # Sentinel: replace _generators with something that would fail
+        # if _dimino tried to enumerate. The closed-form path doesn't
+        # touch _generators, so this must succeed.
+        g._generators = ()
+        assert g.order() == 24
+
+    def test_order_falls_back_to_dimino_when_kind_none(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        g._order = None
+        g._known_kind = None
+        assert g.order() == 6  # via _dimino

--- a/tests/test_perm_group_closed_form_order.py
+++ b/tests/test_perm_group_closed_form_order.py
@@ -6,7 +6,22 @@ import math
 
 import pytest
 
-from flopscope._perm_group import SymmetryGroup, _closed_form_order, _dimino
+from flopscope._perm_group import (
+    _GROUP_INTERN,
+    SymmetryGroup,
+    _closed_form_order,
+    _dimino,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_intern_registry():
+    # Clear before and after each test so mutation of factory output
+    # (which now returns interned singletons after #73) doesn't bleed
+    # across tests. Same isolation pattern as test_perm_group_interning.py.
+    _GROUP_INTERN.clear()
+    yield
+    _GROUP_INTERN.clear()
 
 
 class TestClosedFormOrder:

--- a/tests/test_perm_group_closed_form_order.py
+++ b/tests/test_perm_group_closed_form_order.py
@@ -6,7 +6,7 @@ import math
 
 import pytest
 
-from flopscope._perm_group import SymmetryGroup, _closed_form_order
+from flopscope._perm_group import SymmetryGroup, _closed_form_order, _dimino
 
 
 class TestClosedFormOrder:
@@ -145,3 +145,38 @@ class TestFactoryTagging:
         g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3, 4, 5, 6))
         assert g.order() == 5040
         assert g._elements is None  # not enumerated; _dimino not called
+
+
+class TestClosedFormVsDimino:
+    """Pin the closed-form formula against _dimino ground truth.
+
+    For small n, _dimino enumeration is the source of truth. The closed
+    form should match it exactly.
+    """
+
+    @pytest.mark.parametrize("n", [2, 3, 4, 5, 6])
+    def test_symmetric_matches_dimino(self, n):
+        g = SymmetryGroup.symmetric(axes=tuple(range(n)))
+        assert g.order() == len(_dimino(g._generators)) == math.factorial(n)
+
+    @pytest.mark.parametrize("n", [2, 3, 4, 5, 6, 7, 8, 9, 10])
+    def test_cyclic_matches_dimino(self, n):
+        g = SymmetryGroup.cyclic(axes=tuple(range(n)))
+        assert g.order() == len(_dimino(g._generators)) == n
+
+    @pytest.mark.parametrize("n", [3, 4, 5, 6, 7, 8])
+    def test_dihedral_matches_dimino(self, n):
+        g = SymmetryGroup.dihedral(axes=tuple(range(n)))
+        assert g.order() == len(_dimino(g._generators)) == 2 * n
+
+    def test_direct_product_matches_dimino(self):
+        a = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        b = SymmetryGroup.cyclic(axes=(3, 4, 5, 6))
+        g = SymmetryGroup.direct_product(a, b)
+        # |S_3 × C_4| = 6 * 4 = 24
+        assert g.order() == len(_dimino(g._generators)) == 24
+
+    def test_young_matches_dimino(self):
+        g = SymmetryGroup.young(blocks=[(0, 1), (2, 3, 4)])
+        # |S_2 × S_3| = 2 * 6 = 12
+        assert g.order() == len(_dimino(g._generators)) == 12

--- a/tests/test_perm_group_closed_form_order.py
+++ b/tests/test_perm_group_closed_form_order.py
@@ -63,3 +63,85 @@ class TestOrderDispatch:
         g._order = None
         g._known_kind = None
         assert g.order() == 6  # via _dimino
+
+
+class TestFactoryTagging:
+    def test_symmetric_tag(self):
+        assert SymmetryGroup.symmetric(axes=(0, 1, 2))._known_kind == (
+            "symmetric",
+            (0, 1, 2),
+        )
+
+    def test_symmetric_degree_one_is_identity(self):
+        assert SymmetryGroup.symmetric(axes=(0,))._known_kind == ("identity", (0,))
+
+    def test_cyclic_tag(self):
+        assert SymmetryGroup.cyclic(axes=(0, 1, 2))._known_kind == (
+            "cyclic",
+            (0, 1, 2),
+        )
+
+    def test_cyclic_degree_one_is_identity(self):
+        assert SymmetryGroup.cyclic(axes=(0,))._known_kind == ("identity", (0,))
+
+    def test_dihedral_tag(self):
+        assert SymmetryGroup.dihedral(axes=(0, 1, 2, 3))._known_kind == (
+            "dihedral",
+            (0, 1, 2, 3),
+        )
+
+    def test_dihedral_degree_two_falls_through_to_symmetric(self):
+        # dihedral(k=2) falls through to symmetric (existing behavior); k>=2 → symmetric tag
+        assert SymmetryGroup.dihedral(axes=(0, 1))._known_kind == (
+            "symmetric",
+            (0, 1),
+        )
+
+    def test_direct_product_sorts_children(self):
+        a = SymmetryGroup.symmetric(axes=(3, 4))
+        b = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        g_ab = SymmetryGroup.direct_product(a, b)
+        g_ba = SymmetryGroup.direct_product(b, a)
+        expected = (
+            "direct_product",
+            (("symmetric", (0, 1, 2)), ("symmetric", (3, 4))),
+        )
+        assert g_ab._known_kind == expected
+        assert g_ba._known_kind == expected
+
+    def test_direct_product_unknown_child_poisons(self):
+        known = SymmetryGroup.symmetric(axes=(0, 1))
+        unknown = SymmetryGroup.from_generators([[1, 0]], axes=(2, 3))
+        # from_generators does not tag, so the direct product can't either
+        g = SymmetryGroup.direct_product(known, unknown)
+        assert g._known_kind is None
+
+    def test_young_tag_via_direct_product(self):
+        # young always routes through direct_product
+        y = SymmetryGroup.young(blocks=[(0, 1), (2, 3, 4)])
+        assert y._known_kind == (
+            "direct_product",
+            (("symmetric", (0, 1)), ("symmetric", (2, 3, 4))),
+        )
+
+    def test_direct_product_sorts_mixed_axis_types(self):
+        # Regression: tuple comparison fails on mixed-type axes.
+        # The sort uses key=repr so it stays total-ordered.
+        a = SymmetryGroup.symmetric(axes=("x", "y"))
+        b = SymmetryGroup.symmetric(axes=(0, 1))
+        # Should not raise.
+        g = SymmetryGroup.direct_product(a, b)
+        assert g._known_kind is not None
+        assert g._known_kind[0] == "direct_product"
+        assert len(g._known_kind[1]) == 2
+
+    def test_from_generators_no_tag(self):
+        g = SymmetryGroup.from_generators([[1, 0]], axes=(0, 1))
+        assert g._known_kind is None
+
+    def test_order_uses_closed_form_for_tagged_factories(self):
+        # Now that factories tag, order() should be O(1) — verify by checking
+        # that _elements wasn't enumerated.
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3, 4, 5, 6))
+        assert g.order() == 5040
+        assert g._elements is None  # not enumerated; _dimino not called

--- a/tests/test_perm_group_closed_form_order.py
+++ b/tests/test_perm_group_closed_form_order.py
@@ -1,0 +1,45 @@
+"""Closed-form ``SymmetryGroup.order()`` formulas pinned against ``_dimino``."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from flopscope._perm_group import _closed_form_order
+
+
+class TestClosedFormOrder:
+    def test_identity_kind(self):
+        assert _closed_form_order(("identity", (0,))) == 1
+        assert _closed_form_order(("identity", ("a", "b", "c"))) == 1
+
+    def test_symmetric_kind(self):
+        for n in range(2, 7):
+            kind = ("symmetric", tuple(range(n)))
+            assert _closed_form_order(kind) == math.factorial(n)
+
+    def test_cyclic_kind(self):
+        for n in range(2, 11):
+            assert _closed_form_order(("cyclic", tuple(range(n)))) == n
+
+    def test_dihedral_kind(self):
+        for n in range(3, 11):
+            assert _closed_form_order(("dihedral", tuple(range(n)))) == 2 * n
+
+    def test_direct_product_kind(self):
+        children = (("symmetric", (0, 1)), ("symmetric", (2, 3, 4)))
+        # |S_2| * |S_3| = 2 * 6 = 12
+        assert _closed_form_order(("direct_product", children)) == 12
+
+    def test_direct_product_recursive(self):
+        nested = (
+            ("direct_product", (("symmetric", (0, 1)), ("cyclic", (2, 3, 4)))),
+            ("symmetric", (5, 6)),
+        )
+        # (|S_2| * |C_3|) * |S_2| = (2 * 3) * 2 = 12
+        assert _closed_form_order(("direct_product", nested)) == 12
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(AssertionError):
+            _closed_form_order(("nonsense", (0, 1, 2)))

--- a/tests/test_perm_group_interning.py
+++ b/tests/test_perm_group_interning.py
@@ -1,0 +1,83 @@
+"""Pin instance interning for SymmetryGroup (issue #73)."""
+
+from __future__ import annotations
+
+import pytest
+
+from flopscope._perm_group import _GROUP_INTERN, SymmetryGroup
+
+
+@pytest.fixture(autouse=True)
+def _isolate_intern_registry():
+    # Clear before and after each test so tests don't see each other's
+    # interned instances. Process-global state is hostile to test isolation.
+    _GROUP_INTERN.clear()
+    yield
+    _GROUP_INTERN.clear()
+
+
+class TestSymmetricInterning:
+    def test_same_axes_returns_same_instance(self):
+        a = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        b = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        assert a is b
+
+    def test_different_axes_returns_different_instance(self):
+        a = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        b = SymmetryGroup.symmetric(axes=(0, 1, 3))
+        assert a is not b
+
+
+class TestCyclicDihedralIdentityInterning:
+    def test_cyclic_interns(self):
+        a = SymmetryGroup.cyclic(axes=(0, 1, 2, 3))
+        b = SymmetryGroup.cyclic(axes=(0, 1, 2, 3))
+        assert a is b
+
+    def test_dihedral_interns(self):
+        a = SymmetryGroup.dihedral(axes=(0, 1, 2, 3))
+        b = SymmetryGroup.dihedral(axes=(0, 1, 2, 3))
+        assert a is b
+
+    def test_identity_interns(self):
+        # symmetric(axes=(x,)) is tagged as identity
+        a = SymmetryGroup.symmetric(axes=(0,))
+        b = SymmetryGroup.symmetric(axes=(0,))
+        assert a is b
+
+
+class TestDirectProductInterning:
+    def test_sorted_children_intern_together(self):
+        a = SymmetryGroup.symmetric(axes=(3, 4))
+        b = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        g_ab = SymmetryGroup.direct_product(a, b)
+        g_ba = SymmetryGroup.direct_product(b, a)
+        assert g_ab is g_ba
+
+
+class TestUnknownKindDoesNotIntern:
+    def test_from_generators_does_not_intern(self):
+        a = SymmetryGroup.from_generators([[1, 0]], axes=(0, 1))
+        b = SymmetryGroup.from_generators([[1, 0]], axes=(0, 1))
+        assert a is not b
+
+    def test_from_payload_does_not_intern_with_factory(self):
+        # symmetric → payload → from_payload produces an unknown-kind copy
+        sym = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        roundtripped = SymmetryGroup.from_payload(sym.to_payload())
+        assert roundtripped == sym  # value-equal
+        assert roundtripped is not sym  # but not interned together
+
+
+class TestEdgeCaseWarts:
+    def test_young_single_block_not_interned_with_symmetric(self):
+        sym = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        young = SymmetryGroup.young(blocks=[(0, 1, 2)])
+        assert young == sym  # value-equal (both S_3)
+        assert young is not sym  # but different kind tags
+
+    def test_d3_not_interned_with_s3(self):
+        s3 = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        d3 = SymmetryGroup.dihedral(axes=(0, 1, 2))
+        assert s3 == d3  # value-equal (D_3 ≅ S_3)
+        assert s3 is not d3  # but different kind tags

--- a/tests/test_perm_group_perf.py
+++ b/tests/test_perm_group_perf.py
@@ -1,0 +1,48 @@
+"""Performance smoke tests for SymmetryGroup.order() closed-form (#71).
+
+Marked ``slow`` so CI doesn't fail on machine-speed flakes. Run locally:
+
+    uv run pytest tests/test_perm_group_perf.py -v --no-header
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from flopscope._perm_group import SymmetryGroup
+
+
+@pytest.mark.slow
+class TestOrderPerformance:
+    def test_s_20_order_under_one_millisecond(self):
+        g = SymmetryGroup.symmetric(axes=tuple(range(20)))
+        t = time.perf_counter()
+        result = g.order()
+        elapsed_ms = (time.perf_counter() - t) * 1000.0
+        # |S_20| = 2_432_902_008_176_640_000
+        assert result == 2_432_902_008_176_640_000
+        assert elapsed_ms < 1.0, f"S_20.order() took {elapsed_ms:.3f}ms (expected <1ms)"
+
+    def test_direct_product_s10_x_s10_under_one_millisecond(self):
+        a = SymmetryGroup.symmetric(axes=tuple(range(10)))
+        b = SymmetryGroup.symmetric(axes=tuple(range(10, 20)))
+        g = SymmetryGroup.direct_product(a, b)
+        t = time.perf_counter()
+        result = g.order()
+        elapsed_ms = (time.perf_counter() - t) * 1000.0
+        # |S_10| * |S_10| = 3_628_800 * 3_628_800
+        assert result == 3_628_800 * 3_628_800
+        assert elapsed_ms < 1.0, (
+            f"direct_product(S_10, S_10).order() took {elapsed_ms:.3f}ms"
+        )
+
+    def test_high_degree_cyclic_is_fast(self):
+        # C_100: degree 100, |G| = 100. Old degree-cap would reject; new |G|-cap accepts.
+        g = SymmetryGroup.cyclic(axes=tuple(range(100)))
+        t = time.perf_counter()
+        result = g.order()
+        elapsed_ms = (time.perf_counter() - t) * 1000.0
+        assert result == 100
+        assert elapsed_ms < 1.0

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -7,6 +7,7 @@ import pytest
 from flopscope._perm_group import _GROUP_INTERN, SymmetryGroup
 from flopscope._symmetry_utils import (
     embed_group,
+    intersect_groups,
     remap_group_axes,
     restrict_group_to_axes,
 )
@@ -72,3 +73,32 @@ class TestRestrictGroupToAxesProvenance:
         g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
         with pytest.raises(KeyError):
             restrict_group_to_axes(g, axes=(0, 1, 2))
+
+
+class TestIntersectGroupsProvenance:
+    def test_same_kind_intersect_returns_same_instance(self):
+        # symmetric(A) interned, so two calls give the same object.
+        a = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        b = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        assert a is b  # sanity: interning works
+        result = intersect_groups(a, b, ndim=3)
+        assert result is a
+        assert result._known_kind == ("symmetric", (0, 1, 2))
+
+    def test_identity_kind_intersect_returns_none(self):
+        # Two identity-kind groups intersect to themselves, which is trivial
+        # → existing convention is to return None for trivial intersections.
+        a = SymmetryGroup.symmetric(axes=(0,))  # tagged identity
+        b = SymmetryGroup.symmetric(axes=(0,))
+        result = intersect_groups(a, b, ndim=1)
+        assert result is None  # trivial group → None per existing convention
+
+    def test_unknown_intersection_stays_none(self):
+        # symmetric ∩ cyclic on the same axes: intersection is cyclic
+        # (cyclic ⊂ symmetric), but we don't claim that in the conservative
+        # rule. _known_kind stays None.
+        s = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        c = SymmetryGroup.cyclic(axes=(0, 1, 2))
+        result = intersect_groups(s, c, ndim=3)
+        assert result is not None
+        assert result._known_kind is None  # conservative — no inference

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -1,0 +1,48 @@
+"""Pin helper provenance preservation for SymmetryGroup (issue #73)."""
+
+from __future__ import annotations
+
+import pytest
+
+from flopscope._perm_group import _GROUP_INTERN, SymmetryGroup
+from flopscope._symmetry_utils import embed_group, remap_group_axes
+
+
+@pytest.fixture(autouse=True)
+def _isolate_intern_registry():
+    _GROUP_INTERN.clear()
+    yield
+    _GROUP_INTERN.clear()
+
+
+class TestEmbedGroupProvenance:
+    def test_embed_preserves_kind_when_axes_already_full(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        embedded = embed_group(g, ndim=3)
+        # No rank change → same instance via interning
+        assert embedded is g
+        assert embedded._known_kind == ("symmetric", (0, 1, 2))
+
+
+class TestRemapGroupAxesProvenance:
+    def test_remap_leaf_kind_symmetric(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        remapped = remap_group_axes(g, {0: 3, 1: 4, 2: 5})
+        assert remapped._known_kind == ("symmetric", (3, 4, 5))
+
+    def test_remap_leaf_kind_cyclic(self):
+        g = SymmetryGroup.cyclic(axes=(0, 1, 2))
+        remapped = remap_group_axes(g, {0: 3, 1: 4, 2: 5})
+        assert remapped._known_kind == ("cyclic", (3, 4, 5))
+
+    def test_remap_direct_product_recurses(self):
+        g = SymmetryGroup.direct_product(
+            SymmetryGroup.symmetric(axes=(0, 1)),
+            SymmetryGroup.cyclic(axes=(2, 3, 4)),
+        )
+        remapped = remap_group_axes(g, {0: 10, 1: 11, 2: 12, 3: 13, 4: 14})
+        # After sort: cyclic(12,13,14) < symmetric(10,11) lexicographically
+        assert remapped._known_kind == (
+            "direct_product",
+            (("cyclic", (12, 13, 14)), ("symmetric", (10, 11))),
+        )

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -153,9 +153,7 @@ class TestBroadcastGroupProvenance:
         # Input shape (4, 4) broadcast to (3, 3, 4, 4):
         # two newly-broadcast leading axes of size 3 → symmetric factor on (0, 1)
         g = SymmetryGroup.symmetric(axes=(0, 1))
-        result = broadcast_group(
-            g, input_shape=(4, 4), output_shape=(3, 3, 4, 4)
-        )
+        result = broadcast_group(g, input_shape=(4, 4), output_shape=(3, 3, 4, 4))
         # Inner symmetric on input axes (0,1) remaps to output axes (2,3).
         # Plus a new symmetric on the two created (3,3) axes (0,1).
         assert result is not None

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -8,6 +8,7 @@ from flopscope._perm_group import _GROUP_INTERN, SymmetryGroup
 from flopscope._symmetry_utils import (
     embed_group,
     intersect_groups,
+    reduce_group,
     remap_group_axes,
     restrict_group_to_axes,
 )
@@ -102,3 +103,37 @@ class TestIntersectGroupsProvenance:
         result = intersect_groups(s, c, ndim=3)
         assert result is not None
         assert result._known_kind is None  # conservative — no inference
+
+
+class TestReduceGroupProvenance:
+    def test_reduce_symmetric_produces_smaller_symmetric(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3, 4))
+        result = reduce_group(g, ndim=5, axis=(3, 4))
+        # |G \ R| = 3, axes (0,1,2) after reduction remap to (0,1,2)
+        assert result is not None
+        assert result._known_kind == ("symmetric", (0, 1, 2))
+
+    def test_reduce_symmetric_keepdims(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
+        # With keepdims, reduced axes stay at their positions.
+        result = reduce_group(g, ndim=4, axis=(2, 3), keepdims=True)
+        assert result is not None
+        # The 2 surviving axes keep their tensor positions (0, 1)
+        assert result._known_kind == ("symmetric", (0, 1))
+
+    def test_reduce_all_axes_returns_none(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        result = reduce_group(g, ndim=3, axis=(0, 1, 2))
+        assert result is None
+
+    def test_reduce_direct_product_recurses(self):
+        g = SymmetryGroup.direct_product(
+            SymmetryGroup.symmetric(axes=(0, 1)),
+            SymmetryGroup.cyclic(axes=(2, 3, 4)),
+        )
+        # Reduce one axis from the symmetric factor (drops it to trivial).
+        result = reduce_group(g, ndim=5, axis=(0,))
+        # Surviving: cyclic(2,3,4) only; symmetric(1) becomes trivial.
+        # After remap (axis 0 removed), cyclic axes shift to (1,2,3).
+        assert result is not None
+        assert result._known_kind == ("cyclic", (1, 2, 3))

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -72,13 +72,19 @@ class TestRestrictGroupToAxesProvenance:
         restricted = restrict_group_to_axes(g, axes=(0, 1, 2))
         assert restricted is g
 
-    def test_restrict_strict_subset_of_symmetric_raises(self):
-        # Documented behavior: restrict() requires setwise-preservation.
-        # symmetric(A) doesn't preserve any T⊊A. This is the existing
-        # behavior — provenance code must not silently swallow it.
+    def test_restrict_strict_subset_of_symmetric_returns_subsymmetric_without_kind(
+        self,
+    ):
+        # `restrict_group_to_axes` composes setwise_stabilizer + restrict, so
+        # a strict subset of a free-permuting group projects to S_|T| on T.
+        # Our provenance preservation is scoped to the no-op case (T == A);
+        # strict-subset results carry `_known_kind=None` — the "sub-symmetric
+        # is still symmetric" rule lives in `reduce_group`, not here.
         g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
-        with pytest.raises(KeyError):
-            restrict_group_to_axes(g, axes=(0, 1, 2))
+        restricted = restrict_group_to_axes(g, axes=(0, 1, 2))
+        assert restricted is not None
+        assert restricted.order() == 6  # S_3
+        assert restricted._known_kind is None
 
 
 class TestIntersectGroupsProvenance:

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -137,3 +137,29 @@ class TestReduceGroupProvenance:
         # After remap (axis 0 removed), cyclic axes shift to (1,2,3).
         assert result is not None
         assert result._known_kind == ("cyclic", (1, 2, 3))
+
+
+class TestBroadcastGroupProvenance:
+    def test_broadcast_no_op_preserves_kind(self):
+        from flopscope._symmetry_utils import broadcast_group
+
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        broadcasted = broadcast_group(g, input_shape=(4, 4, 4), output_shape=(4, 4, 4))
+        assert broadcasted is g
+
+    def test_broadcast_adds_symmetric_factor_for_new_axes(self):
+        from flopscope._symmetry_utils import broadcast_group
+
+        # Input shape (4, 4) broadcast to (3, 3, 4, 4):
+        # two newly-broadcast leading axes of size 3 → symmetric factor on (0, 1)
+        g = SymmetryGroup.symmetric(axes=(0, 1))
+        result = broadcast_group(
+            g, input_shape=(4, 4), output_shape=(3, 3, 4, 4)
+        )
+        # Inner symmetric on input axes (0,1) remaps to output axes (2,3).
+        # Plus a new symmetric on the two created (3,3) axes (0,1).
+        assert result is not None
+        assert result._known_kind == (
+            "direct_product",
+            (("symmetric", (0, 1)), ("symmetric", (2, 3))),
+        )

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -27,6 +27,7 @@ class TestEmbedGroupProvenance:
         embedded = embed_group(g, ndim=3)
         # No rank change → same instance via interning
         assert embedded is g
+        assert embedded is not None
         assert embedded._known_kind == ("symmetric", (0, 1, 2))
 
 
@@ -34,11 +35,13 @@ class TestRemapGroupAxesProvenance:
     def test_remap_leaf_kind_symmetric(self):
         g = SymmetryGroup.symmetric(axes=(0, 1, 2))
         remapped = remap_group_axes(g, {0: 3, 1: 4, 2: 5})
+        assert remapped is not None
         assert remapped._known_kind == ("symmetric", (3, 4, 5))
 
     def test_remap_leaf_kind_cyclic(self):
         g = SymmetryGroup.cyclic(axes=(0, 1, 2))
         remapped = remap_group_axes(g, {0: 3, 1: 4, 2: 5})
+        assert remapped is not None
         assert remapped._known_kind == ("cyclic", (3, 4, 5))
 
     def test_remap_direct_product_recurses(self):
@@ -47,6 +50,7 @@ class TestRemapGroupAxesProvenance:
             SymmetryGroup.cyclic(axes=(2, 3, 4)),
         )
         remapped = remap_group_axes(g, {0: 10, 1: 11, 2: 12, 3: 13, 4: 14})
+        assert remapped is not None
         # After sort: cyclic(12,13,14) < symmetric(10,11) lexicographically
         assert remapped._known_kind == (
             "direct_product",
@@ -60,6 +64,7 @@ class TestRestrictGroupToAxesProvenance:
         restricted = restrict_group_to_axes(g, axes=(0, 1, 2, 3))
         # Identity restriction → same instance via interning
         assert restricted is g
+        assert restricted is not None
         assert restricted._known_kind == ("symmetric", (0, 1, 2, 3))
 
     def test_restrict_to_full_axes_preserves_cyclic_kind(self):
@@ -84,6 +89,7 @@ class TestIntersectGroupsProvenance:
         assert a is b  # sanity: interning works
         result = intersect_groups(a, b, ndim=3)
         assert result is a
+        assert result is not None
         assert result._known_kind == ("symmetric", (0, 1, 2))
 
     def test_identity_kind_intersect_returns_none(self):

--- a/tests/test_perm_group_provenance.py
+++ b/tests/test_perm_group_provenance.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 
 from flopscope._perm_group import _GROUP_INTERN, SymmetryGroup
-from flopscope._symmetry_utils import embed_group, remap_group_axes
+from flopscope._symmetry_utils import (
+    embed_group,
+    remap_group_axes,
+    restrict_group_to_axes,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -46,3 +50,25 @@ class TestRemapGroupAxesProvenance:
             "direct_product",
             (("cyclic", (12, 13, 14)), ("symmetric", (10, 11))),
         )
+
+
+class TestRestrictGroupToAxesProvenance:
+    def test_restrict_to_full_axes_preserves_symmetric_kind(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
+        restricted = restrict_group_to_axes(g, axes=(0, 1, 2, 3))
+        # Identity restriction → same instance via interning
+        assert restricted is g
+        assert restricted._known_kind == ("symmetric", (0, 1, 2, 3))
+
+    def test_restrict_to_full_axes_preserves_cyclic_kind(self):
+        g = SymmetryGroup.cyclic(axes=(0, 1, 2))
+        restricted = restrict_group_to_axes(g, axes=(0, 1, 2))
+        assert restricted is g
+
+    def test_restrict_strict_subset_of_symmetric_raises(self):
+        # Documented behavior: restrict() requires setwise-preservation.
+        # symmetric(A) doesn't preserve any T⊊A. This is the existing
+        # behavior — provenance code must not silently swallow it.
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
+        with pytest.raises(KeyError):
+            restrict_group_to_axes(g, axes=(0, 1, 2))

--- a/tests/test_perm_group_threshold.py
+++ b/tests/test_perm_group_threshold.py
@@ -27,8 +27,20 @@ class TestIsOversizedForCostModel:
         assert _is_oversized_for_cost_model(g) is False
 
     def test_large_known_kind_group_is_oversized_above_budget(self):
-        # |S_12| = 479_001_600 > default budget 500_000
+        # |S_12| = 479_001_600 >> default budget 50_000
         g = SymmetryGroup.symmetric(axes=tuple(range(12)))
+        assert _is_oversized_for_cost_model(g) is True
+
+    def test_s_8_fits_under_default_budget(self):
+        # |S_8| = 40_320 < 50_000 → fits with margin.
+        # Confirms the shipped default accepts the S_8-class cold-cost
+        # tier deliberately (see _config.py docstring).
+        g = SymmetryGroup.symmetric(axes=tuple(range(8)))
+        assert _is_oversized_for_cost_model(g) is False
+
+    def test_s_9_exceeds_default_budget(self):
+        # |S_9| = 362_880 > 50_000 → bails to dense cost.
+        g = SymmetryGroup.symmetric(axes=tuple(range(9)))
         assert _is_oversized_for_cost_model(g) is True
 
     def test_high_degree_but_small_order_is_not_oversized(self):
@@ -41,6 +53,14 @@ class TestIsOversizedForCostModel:
         flops.configure(dimino_budget=1)
         g = SymmetryGroup.symmetric(axes=(0, 1, 2))  # |G| = 6 > 1
         assert _is_oversized_for_cost_model(g) is True
+
+
+class TestShippedDefaultBudget:
+    def test_default_dimino_budget_is_50000(self):
+        # Pinned: |S_8| = 40_320 fits with margin; |S_9| = 362_880 doesn't.
+        # See benchmarks/_perm_group_calibration.py for the empirical
+        # justification. Tune via flops.configure(dimino_budget=...).
+        assert _get_setting("dimino_budget") == 50_000
 
 
 class TestRemovedSymbols:

--- a/tests/test_perm_group_threshold.py
+++ b/tests/test_perm_group_threshold.py
@@ -65,8 +65,11 @@ class TestShippedDefaultBudget:
 
 class TestRemovedSymbols:
     def test_max_symmetry_degree_for_cost_no_longer_imports(self):
-        with pytest.raises(ImportError):
-            from flopscope._pointwise import _MAX_SYMMETRY_DEGREE_FOR_COST  # noqa: F401
+        import importlib
+
+        module = importlib.import_module("flopscope._pointwise")
+        with pytest.raises(AttributeError):
+            module._MAX_SYMMETRY_DEGREE_FOR_COST  # noqa: B018
 
 
 class TestDiminoBudgetExceededDoesNotEscape:

--- a/tests/test_perm_group_threshold.py
+++ b/tests/test_perm_group_threshold.py
@@ -95,7 +95,9 @@ class TestDiminoBudgetExceededDoesNotEscape:
                 _warnings.simplefilter("always")
                 # Must not raise _DiminoBudgetExceeded.
                 np.multiply.outer(a, np.array([1.0]))
-        cost_warnings = [w for w in caught if issubclass(w.category, CostFallbackWarning)]
+        cost_warnings = [
+            w for w in caught if issubclass(w.category, CostFallbackWarning)
+        ]
         assert len(cost_warnings) >= 1, "expected a CostFallbackWarning"
 
     def test_tensordot_does_not_raise_on_unknown_oversized_group(self):
@@ -116,5 +118,7 @@ class TestDiminoBudgetExceededDoesNotEscape:
             with _warnings.catch_warnings(record=True) as caught:
                 _warnings.simplefilter("always")
                 np.tensordot(a, b, axes=([0], [0]))
-        cost_warnings = [w for w in caught if issubclass(w.category, CostFallbackWarning)]
+        cost_warnings = [
+            w for w in caught if issubclass(w.category, CostFallbackWarning)
+        ]
         assert len(cost_warnings) >= 1, "expected a CostFallbackWarning"

--- a/tests/test_perm_group_threshold.py
+++ b/tests/test_perm_group_threshold.py
@@ -1,0 +1,49 @@
+"""Pin the dimino_budget-driven threshold migration (issue #71)."""
+
+from __future__ import annotations
+
+import pytest
+
+import flopscope as flops
+from flopscope._config import get_setting as _get_setting
+from flopscope._perm_group import SymmetryGroup
+from flopscope._pointwise import _is_oversized_for_cost_model
+
+
+@pytest.fixture(autouse=True)
+def _reset_dimino_budget():
+    # Snapshot and restore so individual tests can tweak the budget.
+    saved = _get_setting("dimino_budget")
+    yield
+    flops.configure(dimino_budget=saved)
+
+
+class TestIsOversizedForCostModel:
+    def test_none_group_is_not_oversized(self):
+        assert _is_oversized_for_cost_model(None) is False
+
+    def test_small_group_is_not_oversized(self):
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2))
+        assert _is_oversized_for_cost_model(g) is False
+
+    def test_large_known_kind_group_is_oversized_above_budget(self):
+        # |S_12| = 479_001_600 > default budget 500_000
+        g = SymmetryGroup.symmetric(axes=tuple(range(12)))
+        assert _is_oversized_for_cost_model(g) is True
+
+    def test_high_degree_but_small_order_is_not_oversized(self):
+        # C_50 has degree 50 but |G| = 50. The old degree-based cap
+        # would (wrongly) reject this; the new |G|-based cap accepts it.
+        g = SymmetryGroup.cyclic(axes=tuple(range(50)))
+        assert _is_oversized_for_cost_model(g) is False
+
+    def test_configurable_budget_can_make_small_groups_oversized(self):
+        flops.configure(dimino_budget=1)
+        g = SymmetryGroup.symmetric(axes=(0, 1, 2))  # |G| = 6 > 1
+        assert _is_oversized_for_cost_model(g) is True
+
+
+class TestRemovedSymbols:
+    def test_max_symmetry_degree_for_cost_no_longer_imports(self):
+        with pytest.raises(ImportError):
+            from flopscope._pointwise import _MAX_SYMMETRY_DEGREE_FOR_COST  # noqa: F401

--- a/tests/test_perm_group_threshold.py
+++ b/tests/test_perm_group_threshold.py
@@ -47,3 +47,54 @@ class TestRemovedSymbols:
     def test_max_symmetry_degree_for_cost_no_longer_imports(self):
         with pytest.raises(ImportError):
             from flopscope._pointwise import _MAX_SYMMETRY_DEGREE_FOR_COST  # noqa: F401
+
+
+class TestDiminoBudgetExceededDoesNotEscape:
+    """Regression test: unknown-kind oversized groups must not leak the
+    internal :class:`_DiminoBudgetExceeded` exception to user code (issue
+    found in final review of the #71/#73 branch)."""
+
+    def test_outer_does_not_raise_on_unknown_oversized_group(self):
+        import warnings as _warnings
+
+        import numpy as np
+
+        from flopscope._symmetry_utils import wrap_with_symmetry
+        from flopscope.errors import CostFallbackWarning
+
+        flops.configure(dimino_budget=5)
+        # S_4 generators — |G| = 24 > 5, will exceed budget.
+        # from_generators produces an unknown-kind group, so order()
+        # routes through _dimino.
+        g = SymmetryGroup.from_generators(
+            [[1, 2, 3, 0], [1, 0, 2, 3]], axes=tuple(range(4))
+        )
+        a = wrap_with_symmetry(np.ones((2, 2, 2, 2)), g)
+        with flops.BudgetContext(flop_budget=int(1e10)):
+            with _warnings.catch_warnings(record=True) as caught:
+                _warnings.simplefilter("always")
+                # Must not raise _DiminoBudgetExceeded.
+                np.multiply.outer(a, np.array([1.0]))
+        cost_warnings = [w for w in caught if issubclass(w.category, CostFallbackWarning)]
+        assert len(cost_warnings) >= 1, "expected a CostFallbackWarning"
+
+    def test_tensordot_does_not_raise_on_unknown_oversized_group(self):
+        import warnings as _warnings
+
+        import numpy as np
+
+        from flopscope._symmetry_utils import wrap_with_symmetry
+        from flopscope.errors import CostFallbackWarning
+
+        flops.configure(dimino_budget=5)
+        g = SymmetryGroup.from_generators(
+            [[1, 2, 3, 0], [1, 0, 2, 3]], axes=tuple(range(4))
+        )
+        a = wrap_with_symmetry(np.ones((2, 2, 2, 2)), g)
+        b = wrap_with_symmetry(np.ones((2, 2, 2, 2)), g)
+        with flops.BudgetContext(flop_budget=int(1e10)):
+            with _warnings.catch_warnings(record=True) as caught:
+                _warnings.simplefilter("always")
+                np.tensordot(a, b, axes=([0], [0]))
+        cost_warnings = [w for w in caught if issubclass(w.category, CostFallbackWarning)]
+        assert len(cost_warnings) >= 1, "expected a CostFallbackWarning"

--- a/website/content/docs/guides/symmetry.mdx
+++ b/website/content/docs/guides/symmetry.mdx
@@ -504,21 +504,22 @@ frac, integer = fnp.modf(S)   # both SymmetricTensor with the same symmetry
 `out=(o1, o2)` works (per-slot identity is preserved), and `out=(o1, None)`
 lets numpy allocate just the second slot.
 
-### Cost model is a placeholder above degree 12
+### Cost model is a placeholder above the `dimino_budget` group order
 
 Flopscope charges `dense_cost × unique_output_elements / dense_output_elements` for
 `ufunc.outer` and `tensordot` as a coarse proxy for the savings a
 symmetry-aware implementation could realise. The underlying NumPy call still
 does dense work; only the budget reflects the savings.
 
-For a `SymmetryGroup` with degree above **12**, flopscope skips this adjustment and
-charges the full dense cost — `Burnside` enumeration on `S_n` for `n > 12`
-becomes infeasible (`13! ≈ 6.2 × 10⁹`). The skip is announced via
-`CostFallbackWarning`:
+For a `SymmetryGroup` whose order `|G|` exceeds the configured `dimino_budget`
+(default **50,000** — accepts up to `|S_8| = 40,320` with a small margin),
+flopscope skips this adjustment and charges the full dense cost. Burnside
+enumeration on the group would otherwise iterate every element. The skip is
+announced via `CostFallbackWarning`:
 
 ```python
 import warnings
-deep = fnp.ones((1,) * 33)   # auto-inferred S_33 symmetry
+deep = fnp.ones((1,) * 33)   # auto-inferred S_33 symmetry; |G| = 33! ≈ 8.7 × 10³⁶
 with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("always")
     with flops.BudgetContext(flop_budget=int(1e10)):
@@ -528,11 +529,22 @@ with warnings.catch_warnings(record=True) as caught:
             pass   # ndim>64 — the warning still fires before numpy refuses
 ```
 
-This is rare in practice — common user tensors have degree ≤ 8 — but high-rank
-auto-inferred symmetries on degenerate shapes (`(1,)*N` for large `N`) trip
-the cap. The warning fires once per `(op_name, degree)` pair per process to
+This is rare in practice — common user tensors have small group orders — but
+high-rank auto-inferred symmetries on degenerate shapes (`(1,)*N` for large `N`)
+trip the cap. The warning fires once per `(op_name, |G|)` pair per process to
 avoid log flooding. Suppress with `flops.configure(symmetry_warnings=False)`,
 which shares the flag with `SymmetryLossWarning`.
+
+The gate keys on `|G|` rather than degree because `|G|` is the actual driver
+of enumeration cost. A high-degree but small-order group like
+`SymmetryGroup.cyclic(axes=tuple(range(50)))` (degree 50, `|G| = 50`) passes
+the gate easily, whereas `SymmetryGroup.symmetric(axes=tuple(range(9)))`
+(degree 9, `|G| = 362,880`) bails. For known group families
+(`symmetric`, `cyclic`, `dihedral`, `young`, `direct_product`) `order()` is
+closed-form O(1), so the check itself never enumerates. Tune the budget with
+`flops.configure(dimino_budget=...)`, or run
+`python -m benchmarks._perm_group_calibration` for a recommendation tied to
+your host machine.
 
 A proper algorithmic-cost model is a follow-up.
 


### PR DESCRIPTION
## Summary

- **Closes [#71](https://github.com/AIcrowd/flopscope/issues/71)**: `SymmetryGroup.order()` is now O(1) closed-form for known group families (`symmetric`, `cyclic`, `dihedral`, `young`, `direct_product`). A new private `_known_kind` structural fingerprint is set by each public factory and drives the dispatch in `order()` plus the interning key in #73. `S_n.order()` for `n ≤ 20` returns in <1ms (was ~70min cold for `S_12`).

- **Closes [#73](https://github.com/AIcrowd/flopscope/issues/73)**: Process-wide instance interning by `_known_kind` via a `WeakValueDictionary` — two `SymmetryGroup.symmetric(axes=A)` calls return the same Python object, so `_order` / `_elements` / `_canonical_action_cache` are shared across the equivalence class. Helper provenance preservation in `_symmetry_utils.py` (`embed_group`, `remap_group_axes`, `restrict_group_to_axes`, `intersect_groups`, `reduce_group`, `broadcast_group`) ensures the intern + closed-form benefit flows through composed operations.

- **Threshold migration**: `_MAX_SYMMETRY_DEGREE_FOR_COST = 12` is removed. `_is_oversized_for_cost_model` now consults the existing `dimino_budget` setting directly; the early gate is cheap because `order()` is O(1) closed-form for known kinds. The single `dimino_budget` knob now serves both the early gate and the late `_DiminoBudgetExceeded` raise inside `_dimino`. Default lowered from 500,000 → 50,000 (S_8-tolerant with margin; rejects S_9 and larger).

- **Calibration script** at `benchmarks/_perm_group_calibration.py` measures cold `_dimino` + Burnside time across representative groups and recommends a `dimino_budget` value tied to the host machine. Mirrors the FLOP-weights calibration pattern.

- **Doc + fix follow-ups**: symmetry guide rewritten to reflect `|G|`-based gating; `CostFallbackWarning` docstring + warning text updated; one final-review-found crash fixed (`_DiminoBudgetExceeded` escape from `_pointwise.py` call sites when unknown-kind groups exceed budget).

## Test plan

- [ ] `uv run pytest tests/test_perm_group_closed_form_order.py` — 44 tests pin closed-form formulas + factory tagging + dispatch (incl. parametrized contract against `_dimino`).
- [ ] `uv run pytest tests/test_perm_group_interning.py` — 10 tests pin interning identity + acknowledged edge-case warts (`young([single])` vs `symmetric`, `D_3` vs `S_3`).
- [ ] `uv run pytest tests/test_perm_group_provenance.py` — 14 tests pin per-helper provenance rules.
- [ ] `uv run pytest tests/test_perm_group_threshold.py` — 11 tests pin migration semantics + the crash regression + the new default.
- [ ] `uv run pytest tests/test_perm_group_perf.py -v` — slow-marked smokes: `S_20.order() < 1ms`, `direct_product(S_10, S_10).order() < 1ms`, `C_100.order() < 1ms`.
- [ ] `uv run pytest tests/` (full suite, no slow) — no regressions.
- [ ] `uv run python -m benchmarks._perm_group_calibration --budget-ms 100` — completes and prints a recommended `dimino_budget` for the host.