### PR TITLE
fix(release): patch v0.4.0 fallout — [server] extra stale, drift tests not version-agnostic

### DIFF
--- a/tests/test_check_version_sync.py
+++ b/tests/test_check_version_sync.py
@@ -1,7 +1,14 @@
-"""Tests for scripts/check_version_sync.py."""
+"""Tests for scripts/check_version_sync.py.
+
+The drift-detection tests must be version-agnostic — they discover the
+repo's current version at test time and inject a *different* version to
+simulate drift. Hardcoding the current version (e.g. "0.3.0") would
+silently break the tests every time `cz bump` ran.
+"""
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
@@ -12,6 +19,10 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "check_version_sync.py"
 
+_PYPROJECT_VERSION_RE = re.compile(
+    r'^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"', re.MULTILINE
+)
+
 
 def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
     """Run the version-sync script with cwd, return CompletedProcess."""
@@ -21,6 +32,24 @@ def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+def _current_version(repo: Path) -> str:
+    """Read the X.Y.Z currently in the repo's root pyproject.toml."""
+    text = (repo / "pyproject.toml").read_text()
+    m = _PYPROJECT_VERSION_RE.search(text)
+    assert m is not None, f"no version line found in {repo / 'pyproject.toml'}"
+    return m.group(1)
+
+
+def _other_version(version: str) -> str:
+    """Return a different X.Y.Z guaranteed to differ from `version`.
+
+    Bumps the patch digit by 99 — large enough to avoid colliding with
+    any plausible nearby release, small enough to stay parseable.
+    """
+    major, minor, patch = version.split(".")
+    return f"{major}.{minor}.{int(patch) + 99}"
 
 
 def test_real_repo_is_in_sync():
@@ -59,26 +88,36 @@ def repo_copy(tmp_path: Path) -> Path:
 
 def test_root_pyproject_drift_detected(repo_copy: Path):
     """Bumping root pyproject without bumping subpackages fails the check."""
+    current = _current_version(repo_copy)
+    other = _other_version(current)
     pp = repo_copy / "pyproject.toml"
-    pp.write_text(pp.read_text().replace('version = "0.3.0"', 'version = "0.3.1"', 1))
+    pp.write_text(
+        pp.read_text().replace(f'version = "{current}"', f'version = "{other}"', 1)
+    )
     result = _run(repo_copy)
     assert result.returncode != 0
     combined = (result.stdout + result.stderr).lower()
-    assert "0.3.1" in combined or "0.3.0" in combined
+    assert other in combined or current in combined
 
 
 def test_init_file_drift_detected(repo_copy: Path):
     """Bumping only an __init__ file fails the check."""
+    current = _current_version(repo_copy)
+    other = _other_version(current)
     init = repo_copy / "flopscope-server" / "src" / "flopscope_server" / "__init__.py"
-    init.write_text(init.read_text().replace('"0.3.0"', '"0.3.99"'))
+    init.write_text(init.read_text().replace(f'"{current}"', f'"{other}"'))
     result = _run(repo_copy)
     assert result.returncode != 0
 
 
 def test_cross_pin_drift_detected(repo_copy: Path):
     """Server's flopscope==X.Y.Z pin must match root version."""
+    current = _current_version(repo_copy)
+    other = _other_version(current)
     pp = repo_copy / "flopscope-server" / "pyproject.toml"
-    pp.write_text(pp.read_text().replace('"flopscope==0.3.0"', '"flopscope==0.3.99"'))
+    pp.write_text(
+        pp.read_text().replace(f'"flopscope=={current}"', f'"flopscope=={other}"')
+    )
     result = _run(repo_copy)
     assert result.returncode != 0
     combined = (result.stdout + result.stderr).lower()
@@ -87,7 +126,11 @@ def test_cross_pin_drift_detected(repo_copy: Path):
 
 def test_client_pyproject_drift_detected(repo_copy: Path):
     """Client's pyproject version drift is caught."""
