### PR TITLE
feat(remote): make in-process↔client op divergence predictable before submit

### DIFF
--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -58,6 +58,10 @@ from flopscope.errors import (  # noqa: E402
     RemoteCallbackError,
     RemoteSerializationError,
     SymmetryError,
+    SymmetryLossWarning,
+    TimeExhaustedError,
+    UnsupportedFunctionError,
+    UnsupportedReturnType,
 )
 
 # Alias: ``fnp.ndarray`` refers to the RemoteArray class.

--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -56,6 +56,7 @@ from flopscope.errors import (  # noqa: E402
     FlopscopeWarning,
     NoBudgetContextError,
     RemoteCallbackError,
+    RemoteSerializationError,
     SymmetryError,
 )
 
@@ -126,6 +127,37 @@ complex128: str = "complex128"
 # ---------------------------------------------------------------------------
 
 
+_MSGPACK_OK = (type(None), bool, int, float, str, bytes)
+
+
+def _describe_unserializable(args: Any, kwargs: Any) -> str:
+    """Return a short descriptor of the first value msgpack cannot encode,
+    e.g. ``"of type 'generator'"``; ``""`` if none can be pinpointed."""
+
+    def walk(value: Any):
+        if isinstance(value, _MSGPACK_OK):
+            return None
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                bad = walk(item)
+                if bad is not None:
+                    return bad
+            return None
+        if isinstance(value, dict):
+            for item in value.values():
+                bad = walk(item)
+                if bad is not None:
+                    return bad
+            return None
+        return type(value).__name__
+
+    for value in list(args) + list(kwargs.values()):
+        bad = walk(value)
+        if bad is not None:
+            return f"of type {bad!r}"
+    return ""
+
+
 def _make_proxy(op_name: str):
     """Create a proxy function that dispatches *op_name* to the server."""
 
@@ -145,7 +177,13 @@ def _make_proxy(op_name: str):
                     f"in the in-process flopscope backend, or precompute the "
                     f"result."
                 ) from exc
-            raise
+            bad = _describe_unserializable(encoded_args, encoded_kwargs)
+            detail = f" {bad}" if bad else ""
+            raise RemoteSerializationError(
+                f"{op_name}() received an argument{detail} that cannot be sent "
+                f"to the remote (client/server) backend. Pass a materialized "
+                f"array or built-in (list / number / str) instead."
+            ) from exc
         resp = get_connection().send_recv(request)
         return _result_from_response(resp)
 

--- a/flopscope-client/src/flopscope/_config.py
+++ b/flopscope-client/src/flopscope/_config.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 _SETTINGS: dict[str, object] = {
+    "callback_warnings": True,
     "check_nan_inf": False,
     "dimino_budget": 50_000,
     "einsum_path_cache_size": 4096,
@@ -37,6 +38,11 @@ def configure(**kwargs: object) -> None:
 
     Parameters
     ----------
+    callback_warnings : bool
+        If ``False``, suppress
+        :class:`~flopscope.errors.RemoteCallbackWarning` warnings emitted when a
+        callback-taking op (``apply_along_axis`` etc.) is called in-process.
+        Default ``True``.
     check_nan_inf : bool
         If ``True``, scan every counted op's output for NaN/Inf values and
         emit a :class:`~flopscope.errors.FlopscopeWarning` if any are found.

--- a/flopscope-client/src/flopscope/_config.py
+++ b/flopscope-client/src/flopscope/_config.py
@@ -94,6 +94,19 @@ def configure(**kwargs: object) -> None:
             validator(value)  # type: ignore[call-arg]
         _SETTINGS[key] = value
 
+    if kwargs:
+        import warnings
+
+        from flopscope.errors import ConfigureNoOpWarning
+
+        warnings.warn(
+            "flops.configure() configures the in-process flopscope backend only; "
+            "it is a no-op on flopscope-client and the evaluation servers, so "
+            "these settings will not affect a graded submission.",
+            ConfigureNoOpWarning,
+            stacklevel=2,
+        )
+
     if "einsum_path_cache_size" in kwargs:
         # The lightweight client ships this module verbatim (see
         # scripts/sync_client.py) but has no ``flopscope._einsum`` — einsum-path

--- a/flopscope-client/src/flopscope/errors.py
+++ b/flopscope-client/src/flopscope/errors.py
@@ -74,6 +74,10 @@ class CostFallbackWarning(FlopscopeWarning):
     """Warning issued when flopscope skips its symmetry-aware cost adjustment (e.g. ``ufunc.outer`` / ``tensordot`` on a symmetry group whose degree exceeds the per-call Burnside-enumeration threshold). The op runs correctly with the dense cost charged instead. Suppress with ``flops.configure(symmetry_warnings=False)``."""
 
 
+class RemoteCallbackWarning(FlopscopeWarning):
+    """Warning issued when a callback-taking op (e.g. apply_along_axis) is called in-process; it raises RemoteCallbackError on the remote (client/server) backend. Suppress with ``flops.configure(callback_warnings=False)``."""
+
+
 class FlopscopeServerError(FlopscopeError):
     """Server-side error that does not map to a more specific exception."""
 

--- a/flopscope-client/src/flopscope/errors.py
+++ b/flopscope-client/src/flopscope/errors.py
@@ -62,6 +62,13 @@ class RemoteCallbackError(FlopscopeError):
         super().__init__(message)
 
 
+class RemoteSerializationError(FlopscopeError):
+    """Raised when an argument to a remote op cannot be serialized for the client/server backend (e.g. a generator, lambda, or custom object)."""
+
+    def __init__(self, message: str = "") -> None:
+        super().__init__(message)
+
+
 class FlopscopeWarning(UserWarning):
     """Warning issued when flopscope detects potential numerical issues."""
 
@@ -95,6 +102,7 @@ _FLOPSCOPE_ERRORS: frozenset[str] = frozenset(
         "UnsupportedFunctionError",
         "UnsupportedReturnType",
         "RemoteCallbackError",
+        "RemoteSerializationError",
     }
 )
 
