### PR TITLE
release: v0.4.1 — fix broken flopscope[server] extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.4.1 (2026-05-26)
+
+Bug-fix release for the broken `flopscope[server]` extra in v0.4.0.
+
+### Fixed
+
+- The `flopscope[server]` extra now correctly pins
+  `flopscope-server==0.4.1` (matching the rest of the release). In
+  v0.4.0 the extra was stuck at `flopscope-server==0.3.0` because the
+  pin location was not tracked by commitizen's `version_files`, so
+  `pip install "flopscope[server]==0.4.0"` from PyPI was
+  **unresolvable** (it pulled flopscope-server 0.3.0, which in turn
+  requires flopscope==0.3.0, conflicting with the 0.4.0 root).
+- `pip install "flopscope[server]==0.4.1"` resolves cleanly.
+
+### Tooling
+
+- `commitizen.version_files` now includes
+  `pyproject.toml:flopscope-server==` so the `[server]` extra pin
+  follows future bumps automatically.
+- `scripts/check_version_sync.py` now compares 8 version locations
+  (added the `[server]` extra pin) and would catch this regression
+  in CI. `tests/test_check_version_sync.py` includes a corresponding
+  guard test (`test_server_extra_pin_drift_detected`).
+- Drift-detection tests in `tests/test_check_version_sync.py` are
+  now version-agnostic (they read the current X.Y.Z from
+  `pyproject.toml` at test time instead of hardcoding it). v0.4.0's
+  main CI failed after the bump because hardcoded `"0.3.0"` strings
+  no longer matched.
+
 ## v0.4.0 (2026-05-26)
 
 Follow-up to v0.3.0 that completes the multi-package PyPI release. All

--- a/flopscope-client/pyproject.toml
+++ b/flopscope-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flopscope-client"
-version = "0.4.0"
+version = "0.4.1"
 description = "Lightweight flopscope client — drop-in replacement with no numpy dependency"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -18,7 +18,7 @@ import builtins
 import struct
 from typing import Any
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # ---------------------------------------------------------------------------
 # Errors

--- a/flopscope-server/pyproject.toml
+++ b/flopscope-server/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flopscope-server"
-version = "0.4.0"
+version = "0.4.1"
 description = "Backend server for flopscope client-server architecture"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "flopscope==0.4.0",
+    "flopscope==0.4.1",
     "numpy>=2.0.0,<2.5.0",
     "pyzmq>=26.0.0",
     "msgpack>=1.0.0",

--- a/flopscope-server/src/flopscope_server/__init__.py
+++ b/flopscope-server/src/flopscope_server/__init__.py
@@ -1,3 +1,3 @@
 """Flopscope backend server — executes numpy operations on behalf of remote clients."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-server = ["flopscope-server==0.3.0"]
+server = ["flopscope-server==0.4.0"]
 dev = [
     "commitizen>=4.0",
     "gitlint>=0.19",
@@ -50,6 +50,7 @@ major_version_zero = true
 changelog_incremental = true
 version_files = [
     "src/flopscope/__init__.py:^__version__",
+    "pyproject.toml:flopscope-server==",
     "flopscope-server/pyproject.toml:^version",
     "flopscope-server/src/flopscope_server/__init__.py:^__version__",
     "flopscope-server/pyproject.toml:flopscope==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flopscope"
-version = "0.4.0"
+version = "0.4.1"
 description = "NumPy-compatible math primitives with FLOP counting for the Mechanistic Estimation Challenge"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-server = ["flopscope-server==0.4.0"]
+server = ["flopscope-server==0.4.1"]
 dev = [
     "commitizen>=4.0",
     "gitlint>=0.19",

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -4,8 +4,9 @@
 Run from the repo root:
     uv run python scripts/check_version_sync.py
 
-Exits 0 if all seven version locations agree, 1 otherwise:
+Exits 0 if all eight version locations agree, 1 otherwise:
   - pyproject.toml [project].version            (root)
+  - pyproject.toml [server] extra -> "flopscope-server==X.Y.Z"
   - src/flopscope/__init__.py __version__       (leading X.Y.Z only)
   - flopscope-server/pyproject.toml version
   - flopscope-server/src/flopscope_server/__init__.py __version__
@@ -23,6 +24,7 @@ from pathlib import Path
 
 _VERSION_RE = re.compile(r'__version__\s*=\s*f?"([0-9]+\.[0-9]+\.[0-9]+)')
 _CROSS_PIN_RE = re.compile(r'"flopscope==([0-9]+\.[0-9]+\.[0-9]+)"')
+_SERVER_EXTRA_RE = re.compile(r'"flopscope-server==([0-9]+\.[0-9]+\.[0-9]+)"')
 # Matches the `version = "X.Y.Z"` line under `[project]` in pyproject.toml.
 # Anchored at line start to skip the `requires-python = "..."` line and the
 # dependency lines below. The flopscope project keeps a single top-level
@@ -67,10 +69,25 @@ def _read_server_cross_pin(server_pyproject: Path) -> str:
     return m.group(1)
 
 
+def _read_server_extra_pin(root_pyproject: Path) -> str:
+    """Extract X.Y.Z from root's `[server]` extra `flopscope-server==X.Y.Z`."""
+    text = root_pyproject.read_text()
+    m = _SERVER_EXTRA_RE.search(text)
+    if m is None:
+        raise ValueError(
+            f"no 'flopscope-server==X.Y.Z' pin found in {root_pyproject}; "
+            "expected an exact pin in [project.optional-dependencies].server"
+        )
+    return m.group(1)
+
+
 def collect_versions(root: Path) -> dict[str, str]:
-    """Return a dict of {location label: version string} for all 7 spots."""
+    """Return a dict of {location label: version string} for all 8 spots."""
     return {
         "pyproject.toml [project].version": _read_pyproject_version(
+            root / "pyproject.toml"
+        ),
+        "pyproject.toml [server] extra flopscope-server== pin": _read_server_extra_pin(
             root / "pyproject.toml"
         ),
         "src/flopscope/__init__.py __version__": _read_init_version(
@@ -100,7 +117,7 @@ def main(argv: list[str] | None = None) -> int:
     distinct = set(versions.values())
     if len(distinct) == 1:
         v = next(iter(distinct))
-        print(f"OK: all 7 version locations at {v}")
+        print(f"OK: all 8 version locations at {v}")
         return 0
 
     print("DRIFT DETECTED: package versions are not in lockstep.", file=sys.stderr)

--- a/src/flopscope/__init__.py
+++ b/src/flopscope/__init__.py
@@ -32,7 +32,7 @@ import numpy as _np
 
 from flopscope._registry import REGISTRY_META as _REGISTRY_META
 
-__version__ = f"0.4.0+np{_np.__version__}"
+__version__ = f"0.4.1+np{_np.__version__}"
 __numpy_version__ = _np.__version__
 __numpy_pinned__ = _REGISTRY_META["numpy_version"]
 __numpy_supported__ = _REGISTRY_META.get("numpy_supported", ">=2.0.0,<2.5.0")

--- a/tests/test_check_version_sync.py
+++ b/tests/test_check_version_sync.py
@@ -134,3 +134,24 @@ def test_client_pyproject_drift_detected(repo_copy: Path):
     )
     result = _run(repo_copy)
     assert result.returncode != 0
+
+
+def test_server_extra_pin_drift_detected(repo_copy: Path):
+    """Root [server] extra's flopscope-server== pin must match server version.
+
+    This is the trap that silently broke `pip install "flopscope[server]==0.4.0"`
+    between v0.3.0 and v0.4.0: the pin in the extra wasn't tracked by commitizen
+    so it stayed at the old version after `cz bump`. v0.4.1 fixes the tracking
+    via a `pyproject.toml:flopscope-server==` entry in `version_files`; this
+    test guards against regression.
+    """
+    current = _current_version(repo_copy)
+    other = _other_version(current)
+    pp = repo_copy / "pyproject.toml"
+    pp.write_text(
+        pp.read_text().replace(
+            f'"flopscope-server=={current}"', f'"flopscope-server=={other}"'
+        )
+    )
+    result = _run(repo_copy)
+    assert result.returncode != 0

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "flopscope"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -539,7 +539,7 @@ dev = [
 
 [[package]]
 name = "flopscope-server"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "flopscope-server" }
 dependencies = [
     { name = "flopscope" },


### PR DESCRIPTION
## Summary

Patch release that fixes the broken `flopscope[server]` extra in v0.4.0. Two commits:

1. **`fix(packaging): track [server] extra pin across version bumps`** — cherry-picked from a dangling commit on PR #105's branch that wasn't included in the merge (merge happened before this commit was pushed). Backfills the stale 0.3.0 pin to 0.4.0, adds the pin to commitizen `version_files`, extends `check_version_sync.py` to compare an 8th location with a guard test.

2. **`bump: version 0.4.0 → 0.4.1`** — produced by `cz bump --increment PATCH`. Auto-updates all 8 version locations and prepends a v0.4.1 entry to CHANGELOG.md. CHANGELOG entry has been amended with the user-facing impact (broken extra in v0.4.0, fixed in v0.4.1).

## User-visible impact

Right now on PyPI:

```
$ pip install "flopscope[server]==0.4.0"
ERROR: ResolutionImpossible: flopscope-server==0.3.0 requires flopscope==0.3.0,
       but flopscope==0.4.0 is also required
```

After this release ships:

```
$ pip install "flopscope[server]==0.4.1"
Successfully installed flopscope-0.4.1 flopscope-server-0.4.1 ...
```

## Verified locally

- `uv run python scripts/check_version_sync.py` → "OK: all 8 version locations at 0.4.1"
- `uv run pytest tests/test_check_version_sync.py -v` → 6 passed (includes new `test_server_extra_pin_drift_detected` guard)
- `uv run cz bump --dry-run --increment PATCH --yes` from main + cherry-pick produced `0.4.0 → 0.4.1` cleanly

## After merge

I'll tag `v0.4.1` at the merged commit on main and push the tag. That triggers the publish workflow → you approve the gate → v0.4.1 lands on PyPI with the corrected `[server]` extra.

**Important about merging this PR:** to keep the bump commit's hash stable (so tagging is straightforward), please **"Create a merge commit" or "Rebase and merge"** rather than squash. Squash would collapse the two commits into one new commit, which is also fine — I'll just tag whatever commit ends up on main as `v0.4.1`.