### PR TITLE
refactor(budget)!: rename BudgetContext timing props to _s suffix

### DIFF
--- a/flopscope-client/src/flopscope/_budget.py
+++ b/flopscope-client/src/flopscope/_budget.py
@@ -188,18 +188,18 @@ class BudgetContext:
         return self._wall_time_s
 
     @property
-    def flopscope_backend_time(self) -> float:
+    def flopscope_backend_time_s(self) -> float:
         """Seconds of real op compute on the server (0.0 until closed)."""
         return self._flopscope_backend_time
 
     @property
-    def flopscope_overhead_time(self) -> float:
+    def flopscope_overhead_time_s(self) -> float:
         """Seconds of flopscope transport overhead — serialization + network +
         server-side comms (0.0 until closed). Not billed."""
         return self._flopscope_overhead_time
 
     @property
-    def residual_wall_time(self) -> float | None:
+    def residual_wall_time_s(self) -> float | None:
         """Seconds of participant Python outside flopscope calls (None until
         closed). The billed bucket: C_m = F_m + lambda * residual."""
         return self._residual_wall_time
@@ -363,16 +363,16 @@ class BudgetAccumulator:
 
     def record(self, ctx):
         # `or 0.0` coerces the Optional timing fields (wall_time_s /
-        # residual_wall_time are None on a never-closed context) to 0.0.
+        # residual_wall_time_s are None on a never-closed context) to 0.0.
         self._records.append(
             NamespaceRecord(
                 namespace=ctx.namespace,
                 flop_budget=ctx.flop_budget,
                 flops_used=ctx.flops_used,
                 wall_time_s=getattr(ctx, "wall_time_s", 0.0) or 0.0,
-                backend_time_s=getattr(ctx, "flopscope_backend_time", 0.0) or 0.0,
-                overhead_time_s=getattr(ctx, "flopscope_overhead_time", 0.0) or 0.0,
-                residual_time_s=getattr(ctx, "residual_wall_time", 0.0) or 0.0,
+                backend_time_s=getattr(ctx, "flopscope_backend_time_s", 0.0) or 0.0,
+                overhead_time_s=getattr(ctx, "flopscope_overhead_time_s", 0.0) or 0.0,
+                residual_time_s=getattr(ctx, "residual_wall_time_s", 0.0) or 0.0,
             )
         )
 

--- a/flopscope-client/tests/test_budget.py
+++ b/flopscope-client/tests/test_budget.py
@@ -397,16 +397,16 @@ class TestBudgetContextTimingProperties:
 
         ctx = BudgetContext(flop_budget=1000)  # not entered
         assert ctx.wall_time_s is None
-        assert ctx.flopscope_backend_time == 0.0
-        assert ctx.flopscope_overhead_time == 0.0
-        assert ctx.residual_wall_time is None
+        assert ctx.flopscope_backend_time_s == 0.0
+        assert ctx.flopscope_overhead_time_s == 0.0
+        assert ctx.residual_wall_time_s is None
 
     def test_evaluator_getattr_contract(self):
         from flopscope._budget import BudgetContext
 
         ctx = BudgetContext(flop_budget=1000)
         # exactly how whestbench-evaluator/_child_entry.py reads them
-        assert float(getattr(ctx, "flopscope_backend_time", 0.0)) == 0.0
-        assert float(getattr(ctx, "flopscope_overhead_time", 0.0)) == 0.0
+        assert float(getattr(ctx, "flopscope_backend_time_s", 0.0)) == 0.0
+        assert float(getattr(ctx, "flopscope_overhead_time_s", 0.0)) == 0.0
         assert getattr(ctx, "wall_time_s", None) is None
-        assert getattr(ctx, "residual_wall_time", None) is None
+        assert getattr(ctx, "residual_wall_time_s", None) is None

--- a/flopscope-client/tests/test_budget_timing_integration.py
+++ b/flopscope-client/tests/test_budget_timing_integration.py
@@ -4,8 +4,8 @@ Option-3: backend = pure server numpy kernel; overhead = all flopscope machinery
 (client dispatch + wire + server marshaling, including .tolist() and implicit
 fetches such as repr/bool); residual = participant's own Python only.
 