@@ -106,6 +114,7 @@ _ERROR_MAP: dict[str, type[Exception]] = {
     "UnsupportedFunctionError": UnsupportedFunctionError,
     "UnsupportedReturnType": UnsupportedReturnType,
     "RemoteCallbackError": RemoteCallbackError,
+    "RemoteSerializationError": RemoteSerializationError,
     "FlopscopeServerError": FlopscopeServerError,
     "ValueError": ValueError,
     "TypeError": TypeError,

--- a/flopscope-client/src/flopscope/errors.py
+++ b/flopscope-client/src/flopscope/errors.py
@@ -85,6 +85,10 @@ class RemoteCallbackWarning(FlopscopeWarning):
     """Warning issued when a callback-taking op (e.g. apply_along_axis) is called in-process; it raises RemoteCallbackError on the remote (client/server) backend. Suppress with ``flops.configure(callback_warnings=False)``."""
 
 
+class ConfigureNoOpWarning(FlopscopeWarning):
+    """Warning issued when flops.configure() is called. configure affects the in-process flopscope backend only; it is a no-op on flopscope-client and the evaluation servers, so its settings do not carry into a graded submission."""
+
+
 class FlopscopeServerError(FlopscopeError):
     """Server-side error that does not map to a more specific exception."""
 

--- a/flopscope-client/tests/test_configure_noop.py
+++ b/flopscope-client/tests/test_configure_noop.py
@@ -1,0 +1,23 @@
+"""flops.configure() warns that it is a no-op on flopscope-client.
+
+The client ships ``_config.py`` verbatim, so ``configure`` stores settings but
+they do not affect the remote (client/server) evaluation. The warning tells
+participants their config will not carry into a graded submission. No live
+server is needed — ``configure`` is purely local.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import flopscope as fnp
+from flopscope.errors import ConfigureNoOpWarning
+
+
+def test_configure_warns_noop_on_client():
+    with pytest.warns(ConfigureNoOpWarning):
+        fnp.configure(symmetry_warnings=True)
+
+
+def test_configure_noop_warning_is_a_flopscope_warning():
+    assert issubclass(ConfigureNoOpWarning, fnp.FlopscopeWarning)

--- a/flopscope-client/tests/test_error_reexports.py
+++ b/flopscope-client/tests/test_error_reexports.py
@@ -1,0 +1,37 @@
+"""The client re-exports the participant-facing error/warning classes at the
+top level (parity with in-process flopscope), so ``except flops.TimeExhaustedError``
+written against the in-process docs also works on the client.
+"""
+
+from __future__ import annotations
+
+import flopscope
+import flopscope.errors as _errors
+
+# Classes documented for participants that must be reachable as ``flops.<name>``
+_REEXPORTED = [
+    "BudgetExhaustedError",
+    "TimeExhaustedError",
+    "NoBudgetContextError",
+    "UnsupportedFunctionError",
+    "UnsupportedReturnType",
+    "SymmetryError",
+    "SymmetryLossWarning",
+    "FlopscopeError",
+    "FlopscopeWarning",
+]
+
+
+def test_error_classes_reexported_at_top_level():
+    for name in _REEXPORTED:
+        assert hasattr(flopscope, name), f"flopscope.{name} should be re-exported"
+        assert getattr(flopscope, name) is getattr(_errors, name)
+
+
+def test_reexported_errors_subclass_flopscope_error():
+    for name in [
+        "TimeExhaustedError",
+        "UnsupportedFunctionError",
+        "UnsupportedReturnType",
+    ]:
+        assert issubclass(getattr(flopscope, name), flopscope.FlopscopeError)

--- a/flopscope-client/tests/test_remote_serialization_error.py
+++ b/flopscope-client/tests/test_remote_serialization_error.py
@@ -1,0 +1,20 @@
+"""Client raises a clear RemoteSerializationError for non-serializable args."""
+
+from __future__ import annotations
+
+import pytest
+
+import flopscope as fnp
+from flopscope.errors import RemoteCallbackError, RemoteSerializationError
+
+
+def test_generator_arg_raises_remote_serialization_error():
+    with pytest.raises(RemoteSerializationError) as excinfo:
+        fnp.concatenate([(x for x in range(3))])
+    assert "generator" in str(excinfo.value)
+    assert "concatenate" in str(excinfo.value)
+
+
+def test_callback_op_still_raises_remote_callback_error():
+    with pytest.raises(RemoteCallbackError):
+        fnp.apply_along_axis(lambda r: r.sum(), 0, [[1, 2], [3, 4]])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ version_files = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--ignore=tests/numpy_compat -n auto"
+filterwarnings = [
+    # flopscope's own tests call configure() on the in-process backend
+    # legitimately; the participant-facing no-op notice is just noise here.
+    "ignore::flopscope.errors.ConfigureNoOpWarning",
+]
 
 [tool.coverage.run]
 source = ["flopscope"]

--- a/scripts/sync_client.py
+++ b/scripts/sync_client.py
@@ -90,11 +90,12 @@ def _generate_errors() -> str:
     _CUSTOM_INIT_CLASSES = {
         "BudgetExhaustedError",
         "NoBudgetContextError",
+        "RemoteCallbackError",
+        "RemoteSerializationError",
         "SymmetryError",
         "TimeExhaustedError",
         "UnsupportedFunctionError",
         "UnsupportedReturnType",
-        "RemoteCallbackError",
     }
 
     # Classes whose default message must be non-empty (match core's guidance).
@@ -148,6 +149,15 @@ def _generate_errors() -> str:
                 "Raised when a callback-taking op (e.g. apply_along_axis) is "
                 "invoked on the client/server backend, which cannot execute "
                 "Python callbacks remotely."
+            ),
+        ),
+        (
+            "RemoteSerializationError",
+            "FlopscopeError",
+            (
+                "Raised when an argument to a remote op cannot be serialized "
+                "for the client/server backend (e.g. a generator, lambda, or "
+                "custom object)."
             ),
         ),
         (

--- a/scripts/sync_client.py
+++ b/scripts/sync_client.py
@@ -172,6 +172,16 @@ def _generate_errors() -> str:
                 "``flops.configure(symmetry_warnings=False)``."
             ),
         ),
+        (
+            "RemoteCallbackWarning",
+            "FlopscopeWarning",
+            (
+                "Warning issued when a callback-taking op (e.g. apply_along_axis) "
+                "is called in-process; it raises RemoteCallbackError on the "
+                "remote (client/server) backend. Suppress with "
+                "``flops.configure(callback_warnings=False)``."
+            ),
+        ),
         # client-only
         (
             "FlopscopeServerError",

--- a/scripts/sync_client.py
+++ b/scripts/sync_client.py
@@ -192,6 +192,16 @@ def _generate_errors() -> str:
                 "``flops.configure(callback_warnings=False)``."
             ),
         ),
+        (
+            "ConfigureNoOpWarning",
+            "FlopscopeWarning",
+            (
+                "Warning issued when flops.configure() is called. configure "
+                "affects the in-process flopscope backend only; it is a no-op on "
+                "flopscope-client and the evaluation servers, so its settings do "
+                "not carry into a graded submission."
+            ),
+        ),
         # client-only
         (
             "FlopscopeServerError",

--- a/src/flopscope/__init__.py
+++ b/src/flopscope/__init__.py
@@ -166,6 +166,22 @@ def clear_cache() -> None:
     reduction_clear_cache()
 
 
+def remote_unsupported_ops() -> frozenset[str]:
+    """Op names that run a Python callback in-process and therefore CANNOT run
+    on the remote (client/server) backend used for AIcrowd submissions —
+    calling them there raises
+    :class:`~flopscope.errors.RemoteCallbackError`.
+
+    Sourced from the operation registry (single source of truth), so it stays
+    correct as ops are added. Equal to the client's ``LOCAL_CALLBACK_OPS``.
+    """
+    from flopscope._registry import REGISTRY
+
+    return frozenset(
+        name for name, entry in REGISTRY.items() if entry.get("local_callback")
+    )
+
+
 def tier2_reduction_cost(a, axis=None, *, dense_per_output_cost=None):
     """Cost for selection-style reductions (median, percentile, quantile).
 
@@ -257,6 +273,7 @@ __all__ = [
     "reduction_accumulation_cost",
     "reduction_cache_info",
     "reduction_clear_cache",
+    "remote_unsupported_ops",
     "stats",
     "symmetrize",
     "tier2_reduction_cost",

--- a/src/flopscope/_config.py
+++ b/src/flopscope/_config.py
@@ -90,6 +90,19 @@ def configure(**kwargs: object) -> None:
             validator(value)  # type: ignore[call-arg]
         _SETTINGS[key] = value
 
+    if kwargs:
+        import warnings
+
+        from flopscope.errors import ConfigureNoOpWarning
+
+        warnings.warn(
+            "flops.configure() configures the in-process flopscope backend only; "
+            "it is a no-op on flopscope-client and the evaluation servers, so "
+            "these settings will not affect a graded submission.",
+            ConfigureNoOpWarning,
+            stacklevel=2,
+        )
+
     if "einsum_path_cache_size" in kwargs:
         # The lightweight client ships this module verbatim (see
         # scripts/sync_client.py) but has no ``flopscope._einsum`` — einsum-path

--- a/src/flopscope/_config.py
+++ b/src/flopscope/_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 _SETTINGS: dict[str, object] = {
+    "callback_warnings": True,
     "check_nan_inf": False,
     "dimino_budget": 50_000,
     "einsum_path_cache_size": 4096,
@@ -33,6 +34,11 @@ def configure(**kwargs: object) -> None:
 
     Parameters
     ----------
+    callback_warnings : bool
+        If ``False``, suppress
+        :class:`~flopscope.errors.RemoteCallbackWarning` warnings emitted when a
+        callback-taking op (``apply_along_axis`` etc.) is called in-process.
+        Default ``True``.
     check_nan_inf : bool
         If ``True``, scan every counted op's output for NaN/Inf values and
         emit a :class:`~flopscope.errors.FlopscopeWarning` if any are found.

--- a/src/flopscope/_counting_ops.py
+++ b/src/flopscope/_counting_ops.py
@@ -19,6 +19,7 @@ from flopscope._docstrings import attach_docstring
 from flopscope._flops import _ceil_log2
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray, _to_base_ndarray_tree
 from flopscope._validation import require_budget
+from flopscope.errors import _warn_remote_callback
 
 # ---------------------------------------------------------------------------
 # Reductions disguised as free
@@ -368,6 +369,7 @@ def apply_along_axis(
     **kwargs: Any,
 ) -> FlopscopeArray:
     """Counted version of np.apply_along_axis. Cost: numel(output)."""
+    _warn_remote_callback("apply_along_axis")
     budget = require_budget()
     if not isinstance(arr, _np.ndarray):
         arr = _np.asarray(arr)
@@ -403,6 +405,7 @@ def apply_over_axes(
     axes: int | Sequence[int],
 ) -> FlopscopeArray:
     """Counted version of np.apply_over_axes. Cost: numel(output)."""
+    _warn_remote_callback("apply_over_axes")
     budget = require_budget()
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
@@ -434,6 +437,7 @@ def piecewise(
     **kw: Any,
 ) -> FlopscopeArray:
     """Counted version of np.piecewise. Cost: numel(input)."""
+    _warn_remote_callback("piecewise")
     budget = require_budget()
     if not isinstance(x, _np.ndarray):
         x = _np.asarray(x)

--- a/src/flopscope/_free_ops.py
+++ b/src/flopscope/_free_ops.py
@@ -37,6 +37,7 @@ from flopscope._validation import require_budget
 from flopscope.errors import (
     SymmetryError,
     UnsupportedFunctionError,
+    _warn_remote_callback,
     _warn_symmetry_loss,
 )
 
@@ -1770,6 +1771,7 @@ attach_docstring(fromfile, _np.fromfile, "free", "0 FLOPs")
 @_counted_wrapper
 def fromfunction(*args, **kwargs):
     """Construct array by executing function over each coordinate. Cost: numel(output)."""
+    _warn_remote_callback("fromfunction")
     budget = require_budget()
     result = _call_user_code(budget, _np.fromfunction, *args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1
@@ -1784,6 +1786,7 @@ attach_docstring(fromfunction, _np.fromfunction, "free", "0 FLOPs")
 @_counted_wrapper
 def fromiter(*args, **kwargs):
     """Create array from iterable object. Cost: numel(output)."""
+    _warn_remote_callback("fromiter")
     budget = require_budget()
     result = _call_user_code(budget, _np.fromiter, *args, **kwargs)
     cost = result.size if hasattr(result, "size") else 1

--- a/src/flopscope/errors.py
+++ b/src/flopscope/errors.py
@@ -175,6 +175,14 @@ class RemoteCallbackWarning(FlopscopeWarning):
     """
 
 
+class ConfigureNoOpWarning(FlopscopeWarning):
+    """Warning issued when ``flops.configure()`` is called. ``configure``
+    affects the in-process flopscope backend only; it is a no-op on
+    ``flopscope-client`` and the evaluation servers, so its settings do not
+    carry into a graded submission.
+    """
+
+
 # Used by _user_stacklevel() to skip frames inside the flopscope package.
 _FLOPSCOPE_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/flopscope/errors.py
+++ b/src/flopscope/errors.py
@@ -166,6 +166,15 @@ class CostFallbackWarning(FlopscopeWarning):
     """
 
 
+class RemoteCallbackWarning(FlopscopeWarning):
+    """Warning issued when a callback-taking op (e.g. ``apply_along_axis``) is
+    called in-process. The op works in-process but raises
+    :class:`RemoteCallbackError` on the remote (client/server) backend used for
+    AIcrowd submissions. Suppress with
+    ``flops.configure(callback_warnings=False)``.
+    """
+
+
 # Used by _user_stacklevel() to skip frames inside the flopscope package.
 _FLOPSCOPE_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -203,5 +212,21 @@ def _warn_symmetry_loss(
         "Use as_symmetric() to re-tag if you know the result is symmetric. "
         "Suppress with flops.configure(symmetry_warnings=False).",
         SymmetryLossWarning,
+        stacklevel=_user_stacklevel(),
+    )
+
+
+def _warn_remote_callback(op_name: str) -> None:
+    """Emit a :class:`RemoteCallbackWarning` if ``callback_warnings`` is enabled."""
+    from flopscope._config import get_setting
+
+    if not get_setting("callback_warnings"):
+        return
+    _warnings.warn(
+        f"{op_name}() runs a Python callback in-process, but raises "
+        f"RemoteCallbackError on the remote (client/server) backend used for "
+        f"AIcrowd submissions. Precompute the result or avoid this op in "
+        f"submitted code. Suppress with flops.configure(callback_warnings=False).",
+        RemoteCallbackWarning,
         stacklevel=_user_stacklevel(),
     )

--- a/tests/test_client_server_parity.py
+++ b/tests/test_client_server_parity.py
@@ -324,3 +324,18 @@ class TestApiSurfaceParity:
             assert name in defined, (
                 f"client {relative} does not define {name} (core/client API drift)"
             )
+
+
+# ---------------------------------------------------------------------------
+# Op-set / local_callback drift guard
+# ---------------------------------------------------------------------------
+
+
+def test_op_set_and_callback_parity():
+    core_reg = _load_core("_registry.py", "core_registry").REGISTRY
+    client_rd = _load_client("_registry_data.py", "client_registry_data")
+    assert set(core_reg) == set(client_rd.FUNCTION_CATEGORIES)
+    core_callbacks = frozenset(
+        n for n, e in core_reg.items() if e.get("local_callback")
+    )
+    assert core_callbacks == frozenset(client_rd.LOCAL_CALLBACK_OPS)

--- a/tests/test_remote_compat.py
+++ b/tests/test_remote_compat.py
@@ -28,7 +28,7 @@ import warnings
 import pytest
 
 import flopscope.numpy as fnp
-from flopscope.errors import RemoteCallbackWarning
+from flopscope.errors import ConfigureNoOpWarning, RemoteCallbackWarning
 
 
 def _call(op: str) -> None:
@@ -73,3 +73,10 @@ def test_non_callback_op_does_not_warn():
         with warnings.catch_warnings():
             warnings.simplefilter("error", RemoteCallbackWarning)
             fnp.matmul(fnp.ones((3, 3)), fnp.ones((3, 3)))
+
+
+def test_configure_warns_it_is_a_noop_remotely():
+    # configure() works in-process but is a no-op on the client/eval servers;
+    # it warns so participants don't expect it to affect a graded submission.
+    with pytest.warns(ConfigureNoOpWarning):
+        flops.configure(symmetry_warnings=True)

--- a/tests/test_remote_compat.py
+++ b/tests/test_remote_compat.py
@@ -1,0 +1,23 @@
+"""Tests for in-process ↔ remote (client/server) divergence feedback."""
+
+from __future__ import annotations
+
+import flopscope as flops
+
+_CALLBACK_OPS = frozenset(
+    {"apply_along_axis", "apply_over_axes", "fromfunction", "fromiter", "piecewise"}
+)
+
+
+def test_remote_unsupported_ops_returns_frozenset_of_callback_ops():
+    ops = flops.remote_unsupported_ops()
+    assert isinstance(ops, frozenset)
+    assert ops == _CALLBACK_OPS
+
+
+def test_remote_unsupported_ops_matches_registry_flag():
+    from flopscope._registry import REGISTRY
+
+    assert flops.remote_unsupported_ops() == frozenset(
+        name for name, entry in REGISTRY.items() if entry.get("local_callback")
+    )

--- a/tests/test_remote_compat.py
+++ b/tests/test_remote_compat.py
@@ -21,3 +21,55 @@ def test_remote_unsupported_ops_matches_registry_flag():
     assert flops.remote_unsupported_ops() == frozenset(
         name for name, entry in REGISTRY.items() if entry.get("local_callback")
     )
+
+
+import warnings
+
+import pytest
+
+import flopscope.numpy as fnp
+from flopscope.errors import RemoteCallbackWarning
+
+
+def _call(op: str) -> None:
+    if op == "apply_along_axis":
+        fnp.apply_along_axis(lambda r: r.sum(), 0, fnp.ones((3, 3)))
+    elif op == "apply_over_axes":
+        fnp.apply_over_axes(lambda a, ax: a.sum(axis=ax), fnp.ones((3, 3)), [0])
+    elif op == "piecewise":
+        fnp.piecewise(
+            fnp.array([-2.0, 2.0]),
+            [fnp.array([True, False]), fnp.array([False, True])],
+            [lambda v: -v, lambda v: v],
+        )
+    elif op == "fromfunction":
+        fnp.fromfunction(lambda i, j: i + j, (3, 3))
+    elif op == "fromiter":
+        fnp.fromiter((x for x in range(5)), dtype=float)
+    else:  # pragma: no cover
+        raise AssertionError(op)
+
+
+@pytest.mark.parametrize("op", sorted(_CALLBACK_OPS))
+def test_callback_op_warns_in_process(op):
+    with flops.BudgetContext(flop_budget=10**9):
+        with pytest.warns(RemoteCallbackWarning):
+            _call(op)
+
+
+def test_callback_warning_suppressed_by_config():
+    flops.configure(callback_warnings=False)
+    try:
+        with flops.BudgetContext(flop_budget=10**9):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", RemoteCallbackWarning)
+                _call("fromfunction")
+    finally:
+        flops.configure(callback_warnings=True)
+
+
+def test_non_callback_op_does_not_warn():
+    with flops.BudgetContext(flop_budget=10**9):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RemoteCallbackWarning)
+            fnp.matmul(fnp.ones((3, 3)), fnp.ones((3, 3)))

--- a/website/content/docs/getting-started/competition.mdx
+++ b/website/content/docs/getting-started/competition.mdx
@@ -151,6 +151,19 @@ print(f"This matmul will cost {cost:,} FLOPs")  # 33,554,432
 
 **Watch out for hidden costs.** Operations like `fnp.array()` and `fnp.concatenate()` are *not* free -- they charge `numel(output)` FLOPs, and `fnp.where()` charges `numel(condition)`. Check the cost of any operation you are unsure about.
 
+## Local vs. remote backends
+
+You develop against the in-process `flopscope`, but AIcrowd runs your code on
+the remote (client/server) backend. Five callback-taking ops —
+`apply_along_axis`, `apply_over_axes`, `fromfunction`, `fromiter`, `piecewise`
+— work in-process but raise `RemoteCallbackError` remotely, because a Python
+callback can't be sent over the wire. Calling them in-process now emits a
+`RemoteCallbackWarning`; enumerate the set with
+`flopscope.remote_unsupported_ops()`. Precompute these results or avoid the ops
+in submitted code. Likewise, passing a non-serializable argument (a generator,
+lambda, or custom object) to any op raises `RemoteSerializationError` remotely —
+pass materialized arrays or built-ins instead.
+
 ## When things go wrong
 
 If you hit `BudgetExhaustedError`, see [Budget Planning & Debugging](/docs/guides/budget-planning) for a systematic approach to diagnosing overruns and reducing costs.


### PR DESCRIPTION
## Summary

Makes the in-process ↔ `flopscope-client` (remote) divergence **predictable before submission**, so users stop discovering it as a confusing error only after submitting to AIcrowd. It adds **six feedback mechanisms**:

1. **`flops.remote_unsupported_ops()`** — query the ops that can't run on the client/server backend.
2. **`RemoteCallbackWarning`** — in-process warning when one of the 5 callback ops is used (it'll fail remotely).
3. **`RemoteSerializationError`** — a clear client error naming the offending argument type, instead of an opaque msgpack `TypeError`.
4. **Error-class top-level parity** — `TimeExhaustedError` / `UnsupportedFunctionError` / `UnsupportedReturnType` / `SymmetryLossWarning` reachable as `flops.*` on the client (so documented `except flops.X` works).
5. **`ConfigureNoOpWarning`** — `flops.configure()` warns it is a no-op on flopscope-client and the evaluation servers.
6. **Parity drift-guard + docs** — a test locking op-set / `local_callback` parity, plus a "Local vs. remote backends" docs note.

**Background:** users develop against the in-process `flopscope`, but AIcrowd runs their code on the client/server backend. The op registries are otherwise identical *by construction* (the client's `FUNCTION_CATEGORIES`/`LOCAL_CALLBACK_OPS` are generated from the in-process `REGISTRY` by `scripts/sync_client.py`, CI-gated by `client-server-sync --check`; verified: 602 ops both sides, 0 drift). The only **op-level** divergence is the 5 callback ops, which run a Python callback that can't cross the wire; a secondary **argument-level** divergence is any non-serializable arg (generator/lambda/custom object) to any op.

> Builds on the `local_callback` / `LOCAL_CALLBACK_OPS` / `RemoteCallbackError` machinery introduced in #119 (`fix/timing-bucket-attribution`), now merged to `main`; this PR targets `main`.

## What changed

**Query API** (`src/flopscope/__init__.py`)
- New public `flopscope.remote_unsupported_ops() -> frozenset[str]` — enumerates the ops that run a callback in-process and thus can't run remotely, sourced from the registry's `local_callback` flag (single source of truth). Returns `{apply_along_axis, apply_over_axes, fromfunction, fromiter, piecewise}`.

**Proactive in-process warning** (`errors.py`, `_config.py`, `_counting_ops.py`, `_free_ops.py`)
- New `RemoteCallbackWarning(FlopscopeWarning)` + `_warn_remote_callback()` helper, emitted as the first line of each of the 5 callback wrappers when they run in-process — telling the user they'll hit `RemoteCallbackError` on the remote backend and how to avoid it.
- New `flops.configure(callback_warnings=False)` toggle (default **on**), matching the `symmetry_warnings` house style. Zero overhead for all other ops (no central dispatch hook); stacklevel points to the user's call site.

**Clearer client error** (`scripts/sync_client.py`, `flopscope-client/`)
- New client-only `RemoteSerializationError` (codegen'd via `sync_client.py`). The client proxy now raises it — naming the offending argument's type (e.g. *"received an argument of type 'generator' …"*) — instead of re-raising an opaque `msgpack` `TypeError`, for non-callback ops given a non-serializable argument. Callback ops still raise `RemoteCallbackError`. Both fire at encode time (no live server needed).

**Error-class top-level parity** (`flopscope-client/src/flopscope/__init__.py`)
- Re-export `TimeExhaustedError`, `UnsupportedFunctionError`, `UnsupportedReturnType`, and `SymmetryLossWarning` at the client top level. They already existed in the client's `flopscope.errors` (and the server maps errors back through them) but weren't reachable as `flops.X`, so a participant's documented `except flops.TimeExhaustedError:` would `AttributeError` on the client. Now the client's top-level error/warning surface matches in-process flopscope. Guarded by a new parity test.

**`configure()` no-op warning** (`errors.py`, `_config.py`, `scripts/sync_client.py`, `pyproject.toml`)
- `flops.configure()` now emits a `ConfigureNoOpWarning` (a `FlopscopeWarning`) saying it configures the **in-process backend only** and is a **no-op on flopscope-client and the evaluation servers**, so settings don't carry into a graded submission. The warn lives in the shared `_config.py` so it fires both in-process and on the client (which ships `_config.py` verbatim). flopscope's own test suite ignores it via a targeted `filterwarnings` entry (it configures the in-process backend legitimately). `configure` can't change graded cost — counting is server-owned — so this is purely a "don't be misled" notice.

**Drift guard + docs** (`tests/test_client_server_parity.py`, `website/.../competition.mdx`)
- A parity test asserting `set(REGISTRY) == set(client FUNCTION_CATEGORIES)` and `local_callback == LOCAL_CALLBACK_OPS` — locks in "no silent op-set divergence."
- A "Local vs. remote backends" docs subsection naming the callback ops, the warning, the query API, and `RemoteSerializationError`.

## Behavior / scope

- In-process FLOP counts and timing buckets are **unchanged**; the only new in-process behavior is the suppressible warning. No hot-path cost for non-callback ops. Client success path unchanged.
- The client's generated `errors.py`/`_config.py` are regenerated by `sync_client.py` (not hand-edited); `--check` stays green.
- **Known limitation (follow-up):** the hand-written client `einsum` wrapper encodes before connecting and still surfaces the opaque `TypeError` for a non-serializable operand — out of scope here; a shared `_encode_or_raise` helper could unify it later.

## Test plan

- [x] New `tests/test_remote_compat.py`: `remote_unsupported_ops()` equals the registry-derived set; all 5 callback ops emit `RemoteCallbackWarning` in-process (parametrized); `callback_warnings=False` suppresses it; non-callback ops don't warn.
- [x] New `flopscope-client/tests/test_remote_serialization_error.py`: a generator arg to a non-callback op raises `RemoteSerializationError` (message names the type + op); callback ops still raise `RemoteCallbackError`.
- [x] New parity drift-guard test in `tests/test_client_server_parity.py`.
- [x] New `flopscope-client/tests/test_error_reexports.py`: the participant-facing error/warning classes are reachable as `flops.*` and are the same objects as `flopscope.errors.*`.
- [x] `configure()` no-op warning: in-process (`tests/test_remote_compat.py`) and client (`flopscope-client/tests/test_configure_noop.py`) both assert `flops.configure(...)` emits `ConfigureNoOpWarning`; the ~40 internal configure-tests stay green via the `filterwarnings` ignore.
- [x] Full core suite green (0 failed / 0 errored); `scripts/sync_client.py --check` in sync; `ruff check`/`format` clean; `pyright src/flopscope tests` at the pre-existing baseline (no new errors).
- [x] Reviewed: per-task spec + code-quality reviews and a final whole-feature review (stacklevel, hot-path cost, encode-time error path, and serialization heuristic all verified empirically).