+    current = _current_version(repo_copy)
+    other = _other_version(current)
     pp = repo_copy / "flopscope-client" / "pyproject.toml"
-    pp.write_text(pp.read_text().replace('version = "0.3.0"', 'version = "0.4.0"', 1))
+    pp.write_text(
+        pp.read_text().replace(f'version = "{current}"', f'version = "{other}"', 1)
+    )
     result = _run(repo_copy)
     assert result.returncode != 0

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "flopscope"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -539,7 +539,7 @@ dev = [
 
 [[package]]
 name = "flopscope-server"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "flopscope-server" }
 dependencies = [
     { name = "flopscope" },


### PR DESCRIPTION
## Summary

Three related fixes that surfaced after v0.4.0 shipped. All caused by hardcoded version state that wasn't tracked by the release tooling.

### 1. `flopscope[server]` extra pinned at 0.3.0 in v0.4.0 (release-blocking)

The published v0.4.0 wheel of flopscope has `Requires-Dist: flopscope-server==0.3.0; extra == "server"`. This makes `pip install "flopscope[server]==0.4.0"` **unresolvable** — pip tries to install flopscope-server 0.3.0 transitively, which itself requires flopscope==0.3.0, conflicting with the 0.4.0 root the user is installing.

Verified on PyPI:
```bash
$ curl -s "https://pypi.org/pypi/flopscope/0.4.0/json" | jq '.info.requires_dist[] | select(test("server"))'
"flopscope-server==0.3.0; extra == \"server\""
```

Root cause: the `[server]` extra's pin wasn't in commitizen's `version_files`. `cz bump` moved 7 of 8 version locations to 0.4.0 but left this one at 0.3.0.

Fix: backfill the stale pin to 0.4.0, add `pyproject.toml:flopscope-server==` to `version_files` so future bumps don't miss it. Will be republished as v0.4.1.

### 2. `check_version_sync.py` wasn't checking this location either

The script tracked 7 locations and would have caught the drift if it had tracked this 8th one. Extended it to compare the `[server]` extra pin as well; added `test_server_extra_pin_drift_detected` to guard against regression.

### 3. Drift-detection tests hardcoded `"0.3.0"` (main CI failure)

After `cz bump` rewrote files to 0.4.0, the `.replace("0.3.0", ...)` calls in the existing tests matched nothing → no drift was injected → script exited 0 → tests asserted `returncode != 0` and failed across every matrix entry on main CI.

Fix: tests now read the current version from `pyproject.toml` at test time and inject `X.Y.(Z+99)` as the drift value.

### Drive-by

`uv.lock` was left at 0.3.0 after `cz bump` (the lockfile isn't in `version_files` and the bump didn't shell out to `uv sync`). Refreshed it to 0.4.0 in the same commit so this PR's CI doesn't accidentally fail on an unrelated stale-lockfile check.

## Why these escaped earlier CI

- The `[server]` pin bug: would have shown up in `check_version_sync.py` IF that script had been tracking the location. The PR that introduced the `[server]` extra (#103) added it to the script's list of dependencies but not to the script's check, and there were no tests proving the script covered all 8 locations.
- The hardcoded `"0.3.0"` in tests: passed on PR #104's CI because the working tree was still at 0.3.0 there. The bug only surfaces after `cz bump` rewrites versions.

Both are classic "tests pass at write time, rot later" patterns. PR fixes both and adds tests that would have caught each.

## Verified locally

- `uv run python scripts/check_version_sync.py` → "OK: all 8 version locations at 0.4.0"
- `uv run pytest tests/test_check_version_sync.py -v` → 6 passed (1 happy + 5 drift cases including the new `test_server_extra_pin_drift_detected`)
- `uv run cz bump --dry-run --increment PATCH --yes` → "version 0.4.0 → 0.4.1" cleanly
- `ruff check .` + `ruff format --check .` clean

## After this merges

We'll need to cut **v0.4.1** with `cz bump` to ship the corrected `[server]` extra to PyPI. The current v0.4.0 release has the broken pin and will stay there as historical record.