-The production bug: the client proxy reported flopscope_backend_time /
-flopscope_overhead_time / residual_wall_time as 0 for every MLP. These tests run
+The production bug: the client proxy reported flopscope_backend_time_s /
+flopscope_overhead_time_s / residual_wall_time_s as 0 for every MLP. These tests run
 a real FlopscopeServer in a subprocess and assert the split is non-zero,
 decomposes wall, and correctly isolates participant Python in residual.
 """
@@ -78,13 +78,13 @@ def test_timing_nonzero_and_identity():
             a = fl.dot(a, a)
 
     assert ctx.wall_time_s > 0
-    assert ctx.flopscope_backend_time > 0  # pure kernel
-    assert ctx.flopscope_overhead_time > 0  # dispatch + wire
-    assert ctx.residual_wall_time >= 0
+    assert ctx.flopscope_backend_time_s > 0  # pure kernel
+    assert ctx.flopscope_overhead_time_s > 0  # dispatch + wire
+    assert ctx.residual_wall_time_s >= 0
     total = (
-        ctx.flopscope_backend_time
-        + ctx.flopscope_overhead_time
-        + ctx.residual_wall_time
+        ctx.flopscope_backend_time_s
+        + ctx.flopscope_overhead_time_s
+        + ctx.residual_wall_time_s
     )
     assert abs(ctx.wall_time_s - total) < 0.05
 
@@ -98,8 +98,8 @@ def test_tolist_is_overhead_not_residual():
         for _ in range(10):
             _ = a.tolist()
 
-    assert ctx.residual_wall_time < 0.01  # reconstruction is overhead now
-    assert ctx.flopscope_overhead_time > ctx.residual_wall_time
+    assert ctx.residual_wall_time_s < 0.01  # reconstruction is overhead now
+    assert ctx.flopscope_overhead_time_s > ctx.residual_wall_time_s
 
 
 def test_implicit_fetch_is_overhead():
@@ -110,8 +110,8 @@ def test_implicit_fetch_is_overhead():
         for _ in range(5):
             _ = repr(a)
 
-    assert ctx.residual_wall_time < 0.01
-    assert ctx.flopscope_overhead_time > ctx.residual_wall_time
+    assert ctx.residual_wall_time_s < 0.01
+    assert ctx.flopscope_overhead_time_s > ctx.residual_wall_time_s
 
 
 def test_residual_is_only_python():
@@ -123,10 +123,10 @@ def test_residual_is_only_python():
         time.sleep(0.2)  # the only non-flopscope wall
         _ = fl.dot(a, a)
 
-    assert ctx.residual_wall_time >= 0.15
-    assert ctx.flopscope_backend_time < 0.15
-    assert ctx.flopscope_overhead_time < 0.15
-    assert ctx.flopscope_overhead_time > 0
+    assert ctx.residual_wall_time_s >= 0.15
+    assert ctx.flopscope_backend_time_s < 0.15
+    assert ctx.flopscope_overhead_time_s < 0.15
+    assert ctx.flopscope_overhead_time_s > 0
 
 
 def test_worker_tolist_not_billed():
@@ -139,7 +139,7 @@ def test_worker_tolist_not_billed():
             preds = fl.dot(preds, preds)
         _ = preds.tolist()  # harness serialization of participant output
 
-    assert ctx.residual_wall_time < 0.05
+    assert ctx.residual_wall_time_s < 0.05
 
 
 def test_flops_cost_query_round_trip_is_overhead_not_residual():
@@ -167,9 +167,9 @@ def test_flops_cost_query_round_trip_is_overhead_not_residual():
 
     # No participant compute ran inside the context, so residual must stay tiny;
     # the 60 cost-query round-trips are all overhead.
-    assert ctx.flopscope_overhead_time > 0
-    assert ctx.residual_wall_time < 0.01
-    assert ctx.flopscope_overhead_time > ctx.residual_wall_time
+    assert ctx.flopscope_overhead_time_s > 0
+    assert ctx.residual_wall_time_s < 0.01
+    assert ctx.flopscope_overhead_time_s > ctx.residual_wall_time_s
 
 
 def test_backend_scales_with_compute():
@@ -183,7 +183,7 @@ def test_backend_scales_with_compute():
         for _ in range(5):
             b = fl.dot(b, b)
 
-    assert big.flopscope_backend_time > small.flopscope_backend_time
+    assert big.flopscope_backend_time_s > small.flopscope_backend_time_s
 
 
 def test_getattr_end_to_end():
@@ -194,7 +194,7 @@ def test_getattr_end_to_end():
         _ = fl.dot(a, a)
 
     # exactly how whestbench-evaluator reads them
-    assert float(getattr(ctx, "flopscope_backend_time", 0.0)) > 0
+    assert float(getattr(ctx, "flopscope_backend_time_s", 0.0)) > 0
     assert float(getattr(ctx, "wall_time_s", 0.0) or 0.0) > 0
 
 
@@ -243,13 +243,13 @@ def test_empty_context_identity():
         pass
 
     assert ctx.wall_time_s is not None and ctx.wall_time_s > 0
-    assert ctx.flopscope_backend_time >= 0
-    assert ctx.flopscope_overhead_time >= 0  # budget_open/close round-trips
-    assert ctx.residual_wall_time >= 0
+    assert ctx.flopscope_backend_time_s >= 0
+    assert ctx.flopscope_overhead_time_s >= 0  # budget_open/close round-trips
+    assert ctx.residual_wall_time_s >= 0
     total = (
-        ctx.flopscope_backend_time
-        + ctx.flopscope_overhead_time
-        + ctx.residual_wall_time
+        ctx.flopscope_backend_time_s
+        + ctx.flopscope_overhead_time_s
+        + ctx.residual_wall_time_s
     )
     assert abs(ctx.wall_time_s - total) < 0.05
 

--- a/flopscope-client/tests/test_display.py
+++ b/flopscope-client/tests/test_display.py
@@ -28,9 +28,9 @@ class _FakeCtx:
         self.flop_budget = flop_budget
         self.flops_used = flops_used
         self.wall_time_s = wall_time_s
-        self.flopscope_backend_time = backend
-        self.flopscope_overhead_time = overhead
-        self.residual_wall_time = residual
+        self.flopscope_backend_time_s = backend
+        self.flopscope_overhead_time_s = overhead
+        self.residual_wall_time_s = residual
 
 
 def test_accumulator_aggregates_timing():
@@ -52,7 +52,7 @@ def test_accumulator_aggregates_timing():
 
 
 def test_accumulator_coerces_none_timing():
-    """wall_time_s / residual_wall_time can be None on a never-closed context."""
+    """wall_time_s / residual_wall_time_s can be None on a never-closed context."""
     from flopscope._budget import BudgetAccumulator
 
     acc = BudgetAccumulator()

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -153,7 +153,7 @@ def _call_numpy(fn: Any, *args: Any, **kwargs: Any) -> Any:
 
 def _counted_wrapper(fn):
     """Decorator that brackets a flopscope wrapper and bills its non-numpy,
