### PR TITLE
fix(reduction-cost): handle 0-d arrays in _normalize_axis

### DIFF
--- a/src/flopscope/_accumulation/_reduction.py
+++ b/src/flopscope/_accumulation/_reduction.py
@@ -26,7 +26,11 @@ def _normalize_axis(
     - int → singleton, with negative-index wrapping
     - tuple/list → sorted unique, with negative-index wrapping
     """
-    if axis is None:
+    if axis is None or ndim == 0:
+        # 0-d input has no reducible axes. Numpy accepts ``axis=0`` on 0-d
+        # arrays as a no-op (matching ``ufunc.reduce``'s default) and raises
+        # for any other concrete axis before this cost path is reached, so
+        # we short-circuit instead of evaluating ``axis % 0``.
         return tuple(range(ndim))
     if isinstance(axis, int):
         return (axis % ndim,)

--- a/tests/accumulation/test_reduction_helpers.py
+++ b/tests/accumulation/test_reduction_helpers.py
@@ -24,6 +24,26 @@ def test_normalize_axis_tuple_with_negatives():
     assert _normalize_axis((-1, 0), ndim=3) == (0, 2)
 
 
+def test_normalize_axis_zero_dim_array_with_none():
+    """A 0-d array has no axes; full reduction is a no-op."""
+    assert _normalize_axis(None, ndim=0) == ()
+
+
+def test_normalize_axis_zero_dim_array_with_default_axis():
+    """``ufunc.reduce`` passes ``axis=0`` by default; numpy treats this as a
+    no-op on 0-d input (and raises for axis>=1). Match that — return ``()``
+    instead of dividing by ``ndim=0``.
+    """
+    assert _normalize_axis(0, ndim=0) == ()
+
+
+def test_normalize_axis_zero_dim_array_with_tuple_axis():
+    """The tuple branch must also short-circuit on ``ndim=0`` to avoid
+    ``a % 0`` for each tuple element.
+    """
+    assert _normalize_axis((0,), ndim=0) == ()
+
+
 def test_num_output_orbits_no_symmetry_full_reduce_to_scalar():
     assert _num_output_orbits((4, 4), axes_summed=(0, 1), symmetry=None) == 1
 

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -426,6 +426,12 @@ XFAIL_PATTERNS: dict[str, str] = {
     "TestSVDHermitian::test_empty_herm_cases": NEEDS_TRIAGE,
     "TestSVDHermitian::test_generalized_herm_cases": NEEDS_TRIAGE,
     "TestSVDHermitian::test_generalized_empty_herm_cases": NEEDS_TRIAGE,
+    # numpy.linalg.pinv(a, hermitian=True) calls svd internally; svd's
+    # `transpose(u * sgn)` reaches `swapaxes` from inside an fnp wrapper and
+    # trips the __array_function__ tripwire. Same root cause as the
+    # TestSVDHermitian entries above; PR #100's triage sweep missed these.
+    "TestPinvHermitian::test_herm_cases": NEEDS_TRIAGE,
+    "TestPinvHermitian::test_generalized_herm_cases": NEEDS_TRIAGE,
     # numpy.polynomial.polyval — flopscope wrapper subclass / dispatch
     # diverges from numpy expectation. Surfaced by harness fix; out of scope.
     "TestEvaluation::test_polyval": NEEDS_TRIAGE,

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -386,11 +386,6 @@ XFAIL_PATTERNS: dict[str, str] = {
     # state-pollution bug (caching / shared mutable state in the
     # ufunc/SymmetricTensor pipeline) is fixed. Out of scope for this PR.
     "*TestUfunc::test_reduction_with_where*": NEEDS_TRIAGE,
-    # ZeroDivisionError in _normalize_axis when ndim==0 (0-d array as out=)
-    # flopscope's axis normalisation does `axis % ndim` without guarding for
-    # ndim==0; logical_and/logical_or/logical_xor hit this via ufunc.reduce
-    # on 0-d output arrays. Unrelated to issue-70.
-    "*TestUfunc::test_logical_ufuncs_support_anything*": NEEDS_TRIAGE,
     # isclose(np.inf, -np.inf) returns a FlopscopeArray, not the np.False_
     # singleton. The test uses `is np.False_` identity check which fails for
     # any array subclass. SUBCLASS_RETURN / BEHAVIORAL_SHIM pattern.


### PR DESCRIPTION
## Summary

Rebased onto main after [PR #100](https://github.com/AIcrowd/flopscope/pull/100) landed (which restored the numpy-compat harness and triaged most newly-exposed failures).

PR #100 left three of those failures — `test_logical_ufuncs_support_anything[logical_and/or/xor]` — under `NEEDS_TRIAGE`. They have a single shared root cause: a real `ZeroDivisionError` in flopscope's reduction-cost helper.

`_normalize_axis(axis, ndim=0)` evaluated `axis % ndim` on the int and tuple branches, dividing by zero. `ufunc.reduce(a, out=out)` passes `axis=0` by default; numpy accepts that as a no-op on 0-d input, flopscope crashed.

Three commits:

- **`fix(reduction-cost): handle 0-d arrays in _normalize_axis`** — short-circuit when `ndim == 0` and return `()` (no reducible axes). Out-of-bounds `axis` still raises upstream of this helper, so no validation needed here. Three regression tests in [tests/accumulation/test_reduction_helpers.py](tests/accumulation/test_reduction_helpers.py) cover the `None` / `int` / `tuple` branches for 0-d input.

- **`test(numpy-compat): un-xfail test_logical_ufuncs_support_anything`** — removes the `NEEDS_TRIAGE` entry PR #100 added for these tests, since the underlying bug is now fixed and the 3 parametrizations pass for real.

- **`test(numpy-compat): xfail TestPinvHermitian missed by PR #100 sweep`** — PR #100's triage caught the `TestSVDHermitian::test_*_herm_cases` variants but missed the two `TestPinvHermitian` siblings (`pinv(hermitian=True)` calls `svd` internally and hits the same `__array_function__` tripwire). Verified by checking out current main locally and reproducing both failures. Adding them is necessary for the pre-push gate to pass; the underlying triage stays queued.

## Test plan

- [x] `uv run pytest tests/accumulation/test_reduction_helpers.py` — 13 passed (existing + 3 new 0-d regression tests).
- [x] `uv run pytest tests/numpy_compat/ --pyargs numpy._core.tests.test_ufunc -k test_logical_ufuncs_support_anything` — 3 passed (no longer xfailed).
- [x] `uv run pytest tests/numpy_compat/ --pyargs numpy.linalg.tests.test_linalg -k "test_generalized_herm_cases or test_herm_cases"` — 4 xfailed (the two PinvHermitian + two SVDHermitian).
- [x] `make ci` clean (pre-push hook passed).