### PR TITLE
ci: enforce uv.lock freshness and refresh the lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,29 @@ jobs:
       - name: Conventional commits (gitlint)
         run: gitlint --commits origin/main..HEAD
 
+  lockfiles:
+    name: uv lockfiles up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # Validates the *committed* lockfiles as-is. Deliberately runs only
+      # `uv lock --check` and never `uv sync`: a plain `uv sync` silently
+      # refreshes a stale lock in the checkout and would mask the drift —
+      # which is exactly how all three locks fell a release behind unnoticed.
+      - name: Check uv lockfiles are up to date
+        run: |
+          uv lock --check
+          uv lock --check --directory flopscope-server
+          uv lock --check --directory flopscope-client
+
   typecheck:
     name: Pyright
     runs-on: ubuntu-latest
@@ -362,6 +385,7 @@ jobs:
     if: always()
     needs:
       - lint
+      - lockfiles
       - typecheck
       - test
       - numpy-compat

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ UV    := uv run
 # Composite targets
 # ---------------------------------------------------------------------------
 .PHONY: ci
-ci: lint lint-commits typecheck test test-numpy-compat check-sync check-sync-versions docs-build  ## Run the full CI pipeline locally
+ci: lint check-lock lint-commits typecheck test test-numpy-compat check-sync check-sync-versions docs-build  ## Run the full CI pipeline locally
 
 # ---------------------------------------------------------------------------
 # Lint  (mirrors: CI → lint job)
@@ -90,6 +90,21 @@ check-sync:  ## Verify client is in sync with core library
 .PHONY: check-sync-versions
 check-sync-versions:  ## Verify all package versions are in lockstep
 	$(UV) python scripts/check_version_sync.py
+
+# Note: bare `uv lock --check` (NOT `$(UV)` = `uv run`, and NOT `uv sync`).
+# `uv sync` would silently refresh a stale lock instead of failing — which is
+# how the lockfiles drifted a release behind unnoticed. `--check` only reports.
+.PHONY: check-lock
+check-lock:  ## Verify all three uv.lock files are in sync with their pyproject.toml
+	uv lock --check
+	uv lock --check --directory flopscope-server
+	uv lock --check --directory flopscope-client
+
+.PHONY: relock
+relock:  ## Refresh all three uv.lock files (run after a version bump; fixes check-lock)
+	uv lock
+	uv lock --directory flopscope-server
+	uv lock --directory flopscope-client
 
 .PHONY: sync-client
 sync-client:  ## Regenerate client files from core library

--- a/flopscope-client/uv.lock
+++ b/flopscope-client/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "flopscope-client"
-version = "0.3.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "msgpack" },

--- a/flopscope-server/uv.lock
+++ b/flopscope-server/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "flopscope"
-version = "0.3.0"
+version = "0.7.0"
 source = { editable = "../" }
 dependencies = [
     { name = "numpy" },
@@ -143,7 +143,7 @@ dev = [
 
 [[package]]
 name = "flopscope-server"
-version = "0.3.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "flopscope" },

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "flopscope"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -539,7 +539,7 @@ dev = [
 
 [[package]]
 name = "flopscope-server"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "flopscope-server" }
 dependencies = [
     { name = "flopscope" },


### PR DESCRIPTION
## What

Adds CI enforcement that the `uv.lock` files stay in sync with their `pyproject.toml`, and refreshes the three lockfiles (root, `flopscope-server`, `flopscope-client`) to the current version.

## Why

The lockfiles had drifted behind the package version — `uv.lock` recorded an older version than `pyproject.toml` — and nothing verified lockfile freshness, so it went unnoticed across releases. Published wheels were unaffected (they are built from `pyproject.toml`, not the lockfile); this is purely dev/CI hygiene.

## Changes

- New `lockfiles` CI job runs `uv lock --check` on all three lockfiles. It deliberately does **not** run `uv sync`, which would silently refresh a stale lock and mask the drift.
- `make check-lock` mirrors the check locally (and runs as part of `make ci`).
- `make relock` refreshes all three lockfiles in one command.
- Refreshed the three lockfiles.

## Notes

- No version bump — there are no published-package changes.
- After a future version bump, run `make relock` and commit so the `lockfiles` check stays green.

## Verification

- `make check-lock` passes on the synced lockfiles and fails (as intended) when any lockfile is out of sync with its `pyproject.toml`.
- CI YAML validated; the new job runs `uv lock --check` only.