-    non-nested-overhead time to flopscope_overhead_time.
+    non-nested-overhead time to flopscope_overhead_time_s.
 
     Formula: wall - backend_delta - overhead_delta. Handles nesting naturally
     (outer attributes only its own remainder), so no re-entrancy guard.
@@ -429,7 +429,7 @@ class BudgetContext:
     ):
         # Capture creation time as the very first thing so any work done in
         # __init__ (validation, list/dict allocation) is included in the
-        # eventual wall_time_s span, billed to flopscope_overhead_time. See
+        # eventual wall_time_s span, billed to flopscope_overhead_time_s. See
         # issue #82.
         self._creation_time = time.perf_counter()
         if flop_budget <= 0:
@@ -498,12 +498,12 @@ class BudgetContext:
         accumulator-record and active-budget restoration work). ``None`` until
         ``__exit__`` has run.
 
-        The decomposition ``wall_time_s == flopscope_backend_time
-        + flopscope_overhead_time + residual_wall_time`` holds within numerical
+        The decomposition ``wall_time_s == flopscope_backend_time_s
+        + flopscope_overhead_time_s + residual_wall_time_s`` holds within numerical
         tolerance. The pre-``__enter__`` slice (``__init__`` body + banner print)
         and the post-``__exit__`` body slice (accumulator-record,
         active-budget restore) are both attributed to
-        ``flopscope_overhead_time``.
+        ``flopscope_overhead_time_s``.
         """
         return self._wall_time_s
 
@@ -514,11 +514,11 @@ class BudgetContext:
         return time.perf_counter() - self._start_time
 
     @property
-    def flopscope_backend_time(self) -> float:
+    def flopscope_backend_time_s(self) -> float:
         return self._total_flopscope_backend_time
 
     @property
-    def flopscope_overhead_time(self) -> float:
+    def flopscope_overhead_time_s(self) -> float:
         """Wall-clock seconds spent inside flopscope's own dispatch code.
 
         Includes wrapper preambles, BudgetContext.deduct() body, _OpTimer
