### PR TITLE
fix: support default_rng() across the flopscope client/server boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.4.2 (2026-06-01)
+
+### Feat
+
+- **ci**: gate numpy compat checks
+
+### Fix
+
+- support fnp.random.default_rng() across the client/server boundary
+
 ## v0.4.1 (2026-05-26)
 
 Bug-fix release for the broken `flopscope[server]` extra in v0.4.0.

--- a/flopscope-client/pyproject.toml
+++ b/flopscope-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flopscope-client"
-version = "0.4.1"
+version = "0.4.2"
 description = "Lightweight flopscope client — drop-in replacement with no numpy dependency"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -18,7 +18,7 @@ import builtins
 import struct
 from typing import Any
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 # ---------------------------------------------------------------------------
 # Errors

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -598,6 +598,85 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
 
 
 # ---------------------------------------------------------------------------
+# RemoteGenerator
+# ---------------------------------------------------------------------------
+
+
+class RemoteGenerator:
+    """Transparent proxy for a server-side numpy ``Generator``.
+
+    ``fnp.random.default_rng(seed)`` returns one of these. Sampling methods
+    dispatch to the server, where the RNG state lives and advances — so the
+    stream is deterministic per seed and FLOP-counted server-side, exactly
+    like the in-process counted Generator.
+    """
+
+    __slots__ = ("_handle_id",)
+
+    def __init__(self, handle_id: str) -> None:
+        self._handle_id = handle_id
+
+    @property
+    def handle_id(self) -> str:
+        return self._handle_id
+
+    def __repr__(self) -> str:
+        return f"RemoteGenerator(handle_id={self._handle_id!r})"
+
+    def _call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        from flopscope._connection import get_connection
+        from flopscope._protocol import encode_request
+
+        encoded_args = [_encode_arg(self)] + [_encode_arg(a) for a in args]
+        encoded_kwargs = {k: _encode_arg(v) for k, v in kwargs.items()}
+        resp = get_connection().send_recv(
+            encode_request(
+                f"Generator.{method}", args=encoded_args, kwargs=encoded_kwargs
+            )
+        )
+        return _result_from_response(resp)
+
+    def uniform(self, *args, **kwargs):
+        return self._call("uniform", *args, **kwargs)
+
+    def standard_normal(self, *args, **kwargs):
+        return self._call("standard_normal", *args, **kwargs)
+
+    def normal(self, *args, **kwargs):
+        return self._call("normal", *args, **kwargs)
+
+    def integers(self, *args, **kwargs):
+        return self._call("integers", *args, **kwargs)
+
+    def random(self, *args, **kwargs):
+        return self._call("random", *args, **kwargs)
+
+    def standard_exponential(self, *args, **kwargs):
+        return self._call("standard_exponential", *args, **kwargs)
+
+    def exponential(self, *args, **kwargs):
+        return self._call("exponential", *args, **kwargs)
+
+    def poisson(self, *args, **kwargs):
+        return self._call("poisson", *args, **kwargs)
+
+    def binomial(self, *args, **kwargs):
+        return self._call("binomial", *args, **kwargs)
+
+    def beta(self, *args, **kwargs):
+        return self._call("beta", *args, **kwargs)
+
+    def gamma(self, *args, **kwargs):
+        return self._call("gamma", *args, **kwargs)
+
+    def choice(self, *args, **kwargs):
+        return self._call("choice", *args, **kwargs)
+
+    def permutation(self, *args, **kwargs):
+        return self._call("permutation", *args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
 # Module-level helper
 # ---------------------------------------------------------------------------
 
@@ -613,6 +692,9 @@ def _result_from_response(resp: dict) -> RemoteArray | RemoteScalar | tuple | di
     * otherwise           -> raw dict
     """
     result = resp.get("result", {})
+
+    if "gen_id" in result:
+        return RemoteGenerator(result["gen_id"])
 
     if "value" in result:
         return RemoteScalar(value=result["value"], dtype=result.get("dtype", "float64"))
@@ -682,6 +764,8 @@ def _encode_arg(arg):
         return arg._value
     if isinstance(arg, RemoteArray):
         return {"__handle__": arg.handle_id}
+    if isinstance(arg, RemoteGenerator):
+        return {"__gen__": arg.handle_id}
     from flopscope._perm_group import SymmetryGroup
 
     if isinstance(arg, SymmetryGroup):

--- a/flopscope-client/tests/test_remote_generator_integration.py
+++ b/flopscope-client/tests/test_remote_generator_integration.py
@@ -1,0 +1,95 @@
+"""Integration tests for fnp.random.default_rng() over the client/server boundary.
+
+Regression coverage for the grader failure where
+``fnp.random.default_rng(seed)`` raised
+``FlopscopeServerError: failed to serialize response: TypeError`` because the
+server could not serialize a numpy Generator (no remote-handle support).
+
+Runs a real FlopscopeServer in a subprocess (its own port so this file is
+isolation-safe) and drives the full request/response chain.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+_WORKTREE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CLIENT_SRC = os.path.join(_WORKTREE, "flopscope-client", "src")
+_SERVER_SRC = os.path.join(_WORKTREE, "flopscope-server", "src")
+_REAL_SRC = os.path.join(_WORKTREE, "src")
+_VENV_PYTHON = os.path.join(_WORKTREE, ".venv", "bin", "python")
+
+for _p in (_CLIENT_SRC,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SERVER_URL = "tcp://127.0.0.1:15557"
+
+_SERVER_SCRIPT = f"""
+import sys
+sys.path.insert(0, {_REAL_SRC!r})
+sys.path.insert(0, {_SERVER_SRC!r})
+from flopscope_server._server import FlopscopeServer
+server = FlopscopeServer(url={_SERVER_URL!r})
+print("SERVER_READY", flush=True)
+server.run()
+"""
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _start_server():
+    os.environ["FLOPSCOPE_SERVER_URL"] = _SERVER_URL
+    proc = subprocess.Popen(
+        [_VENV_PYTHON, "-c", _SERVER_SCRIPT],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    line = proc.stdout.readline()
+    assert "SERVER_READY" in line, f"Server failed to start: {line}"
+    time.sleep(0.3)
+    yield proc
+    proc.send_signal(signal.SIGTERM)
+    proc.wait(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _reset_client():
+    from flopscope._connection import reset_connection
+
+    reset_connection()
+    yield
+    reset_connection()
+
+
+def test_default_rng_uniform_returns_array():
+    """default_rng(seed).uniform(...) must work across the boundary (RED until fix)."""
+    import flopscope as we
+
+    with we.BudgetContext(flop_budget=10_000_000):
+        rng = we.random.default_rng(0)
+        out = rng.uniform(0.0, 1.0, size=(2, 3))
+        assert out.shape == (2, 3)
+        vals = out.tolist()
+        assert all(0.0 <= v <= 1.0 for row in vals for v in row)
+
+
+def test_default_rng_reproducible():
+    """Same seed must yield an identical stream (server-side determinism).
+
+    The bit-for-bit match against numpy's own default_rng is asserted in the
+    server-side suite, where numpy is importable (the client is numpy-free).
+    """
+    import flopscope as we
+
+    with we.BudgetContext(flop_budget=10_000_000):
+        a = we.random.default_rng(7).standard_normal(size=(5,)).tolist()
+        b = we.random.default_rng(7).standard_normal(size=(5,)).tolist()
+    assert a == b
+    assert any(x != 0.0 for x in a)

--- a/flopscope-server/pyproject.toml
+++ b/flopscope-server/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flopscope-server"
-version = "0.4.1"
+version = "0.4.2"
 description = "Backend server for flopscope client-server architecture"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "flopscope==0.4.1",
+    "flopscope==0.4.2",
     "numpy>=2.0.0,<2.5.0",
     "pyzmq>=26.0.0",
     "msgpack>=1.0.0",

--- a/flopscope-server/src/flopscope_server/__init__.py
+++ b/flopscope-server/src/flopscope_server/__init__.py
@@ -1,3 +1,3 @@
 """Flopscope backend server — executes numpy operations on behalf of remote clients."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/flopscope-server/src/flopscope_server/_protocol.py
+++ b/flopscope-server/src/flopscope_server/_protocol.py
@@ -130,6 +130,10 @@ def validate_request(msg: dict) -> None:
         If the op name is not in :data:`WHITELIST`.
     """
     op = msg.get("op", "")
+    # Generator.<method> ops are dispatched to a server-side RNG handle and are
+    # method-whitelisted in the request handler (_ALLOWED_GEN_METHODS).
+    if op.startswith("Generator."):
+        return
     if op not in WHITELIST:
         raise InvalidRequestError(f"unknown op: {op!r}")
 

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -14,6 +14,27 @@ from flopscope_server._session import Session
 
 _HANDLE_RE = re.compile(r"^a\d+$")
 
+# Generator methods the server will dispatch to a server-side numpy Generator
+# resolved from a ``{"__gen__": handle}`` argument. Array-returning samplers
+# only (``shuffle`` mutates in place and is intentionally excluded).
+_ALLOWED_GEN_METHODS = frozenset(
+    {
+        "uniform",
+        "standard_normal",
+        "normal",
+        "integers",
+        "random",
+        "standard_exponential",
+        "exponential",
+        "poisson",
+        "binomial",
+        "beta",
+        "gamma",
+        "choice",
+        "permutation",
+    }
+)
+
 
 def _make_serializable(obj):
     """Convert a nested structure to be msgpack-safe (no numpy types)."""
@@ -221,6 +242,24 @@ class RequestHandler:
             result = arr.astype(dtype)
             return self._pack_result(result)
 
+        # Generator method calls: op is "Generator.<method>" with the remote
+        # generator handle as the first arg. Resolve it and call the method
+        # server-side, so the RNG state lives + advances on the server (the
+        # stream stays deterministic per seed and FLOP-counted).
+        if op.startswith("Generator."):
+            method = op[len("Generator.") :]
+            if method not in _ALLOWED_GEN_METHODS:
+                return {
+                    "status": "error",
+                    "error_type": "UnsupportedFunctionError",
+                    "message": f"Generator.{method} is not supported by the flopscope server",
+                }
+            gen = self._resolve_arg(raw_args[0])
+            rest = [self._resolve_arg(a) for a in raw_args[1:]]
+            resolved_kwargs = {k: self._resolve_arg(v) for k, v in kwargs.items()}
+            result = getattr(gen, method)(*rest, **resolved_kwargs)
+            return self._pack_result(result)
+
         func = _get_flopscope_func(op)
         resolved_args = [self._resolve_arg(a) for a in raw_args]
         resolved_kwargs = {k: self._resolve_arg(v) for k, v in kwargs.items()}
@@ -247,6 +286,13 @@ class RequestHandler:
                 if isinstance(handle, bytes):
                     handle = handle.decode("utf-8")
                 return self._session.get_array(handle)
+            gen_handle = arg.get("__gen__")
+            if gen_handle is None:
+                gen_handle = arg.get(b"__gen__")
+            if gen_handle is not None:
+                if isinstance(gen_handle, bytes):
+                    gen_handle = gen_handle.decode("utf-8")
+                return self._session.get_generator(gen_handle)
             # SymmetryGroup wire format
             pg_data = arg.get("__symmetry_group__") or arg.get(b"__symmetry_group__")
             if pg_data is not None:
@@ -370,6 +416,10 @@ class RequestHandler:
                 "result": {"value": str(result), "dtype": "str"},
                 "budget": budget,
             }
+        if isinstance(result, np.random.Generator):
+            handle = self._session.store_generator(result)
+            return {"status": "ok", "result": {"gen_id": handle}, "budget": budget}
+
         # Fallback: try to make it serializable
         try:
             serializable = _make_serializable(result)

--- a/flopscope-server/src/flopscope_server/_session.py
+++ b/flopscope-server/src/flopscope_server/_session.py
@@ -24,6 +24,8 @@ class Session:
 
     def __init__(self, flop_budget: int, flop_multiplier: float = 1.0) -> None:
         self._store = ArrayStore()
+        self._generators: dict[str, Any] = {}
+        self._gen_counter: int = 0
         self._comms_tracker = CommsTracker()
         self._budget_ctx = flops.BudgetContext(
             flop_budget=flop_budget,
@@ -110,6 +112,29 @@ class Session:
         self._store.free(handles)
 
     # ------------------------------------------------------------------
+    # Generator operations (server-side RNG handles)
+    # ------------------------------------------------------------------
+
+    def store_generator(self, gen: Any) -> str:
+        """Store an RNG ``Generator`` and return its handle ID (``g0``, ``g1`` …)."""
+        handle = f"g{self._gen_counter}"
+        self._generators[handle] = gen
+        self._gen_counter += 1
+        return handle
+
+    def get_generator(self, handle: str) -> Any:
+        """Return the ``Generator`` for *handle*.
+
+        Raises
+        ------
+        KeyError
+            If *handle* is not a known generator handle.
+        """
+        if handle not in self._generators:
+            raise KeyError(f"Generator handle {handle!r} not found in store")
+        return self._generators[handle]
+
+    # ------------------------------------------------------------------
     # Budget
     # ------------------------------------------------------------------
 
@@ -162,6 +187,7 @@ class Session:
         budget_summary = self._budget_ctx.summary(by_namespace=show_namespaces)
         comms_summary = self._comms_tracker.summary()
         self._store.clear()
+        self._generators.clear()
         self._is_open = False
 
         return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flopscope"
-version = "0.4.1"
+version = "0.4.2"
 description = "NumPy-compatible math primitives with FLOP counting for the Mechanistic Estimation Challenge"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-server = ["flopscope-server==0.4.1"]
+server = ["flopscope-server==0.4.2"]
 dev = [
     "commitizen>=4.0",
     "gitlint>=0.19",

--- a/src/flopscope/__init__.py
+++ b/src/flopscope/__init__.py
@@ -32,7 +32,7 @@ import numpy as _np
 
 from flopscope._registry import REGISTRY_META as _REGISTRY_META
 
-__version__ = f"0.4.1+np{_np.__version__}"
+__version__ = f"0.4.2+np{_np.__version__}"
 __numpy_version__ = _np.__version__
 __numpy_pinned__ = _REGISTRY_META["numpy_version"]
 __numpy_supported__ = _REGISTRY_META.get("numpy_supported", ">=2.0.0,<2.5.0")

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "flopscope"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -539,7 +539,7 @@ dev = [
 
 [[package]]
 name = "flopscope-server"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "flopscope-server" }
 dependencies = [
     { name = "flopscope" },


### PR DESCRIPTION
## Summary
`fnp.random.default_rng(seed)` returned a numpy `Generator` the server could not serialize (`failed to serialize response: TypeError`), so every estimator using the documented seeding scaffold (`self._setup_rng = fnp.random.default_rng(...)`) failed grading with `SETUP_FAILED` — surfacing to participants as a generic "Evaluation error".

Adds a `RemoteGenerator` handle mirroring `RemoteArray`:
- **server**: `Session.store_generator/get_generator`; `_pack_result` returns `{"gen_id": handle}` for a `np.random.Generator`; `Generator.<method>` ops dispatch to the stored generator (method-allowlisted via `_ALLOWED_GEN_METHODS`); `_resolve_arg` learns `{"__gen__": h}`; `validate_request` lets `Generator.*` through.
- **client**: `RemoteGenerator` proxy (`uniform`, `standard_normal`, `integers`, `normal`, `random`, …) dispatching `Generator.<method>` back; `_result_from_response` / `_encode_arg` wired.
- Sampling runs + advances **server-side** → deterministic per seed, **bit-identical to numpy**, FLOP-counted.

Bumps `0.4.1 → 0.4.2` (patch) across all `version_files` — stays within the evaluator's `flopscope-client>=0.4.1,<0.5` pin.

## Test plan
- [x] New `flopscope-client/tests/test_remote_generator_integration.py`: `default_rng().uniform(...)` over the boundary + reproducibility
- [x] Determinism: `standard_normal`/`uniform` bit-identical to `numpy.random.default_rng`
- [x] `scripts/check_version_sync.py` → all 8 locations 0.4.2
- [x] `test_full_integration.py` (34 passed) + root suite (0 failed)
- [ ] Reviewer: confirm `_ALLOWED_GEN_METHODS` covers the RNG surface participants need

Found while E2E-testing the starter-kit examples via `whest submit` (failed submission 309632). Does not tag/publish — release is gated.