### PR TITLE
v0.3.1: PyPI READMEs for all three packages; flopscope-client re-enabled

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,13 +20,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # NOTE: flopscope-client is intentionally absent from both matrices in this
-  # release. A PyPI bug currently blocks creating a Trusted Publisher for the
-  # `flopscope-client` project (server-side 500 on the publisher-create form,
-  # despite the identical request succeeding for `flopscope-server`). The
-  # package's version is bumped + handshake code is present, so the next
-  # release that includes it just needs to add the entries back in both
-  # matrices. Track the unblock in the PyPI bug filed for this issue.
   build:
     name: Build ${{ matrix.package.name }}
     runs-on: ubuntu-latest
@@ -40,6 +33,8 @@ jobs:
             path: .
           - name: flopscope-server
             path: flopscope-server
+          - name: flopscope-client
+            path: flopscope-client
     steps:
       - uses: actions/checkout@v4
 
@@ -67,9 +62,10 @@ jobs:
         package:
           - name: flopscope
           - name: flopscope-server
+          - name: flopscope-client
     # The `pypi` environment in repo settings has Required Reviewers
-    # configured. A single approval click in this environment covers both
-    # matrix entries that share it.
+    # configured. A single approval click in this environment covers all
+    # three matrix entries that share it.
     environment:
       name: pypi
       url: https://pypi.org/project/${{ matrix.package.name }}/

--- a/README.md
+++ b/README.md
@@ -127,17 +127,16 @@ pip install flopscope-server
 ```
 
 For the lightweight client (proxies all calls to a remote
-flopscope-server over ZMQ; no numpy dependency), build from the
-`flopscope-client/` subdirectory:
+flopscope-server over ZMQ; no numpy dependency):
 
 ```bash