@@ -532,7 +532,7 @@ class BudgetContext:
         return self._total_flopscope_overhead_time
 
     @property
-    def residual_wall_time(self) -> float | None:
+    def residual_wall_time_s(self) -> float | None:
         """Wall time minus flopscope backend and overhead time.
 
         This is the measured wall-clock remainder outside the backend calls and
@@ -626,7 +626,7 @@ class BudgetContext:
         wall_time = self._wall_time_s
         if wall_time is None and self._start_time is not None:
             wall_time = self.elapsed_s
-        wall_time, backend_time, overhead_time, residual_wall_time = _timing_summary(
+        wall_time, backend_time, overhead_time, residual_wall_time_s = _timing_summary(
             wall_time,
             self._total_flopscope_backend_time,
             self._total_flopscope_overhead_time,
@@ -640,7 +640,7 @@ class BudgetContext:
             "wall_time_s": wall_time,
             "flopscope_backend_time_s": backend_time,
             "flopscope_overhead_time_s": overhead_time,
-            "residual_wall_time_s": residual_wall_time,
+            "residual_wall_time_s": residual_wall_time_s,
         }
         if by_namespace:
             result["by_namespace"] = _summarize_by_namespace(self._op_log)
@@ -736,7 +736,7 @@ class BudgetContext:
             print(banner, file=sys.stderr)
         # Mark wall start AFTER all enter setup (including the banner print).
         # The slice from _creation_time → _start_time is pre-enter overhead;
-        # __exit__ adds it to flopscope_overhead_time. See issue #82.
+        # __exit__ adds it to flopscope_overhead_time_s. See issue #82.
         self._start_time = time.perf_counter()
         self._pre_enter_overhead = self._start_time - self._creation_time
         if self._wall_time_limit_s is not None:
@@ -747,7 +747,7 @@ class BudgetContext:
         # body_end snapshots the user-code window (start_time → here). Then
         # we do the post-exit accumulator work and snapshot post_exit_end.
         # wall_time_s spans creation → post_exit_end, and the pre-enter +
-        # post-exit slices are billed to flopscope_overhead_time. See #82.
+        # post-exit slices are billed to flopscope_overhead_time_s. See #82.
         body_end = time.perf_counter()
         if self._start_time is not None:
             _accumulator.record(self)
@@ -916,7 +916,7 @@ class BudgetAccumulator:
                     total_overhead or 0.0
                 ) + rec.total_flopscope_overhead_time
 
-        wall_time, backend_time, overhead_time, residual_wall_time = _timing_summary(
+        wall_time, backend_time, overhead_time, residual_wall_time_s = _timing_summary(
             total_wall_time, total_backend, total_overhead
         )
 
@@ -928,7 +928,7 @@ class BudgetAccumulator:
             "wall_time_s": wall_time,
             "flopscope_backend_time_s": backend_time,
             "flopscope_overhead_time_s": overhead_time,
-            "residual_wall_time_s": residual_wall_time,
+            "residual_wall_time_s": residual_wall_time_s,
         }
 
         if by_namespace:

--- a/src/flopscope/_config.py
+++ b/src/flopscope/_config.py
@@ -37,7 +37,7 @@ def configure(**kwargs: object) -> None:
         If ``True``, scan every counted op's output for NaN/Inf values and
         emit a :class:`~flopscope.errors.FlopscopeWarning` if any are found.
         The scan is two full O(n) sweeps over the result and is attributed
-        to ``flopscope_overhead_time``, so it is off by default for
+        to ``flopscope_overhead_time_s``, so it is off by default for
         production scoring.  Opt in when debugging an estimator that
         produces NaN/Inf to identify the introducing op.  Default ``False``.
     dimino_budget : int

--- a/src/flopscope/_display.py
+++ b/src/flopscope/_display.py
@@ -84,14 +84,14 @@ def _format_budget_summary_text(
     wall_time = data.get("wall_time_s")
     backend_time = data.get("flopscope_backend_time_s", 0.0)
     overhead_time = data.get("flopscope_overhead_time_s", 0.0)
-    residual_wall_time = data.get("residual_wall_time_s")
-    if wall_time is not None and residual_wall_time is not None:
+    residual_wall_time_s = data.get("residual_wall_time_s")
+    if wall_time is not None and residual_wall_time_s is not None:
         lines += [
             "",
             f"  Total Wall Time:     {wall_time:.3f}s",
             f"  Flopscope Backend:   {backend_time:.3f}s  ({_pct(backend_time, wall_time)})",
             f"  Flopscope Overhead:  {overhead_time:.3f}s  ({_pct(overhead_time, wall_time)})",
-            f"  Residual Wall Time:  {residual_wall_time:.3f}s  ({_pct(residual_wall_time, wall_time)})",
+            f"  Residual Wall Time:  {residual_wall_time_s:.3f}s  ({_pct(residual_wall_time_s, wall_time)})",
         ]
 
     op_backend_times = {
@@ -247,8 +247,8 @@ def _rich_totals_table(data: dict):
     wall_time = data.get("wall_time_s")
     backend_time = data.get("flopscope_backend_time_s", 0.0)
     overhead_time = data.get("flopscope_overhead_time_s", 0.0)
-    residual_wall_time = data.get("residual_wall_time_s")
-    if wall_time is not None and residual_wall_time is not None:
+    residual_wall_time_s = data.get("residual_wall_time_s")
+    if wall_time is not None and residual_wall_time_s is not None:
         table.add_section()
         table.add_row("Total Wall Time", f"{wall_time:.3f}s")
         table.add_row(
@@ -268,7 +268,7 @@ def _rich_totals_table(data: dict):
         table.add_row(
             "Residual Wall Time",
             Text(
-                f"{residual_wall_time:.3f}s  ({_pct(residual_wall_time, wall_time)})",
+                f"{residual_wall_time_s:.3f}s  ({_pct(residual_wall_time_s, wall_time)})",
                 style="dim",
             ),
         )

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -173,8 +173,8 @@ def test_budget_context_flopscope_backend_time():
         _ = flopscope.numpy.add(
             flopscope.numpy.ones((1000,)), flopscope.numpy.ones((1000,))
         )
-    assert b.flopscope_backend_time >= 0
-    assert b.flopscope_backend_time <= b.wall_time_s  # pyright: ignore[reportOperatorIssue]
+    assert b.flopscope_backend_time_s >= 0
+    assert b.flopscope_backend_time_s <= b.wall_time_s  # pyright: ignore[reportOperatorIssue]
 
 
 def test_budget_context_residual_wall_time():
@@ -185,8 +185,8 @@ def test_budget_context_residual_wall_time():
             flopscope.numpy.ones((1000,)), flopscope.numpy.ones((1000,))
         )
         _time.sleep(0.01)
-    assert b.residual_wall_time is not None
-    assert b.residual_wall_time >= 0
+    assert b.residual_wall_time_s is not None
+    assert b.residual_wall_time_s >= 0
 
 
 def test_wall_time_limit_raises_time_exhausted():
@@ -650,10 +650,10 @@ def test_budget_context_flopscope_overhead_time_property():
     import flopscope
 
     b = flopscope.BudgetContext(flop_budget=int(1e9))
-    assert b.flopscope_overhead_time == 0.0
+    assert b.flopscope_overhead_time_s == 0.0
 
     b._total_flopscope_overhead_time = 1.5
-    assert b.flopscope_overhead_time == 1.5
+    assert b.flopscope_overhead_time_s == 1.5
 
 
 def test_timing_summary_subtracts_overhead():
@@ -731,7 +731,7 @@ def test_counted_wrapper_records_overhead():
     with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
         result = fake_wrapper(5)
     assert result == 6
-    assert b.flopscope_overhead_time >= 0.01
+    assert b.flopscope_overhead_time_s >= 0.01
 
 
 def test_counted_wrapper_handles_exceptions():
@@ -746,7 +746,7 @@ def test_counted_wrapper_handles_exceptions():
         with pytest.raises(ValueError):
             boom()
     # Overhead recorded despite the exception
-    assert b.flopscope_overhead_time > 0
+    assert b.flopscope_overhead_time_s > 0
 
 
 def test_optimer_splits_block_into_backend_and_overhead():
@@ -765,7 +765,7 @@ def test_optimer_splits_block_into_backend_and_overhead():
     # significantly, so use a generous upper bound.
     assert op.flopscope_backend_duration_s is not None
     assert op.flopscope_backend_duration_s >= 0.009
-    assert b.flopscope_backend_time == op.flopscope_backend_duration_s
+    assert b.flopscope_backend_time_s == op.flopscope_backend_duration_s
     # in-block overhead = block - backend, includes the two 0.005 sleeps
     assert op.flopscope_overhead_duration_s is not None
     assert op.flopscope_overhead_duration_s >= 0.008
@@ -775,11 +775,11 @@ def test_deduct_self_charges_body_to_overhead_and_oprecord():
     import flopscope
 
     with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
-        baseline = b.flopscope_overhead_time
+        baseline = b.flopscope_overhead_time_s
         # Call deduct directly without entering the timer
         timer = b.deduct("x", flop_cost=1, subscripts=None, shapes=())
         # The deduct body itself should have charged some overhead
-        assert b.flopscope_overhead_time > baseline
+        assert b.flopscope_overhead_time_s > baseline
         # And the OpRecord should reflect it
         assert b.op_log[-1].flopscope_overhead_duration_s is not None
         assert b.op_log[-1].flopscope_overhead_duration_s > 0
@@ -789,11 +789,11 @@ def test_namespace_scope_charges_push_pop_to_overhead():
     import flopscope
 
     with flopscope.BudgetContext(flop_budget=int(1e9), quiet=True) as b:
-        baseline = b.flopscope_overhead_time
+        baseline = b.flopscope_overhead_time_s
         with flopscope.namespace("ns"):
             pass
         # Push + pop are tiny but non-zero
-        assert b.flopscope_overhead_time > baseline
+        assert b.flopscope_overhead_time_s > baseline
 
 
 def test_per_namespace_summary_includes_flopscope_overhead():
@@ -834,7 +834,7 @@ def test_factory_wrapper_backend_time_is_numpy_only():
     with flopscope.BudgetContext(flop_budget=int(1e15), quiet=True) as b:
         for _ in range(1000):
             flopscope.numpy.add(fnp_a, fnp_b)
-    flopscope_tracked = b.flopscope_backend_time / 1000
+    flopscope_tracked = b.flopscope_backend_time_s / 1000
 
     # Generous bounds for noisy timing
     assert flopscope_tracked < pure_numpy_wall * 50.0
@@ -906,7 +906,7 @@ def test_per_op_overhead_sums_to_global_no_namespace():
     # counter without creating an OpRecord, so per_op_total <= global overhead.
     # We verify that the per-op sum is positive and does not exceed the global.
     assert per_op_total > 0
-    assert per_op_total <= b.flopscope_overhead_time + 1e-9
+    assert per_op_total <= b.flopscope_overhead_time_s + 1e-9
 
 
 def test_per_namespace_overhead_breakdown():
@@ -936,7 +936,7 @@ def test_overhead_recorded_on_budget_exhausted():
                 flopscope.numpy.ones((100, 100)),
                 flopscope.numpy.ones((100, 100)),
             )
-    assert b.flopscope_overhead_time > 0
+    assert b.flopscope_overhead_time_s > 0
 
 
 def test_overhead_recorded_on_numpy_call_exception():
@@ -950,7 +950,7 @@ def test_overhead_recorded_on_numpy_call_exception():
         with pytest.raises(np.linalg.LinAlgError):
             _ = flopscope.numpy.linalg.inv(singular)
     # Decorator's try/finally captured the wrapper time
-    assert b.flopscope_overhead_time > 0
+    assert b.flopscope_overhead_time_s > 0
 
 
 def test_nested_wrapper_no_double_count():
@@ -1013,8 +1013,8 @@ def test_check_nan_inf_opt_in_attributes_to_overhead():
     finally:
         flopscope.configure(check_nan_inf=False)
 
-    overhead_off = b_off.flopscope_overhead_time
-    overhead_on = b_on.flopscope_overhead_time
+    overhead_off = b_off.flopscope_overhead_time_s
+    overhead_on = b_on.flopscope_overhead_time_s
 
     # check_nan_inf=True must add measurable overhead. We verify per-call
     # overhead grew by at least 5 µs per call (a very conservative lower bound
@@ -1028,7 +1028,7 @@ def test_check_nan_inf_opt_in_attributes_to_overhead():
 
 
 def test_residual_wall_time_property_agrees_with_summary_dict():
-    """Regression: BudgetContext.residual_wall_time property must match
+    """Regression: BudgetContext.residual_wall_time_s property must match
     summary_dict()['residual_wall_time_s'].
     """
     import flopscope
@@ -1041,14 +1041,14 @@ def test_residual_wall_time_property_agrees_with_summary_dict():
         for _ in range(20):
             a = a @ a + a
 
-    prop_value = ctx.residual_wall_time
+    prop_value = ctx.residual_wall_time_s
     summary_value = ctx.summary_dict()["residual_wall_time_s"]
     assert prop_value is not None
     assert summary_value is not None
     assert prop_value == pytest.approx(summary_value, abs=1e-9)
     # Also verify both equal the documented identity.
     expected = (
-        ctx.wall_time_s - ctx.flopscope_backend_time - ctx.flopscope_overhead_time  # type: ignore[operator]
+        ctx.wall_time_s - ctx.flopscope_backend_time_s - ctx.flopscope_overhead_time_s  # type: ignore[operator]
     )
     assert prop_value == pytest.approx(max(expected, 0.0), abs=1e-9)
 
@@ -1069,25 +1069,25 @@ def test_budget_context_init_and_exit_billed_as_overhead():
 
     assert ctx.wall_time_s is not None
     assert ctx.wall_time_s > 0
-    assert ctx.flopscope_backend_time == 0.0
+    assert ctx.flopscope_backend_time_s == 0.0
     # Most of the wall should be overhead. Allow a few µs of residual wall time
     # for the Python ``with`` protocol's enter->exit gap.