-pip install "flopscope-client @ git+https://github.com/AIcrowd/flopscope.git#subdirectory=flopscope-client"
+pip install flopscope-client
 ```
 
 The client occupies the same `import flopscope` namespace as the main
-package — install it *instead of* `flopscope`, not alongside. A PyPI
-release of flopscope-client is pending; see
-[CHANGELOG.md](CHANGELOG.md) for status.
+package — install it *instead of* `flopscope`, not alongside. All three
+packages are released in lockstep at the same version. See
+[CHANGELOG.md](CHANGELOG.md) for the release notes.
 
 Latest development version from git:
 

--- a/flopscope-client/README.md
+++ b/flopscope-client/README.md
@@ -1,0 +1,81 @@
+# flopscope-client
+
+[![PyPI version](https://img.shields.io/pypi/v/flopscope-client.svg)](https://pypi.org/project/flopscope-client/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+Lightweight drop-in replacement for [flopscope](https://pypi.org/project/flopscope/) that proxies all operations to a remote [`flopscope-server`](https://pypi.org/project/flopscope-server/) over ZMQ + msgpack.
+
+`flopscope-client` provides the same `import flopscope` Python module as the main `flopscope` distribution, but with **no NumPy dependency** — it forwards every counted operation to a `flopscope-server` process. Use this in constrained environments where you want flopscope's FLOP-counting API but cannot ship numpy + the full library (e.g. sandboxed participant containers in the [ARC Whitebox Estimation Challenge](https://www.alignment.org/blog/will-whitebox-runtime-monitoring-defeat-scheming-models/)).
+
+## Install instead of, not alongside
+
+`flopscope-client` occupies the same `flopscope` Python import namespace as the main package. The two are **mutually exclusive** — installing both leads to file-overlap in `flopscope/`. Choose one:
+
+```bash
+# Lightweight: client-only, no numpy
+pip install flopscope-client
+
+# Heavy: full library on the local machine
+pip install flopscope
+
+# Server-side: both flopscope + flopscope-server, pinned together
+pip install "flopscope[server]"
+```
+
+## Quick start
+
+The client connects to a `flopscope-server` instance specified by the `FLOPSCOPE_SERVER_URL` environment variable:
+
+```bash
+export FLOPSCOPE_SERVER_URL=tcp://flopscope-server.example.com:15555
+# or for a local UNIX socket:
+export FLOPSCOPE_SERVER_URL=ipc:///tmp/flopscope.sock
+```
+
+Then use flopscope normally — the import path and API are identical to the main distribution:
+
+```python
+import flopscope as flops
+import flopscope.numpy as fnp
+
+with flops.BudgetContext(flop_budget=1_000_000):
+    a = fnp.array([1.0, 2.0, 3.0])
+    b = fnp.array([4.0, 5.0, 6.0])
+    result = fnp.add(a, b)   # round-trips to the server, runs there
+    flops.budget_summary()
+```
+
+On the first request, the client performs a version handshake with the server. A version mismatch raises `ConnectionError` with both versions in the error message — keep `flopscope-server` and `flopscope-client` on the same release.
+
+## When to choose this over the main `flopscope` install
+
+| Scenario | Install |
+|----------|---------|
+| You want flopscope's API in a process that has full NumPy + scientific stack | `pip install flopscope` |
+| You're shipping a sandboxed container that must not contain numpy / scipy | `pip install flopscope-client` |
+| You're running the server side that hosts computation for many clients | `pip install flopscope-server` (brings `flopscope` along) |
+| You're deploying both sides on one machine, version-pinned | `pip install "flopscope[server]"` |
+
+## Architecture overview
+
+```
+┌─────────────────────────────┐         ZMQ + msgpack         ┌──────────────────────────────┐
+│  flopscope-client process   │ ───────────────────────────▶  │  flopscope-server process    │
+│  (sandbox; no numpy)        │                                │  (full flopscope + numpy)    │
+│  `import flopscope as flops`│ ◀───────────────────────────  │  Executes ops, tracks budget │
+└─────────────────────────────┘                                └──────────────────────────────┘
+```
+
+The client serializes each operation (op name, args, kwargs) as msgpack, sends it over the ZMQ REQ/REP socket, and decodes the response. Budget tracking, symmetry-aware FLOP counting, and operation-cost analytics all happen on the server side; the client just relays calls.
+
+## Related
+
+- [`flopscope`](https://pypi.org/project/flopscope/) — full NumPy-backed library (alternative install)
+- [`flopscope-server`](https://pypi.org/project/flopscope-server/) — the server-side runtime this client connects to
+- [Documentation](https://aicrowd.github.io/flopscope/) — full guides
+- [GitHub](https://github.com/AIcrowd/flopscope) — source, CHANGELOG, contributor guide
+
+## License
+
+[MIT](https://github.com/AIcrowd/flopscope/blob/main/LICENSE)

--- a/flopscope-client/pyproject.toml
+++ b/flopscope-client/pyproject.toml
@@ -6,7 +6,9 @@ build-backend = "hatchling.build"
 name = "flopscope-client"
 version = "0.3.0"
 description = "Lightweight flopscope client — drop-in replacement with no numpy dependency"
+readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
 dependencies = [
     "pyzmq>=26.0.0",
     "msgpack>=1.0.0",

--- a/flopscope-server/README.md
+++ b/flopscope-server/README.md
@@ -1,0 +1,79 @@
+# flopscope-server
+
+[![PyPI version](https://img.shields.io/pypi/v/flopscope-server.svg)](https://pypi.org/project/flopscope-server/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+Server-side runtime for the [flopscope](https://pypi.org/project/flopscope/) client-server architecture.
+
+`flopscope-server` runs the heavy NumPy-backed `flopscope` library on behalf of remote `flopscope-client` processes that connect over ZMQ + msgpack. Use it when you want to isolate untrusted or sandboxed code (typically participant submissions in the [ARC Whitebox Estimation Challenge](https://www.alignment.org/blog/will-whitebox-runtime-monitoring-defeat-scheming-models/)) from the actual computation environment.
+
+## When to install this
+
+You want this on the **server** side of a client-server flopscope deployment. It pulls in `flopscope`, `numpy`, `pyzmq`, and `msgpack`:
+
+```bash
+pip install flopscope-server
+```
+
+Equivalent extra on the main flopscope distribution (installs both at the same exact version):
+
+```bash
+pip install "flopscope[server]"
+```
+
+## Quick start
+
+### Launch the server
+
+```bash
+# Over a UNIX domain socket (recommended for local / single-host deployments)
+python -m flopscope_server --url ipc:///tmp/flopscope.sock
+
+# Or over TCP
+python -m flopscope_server --url tcp://127.0.0.1:15555
+```
+
+### Connect a client
+
+In a separate process (typically a sandboxed container) that has [`flopscope-client`](https://pypi.org/project/flopscope-client/) installed:
+
+```bash
+export FLOPSCOPE_SERVER_URL=ipc:///tmp/flopscope.sock
+```
+
+```python
+import flopscope as flops
+import flopscope.numpy as fnp
+
+with flops.BudgetContext(flop_budget=1_000_000):
+    a = fnp.array([1.0, 2.0, 3.0])
+    b = fnp.array([4.0, 5.0, 6.0])
+    fnp.add(a, b)
+    flops.budget_summary()
+```
+
+The client's first request performs a version handshake with the server; mismatched flopscope versions raise `ConnectionError` with both versions in the message. Keep `flopscope-server` and `flopscope-client` on the same release.
+
+## Architecture overview
+
+```
+┌─────────────────────────────┐         ZMQ + msgpack         ┌──────────────────────────────┐
+│  flopscope-client process   │ ───────────────────────────▶  │  flopscope-server process    │
+│  (sandbox; no numpy)        │                                │  (full flopscope + numpy)    │
+│  `import flopscope as flops`│ ◀───────────────────────────  │  Executes ops, tracks budget │
+└─────────────────────────────┘                                └──────────────────────────────┘
+```
+
+Every counted operation (matmul, einsum, FFT, reductions, …) is dispatched to the server, executed against the real library, and the result + remaining budget streamed back. The client never sees numpy.
+
+## Related
+
+- [`flopscope`](https://pypi.org/project/flopscope/) — the NumPy-backed library hosted by this server
+- [`flopscope-client`](https://pypi.org/project/flopscope-client/) — the lightweight proxy clients use to talk to a flopscope-server
+- [Documentation](https://aicrowd.github.io/flopscope/) — full guides including client/server architecture and Docker recipes
+- [GitHub](https://github.com/AIcrowd/flopscope) — source, CHANGELOG, contributor guide
+
+## License
+
+[MIT](https://github.com/AIcrowd/flopscope/blob/main/LICENSE)

--- a/flopscope-server/pyproject.toml
+++ b/flopscope-server/pyproject.toml
@@ -6,7 +6,9 @@ build-backend = "hatchling.build"
 name = "flopscope-server"
 version = "0.3.0"
 description = "Backend server for flopscope client-server architecture"
+readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
 dependencies = [
     "flopscope==0.3.0",
     "numpy>=2.0.0,<2.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "flopscope"
 version = "0.3.0"
 description = "NumPy-compatible math primitives with FLOP counting for the Mechanistic Estimation Challenge"
+readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [

--- a/website/content/docs/development/release.mdx
+++ b/website/content/docs/development/release.mdx
@@ -101,21 +101,13 @@ project name being published.
 1. Go to https://pypi.org/manage/account/publishing/
 2. Click "Add a new pending publisher"
 3. Fill in (repeat with each project name in turn):
-   - PyPI Project Name: `flopscope`, then `flopscope-server`
+   - PyPI Project Name: `flopscope`, then `flopscope-server`, then
+     `flopscope-client`
    - Owner: `AIcrowd`
    - Repository name: `flopscope`
    - Workflow name: `pypi-publish.yml`
    - Environment name: `pypi`
 4. Save each one.
-
-> **Note on `flopscope-client`** — as of v0.3.0 the `flopscope-client`
-> Trusted Publisher cannot be created because the publisher-create form
-> returns a server-side 500 on PyPI. The identical form succeeded for
-> `flopscope-server`. Until PyPI is fixed (or the name is overridden
-> via admin@pypi.org support), `flopscope-client` is excluded from both
-> matrices in `.github/workflows/pypi-publish.yml`. Once unblocked,
-> re-add the publisher and put `flopscope-client` back into both build
-> and publish matrices, then cut a follow-up release.
 
 **On GitHub — create the `pypi` environment with required reviewers
 (do this once; it is shared across all matrix-publish jobs):**


### PR DESCRIPTION
## Summary

Two fixes that ship together as v0.3.1:

1. **PyPI READMEs.** v0.3.0 published flopscope and flopscope-server with empty descriptions on the PyPI project pages because no `[project].readme` was configured. This patch wires it up:
   - `readme = "README.md"` added to all three pyproject.toml files
   - Dedicated `README.md` for `flopscope-server` (server-side runtime — covers what it is, when to install, quick start, architecture diagram)
   - Dedicated `README.md` for `flopscope-client` (drop-in proxy — emphasizes "install instead of, not alongside", decision-matrix table, architecture diagram)
   - `license = "MIT"` added to the server and client pyprojects (was missing — only the root had it)

2. **flopscope-client re-enabled.** The PyPI Trusted Publisher for `flopscope-client` was successfully added on a retry (originally returned 500). Reverts the v0.3.0 deferral:
   - Both `build` and `publish-pypi` matrices in `pypi-publish.yml` now include `flopscope-client`
   - `README.md` and `release.mdx` point at `pip install flopscope-client` (instead of the git-subdir fallback)
   - Removed the deferral note from `release.mdx`

After this merges + `cz bump` + tag push, v0.3.1 publishes **all three** packages with the README rendered on each PyPI page.

## Verified locally

For each of the three packages I ran `uv build` and inspected the wheel METADATA:

```
=== flopscope ===
Description-Content-Type: text/markdown
<div align="center">
<h1>flopscope</h1>
...

=== flopscope-server ===
Description-Content-Type: text/markdown
# flopscope-server
[![PyPI version](https://img.shields.io/pypi/v/flopscope-server.svg)]...

=== flopscope-client ===
Description-Content-Type: text/markdown
# flopscope-client
[![PyPI version](https://img.shields.io/pypi/v/flopscope-client.svg)]...
```

Matrix entries confirmed via `python -c "import yaml; ..."`:
```
build:   [flopscope, flopscope-server, flopscope-client]
publish: [flopscope, flopscope-server, flopscope-client]
```

## Test plan

- [x] `make check-sync-versions` → "OK: all 7 version locations at 0.3.0"
- [x] `uv build` in `.`, `flopscope-server/`, `flopscope-client/` produces wheels whose METADATA has `Description-Content-Type: text/markdown` plus the README body
- [x] `ruff check .` + `ruff format --check .` clean
- [ ] (after publish) https://pypi.org/project/flopscope/ shows the full README
- [ ] (after publish) https://pypi.org/project/flopscope-server/ shows the full README
- [ ] (after publish) https://pypi.org/project/flopscope-client/ exists and shows the full README