-    assert ctx.flopscope_overhead_time > 0
-    assert ctx.flopscope_overhead_time >= ctx.residual_wall_time, (  # type: ignore[operator]
-        f"overhead ({ctx.flopscope_overhead_time}) "
-        f"should dominate residual wall time ({ctx.residual_wall_time})"
+    assert ctx.flopscope_overhead_time_s > 0
+    assert ctx.flopscope_overhead_time_s >= ctx.residual_wall_time_s, (  # type: ignore[operator]
+        f"overhead ({ctx.flopscope_overhead_time_s}) "
+        f"should dominate residual wall time ({ctx.residual_wall_time_s})"
     )
-    assert ctx.residual_wall_time < 5e-6, (  # type: ignore[operator]
+    assert ctx.residual_wall_time_s < 5e-6, (  # type: ignore[operator]
         f"empty BudgetContext leaked >5µs into residual wall time: "
-        f"{ctx.residual_wall_time}"
+        f"{ctx.residual_wall_time_s}"
     )
     # Decomposition invariant.
     assert (
         abs(
             ctx.wall_time_s
-            - ctx.flopscope_backend_time
-            - ctx.flopscope_overhead_time
-            - ctx.residual_wall_time  # type: ignore[operator]
+            - ctx.flopscope_backend_time_s
+            - ctx.flopscope_overhead_time_s
+            - ctx.residual_wall_time_s  # type: ignore[operator]
         )
         < 1e-9
     )
@@ -1101,11 +1101,11 @@ def test_namespace_scope_billed_as_overhead_amplified():
 
     ctx = flops.BudgetContext(flop_budget=int(1e12), quiet=True)
     with ctx:
-        overhead_before = ctx.flopscope_overhead_time
+        overhead_before = ctx.flopscope_overhead_time_s
         for _ in range(1000):
             with flops.namespace("foo"):
                 pass
-        overhead_after = ctx.flopscope_overhead_time
+        overhead_after = ctx.flopscope_overhead_time_s
 
     delta = overhead_after - overhead_before
     # 1000 pairs × O(100ns) each → at least 100 μs of overhead growth.
@@ -1114,9 +1114,9 @@ def test_namespace_scope_billed_as_overhead_amplified():
     assert (
         abs(
             ctx.wall_time_s  # type: ignore[operator]
-            - ctx.flopscope_backend_time
-            - ctx.flopscope_overhead_time
-            - ctx.residual_wall_time  # type: ignore[operator]
+            - ctx.flopscope_backend_time_s
+            - ctx.flopscope_overhead_time_s
+            - ctx.residual_wall_time_s  # type: ignore[operator]
         )
         < 1e-9
     )
@@ -1137,7 +1137,7 @@ def test_namespace_scope_exit_exception_still_charges_overhead(monkeypatch):
         raise RuntimeError("synthetic pop failure")
 
     with ctx:
-        overhead_before = ctx.flopscope_overhead_time
+        overhead_before = ctx.flopscope_overhead_time_s
         monkeypatch.setattr(type(ctx), "_pop_namespace", boom)
         with pytest.raises(RuntimeError, match="synthetic pop failure"):
             with flops.namespace("foo"):
@@ -1147,4 +1147,4 @@ def test_namespace_scope_exit_exception_still_charges_overhead(monkeypatch):
         monkeypatch.setattr(type(ctx), "_pop_namespace", original)
         ctx._namespace_stack.pop()
     assert raised["flag"]
-    assert ctx.flopscope_overhead_time > overhead_before
+    assert ctx.flopscope_overhead_time_s > overhead_before

--- a/website/.generated/public-api-symbols.json
+++ b/website/.generated/public-api-symbols.json
@@ -3290,7 +3290,7 @@
                       },
                       {
                         "kind": "code",
-                        "text": "flopscope_overhead_time"
+                        "text": "flopscope_overhead_time_s"
                       },
                       {
                         "kind": "text",
@@ -3340,7 +3340,7 @@
                   },
                   {
                     "kind": "code",
-                    "text": "flopscope_overhead_time"
+                    "text": "flopscope_overhead_time_s"
                   },
                   {
                     "kind": "text",

--- a/website/.generated/public-api/flopscope-configure.json
+++ b/website/.generated/public-api/flopscope-configure.json
@@ -56,7 +56,7 @@
                     },
                     {
                       "kind": "code",
-                      "text": "flopscope_overhead_time"
+                      "text": "flopscope_overhead_time_s"
                     },
                     {
                       "kind": "text",
@@ -106,7 +106,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "flopscope_overhead_time"
+                  "text": "flopscope_overhead_time_s"
                 },
                 {
                   "kind": "text",
@@ -534,7 +534,7 @@
         "If ``True``, scan every counted op's output for NaN/Inf values and",
         "emit a :class:`~flopscope.errors.FlopscopeWarning` if any are found.",
         "The scan is two full O(n) sweeps over the result and is attributed",
-        "to ``flopscope_overhead_time``, so it is off by default for",
+        "to ``flopscope_overhead_time_s``, so it is off by default for",
         "production scoring.  Opt in when debugging an estimator that",
         "produces NaN/Inf to identify the introducing op.  Default ``False``."
       ],

--- a/website/.generated/symbols/configure.json
+++ b/website/.generated/symbols/configure.json
@@ -59,7 +59,7 @@
                     },
                     {
                       "kind": "code",
-                      "text": "flopscope_overhead_time"
+                      "text": "flopscope_overhead_time_s"
                     },
                     {
                       "kind": "text",
@@ -109,7 +109,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "flopscope_overhead_time"
+                  "text": "flopscope_overhead_time_s"
                 },
                 {
                   "kind": "text",


### PR DESCRIPTION
Renames the three `BudgetContext` timing **properties** to carry the `_s` suffix, for consistency with `wall_time_s` / `elapsed_s` / `wall_time_limit_s` and the `summary_dict()` / report keys (which were already `_s`):

| old | new |
|---|---|
| `flopscope_backend_time` | `flopscope_backend_time_s` |
| `flopscope_overhead_time` | `flopscope_overhead_time_s` |
| `residual_wall_time` | `residual_wall_time_s` |

Applies to **both** `BudgetContext` implementations (the in-process `flopscope` and the dispatch-client `flopscope`). The private `_total_*` accumulators and the `summary_dict()`/report dict keys are unchanged.

**BREAKING** — no aliases. Consumers reading these attributes must move to the `_s` names. The `!` + `BREAKING CHANGE:` footer drive the version bump.

### Version bump
Intentionally **not** in this PR — done via `cz bump` as the separate release step (per flopscope's convention of dedicated `bump:` commits + `v*` tag → PyPI).

### Tested
`tests/test_budget.py` (69) + client `test_budget_timing_integration.py`/`test_budget.py`/`test_display.py` (47) + server suite (206) pass. Validated end-to-end in a unified venv: new `_s` props present, **old names raise** (no silent fallback), real ops produce non-zero backend/overhead/residual with `wall == backend+overhead+residual`.

### Coordinated cutover (FYI)
Lead of a no-alias cutover: whestbench (`>=0.6.0`) → evaluator follow once this releases. Their PRs' CI is blocked until flopscope 0.6.0 is on PyPI.