### PR TITLE
fix(client): don't bill flops.load ingress and transport as residual

### DIFF
--- a/flopscope-client/src/flopscope/_connection.py
+++ b/flopscope-client/src/flopscope/_connection.py
@@ -7,6 +7,7 @@ import time
 
 import zmq
 
+from flopscope._dispatch import dispatch_span
 from flopscope._protocol import decode_response
 from flopscope.errors import raise_from_response
 
@@ -121,33 +122,34 @@ class Connection:
         """
         from flopscope.errors import FlopscopeServerError
 
-        sock = self._ensure_connected()
-        self._ensure_handshaked()
+        with dispatch_span():
+            sock = self._ensure_connected()
+            self._ensure_handshaked()
 
-        t0 = time.monotonic_ns()
-        try:
-            sock.send(raw_request)
-            raw_response: bytes = sock.recv()
-        except zmq.Again as err:
-            # Socket is in a bad state after timeout — reset it
-            self._reset_socket()
-            raise FlopscopeServerError(
-                "server timeout: no response within timeout period"
-            ) from err
-        t1 = time.monotonic_ns()
+            t0 = time.monotonic_ns()
+            try:
+                sock.send(raw_request)
+                raw_response: bytes = sock.recv()
+            except zmq.Again as err:
+                # Socket is in a bad state after timeout — reset it
+                self._reset_socket()
+                raise FlopscopeServerError(
+                    "server timeout: no response within timeout period"
+                ) from err
+            t1 = time.monotonic_ns()
 
-        response = decode_response(raw_response)
-        response["_round_trip_ns"] = t1 - t0
-        response["_request_bytes"] = len(raw_request)
-        response["_response_bytes"] = len(raw_response)
+            response = decode_response(raw_response)
+            response["_round_trip_ns"] = t1 - t0
+            response["_request_bytes"] = len(raw_request)
+            response["_response_bytes"] = len(raw_response)
 
-        if response.get("status") == "error":
-            raise_from_response(
-                response.get("error_type", "FlopscopeServerError"),
-                response.get("message", ""),
-            )
+            if response.get("status") == "error":
+                raise_from_response(
+                    response.get("error_type", "FlopscopeServerError"),
+                    response.get("message", ""),
+                )
 
-        return response
+            return response
 
     def _reset_socket(self) -> None:
         """Close and discard the socket so it will be recreated on next use."""

--- a/flopscope-client/src/flopscope/_io.py
+++ b/flopscope-client/src/flopscope/_io.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from flopscope import _codec
 from flopscope._connection import get_connection
+from flopscope._dispatch import timed_dispatch
 from flopscope._protocol import encode_create_from_data
 from flopscope._remote_array import (
     _DTYPE_INFO,
@@ -19,6 +20,7 @@ from flopscope._remote_array import (
 _META_KEY = "__meta__"
 
 
+@timed_dispatch
 def _ingest(dtype: str, shape: tuple, buffer: bytes) -> RemoteArray:
     conn = get_connection()
     resp = conn.send_recv(encode_create_from_data(buffer, list(shape), dtype))
@@ -49,6 +51,7 @@ def _as_triple(val: Any) -> tuple[str, tuple, bytes]:
     return dtype, shape, struct.pack(f"<{len(flat)}{fmt}", *[float(x) for x in flat])
 
 
+@timed_dispatch
 def load(file: str) -> Any:
     """Load .npy/.npz. Returns a RemoteArray, or {name: RemoteArray, __meta__}."""
     with open(file, "rb") as fh:
@@ -65,6 +68,8 @@ def load(file: str) -> Any:
     return _ingest(dtype, shape, data)
 
 
+# Overhead attribution: absorb local codec encode + any _fetch_data egress.
+@timed_dispatch
 def save(file: str, arr: Any) -> None:
     dtype, shape, buf = _as_triple(arr)
     with open(file, "wb") as fh:
@@ -85,9 +90,11 @@ def _write_npz(file: str, arrays: dict, compressed: bool) -> None:
         fh.write(blob)
 
 
+@timed_dispatch
 def savez(file: str, **arrays: Any) -> None:
     _write_npz(file, arrays, compressed=False)
 
 
+@timed_dispatch
 def savez_compressed(file: str, **arrays: Any) -> None:
     _write_npz(file, arrays, compressed=True)

--- a/flopscope-client/tests/test_budget_timing_integration.py
+++ b/flopscope-client/tests/test_budget_timing_integration.py
@@ -16,6 +16,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 
 import pytest
@@ -224,6 +225,10 @@ def test_every_op_family_increments_dispatch():
         _grew(lambda: fl.stats.norm.pdf(fl.ones((4,))))  # stats _DistributionProxy.pdf
         _grew(lambda: fl.array([1.0, 2.0, 3.0]))  # array() special-case
         _grew(lambda: fl.einsum("ij,jk->ik", a, b))  # einsum() special-case
+        with tempfile.TemporaryDirectory() as _tmpdir:
+            npy_path = os.path.join(_tmpdir, "state.npy")
+            _grew(lambda: fl.save(npy_path, a))  # save: _fetch_data egress + local write
+            _grew(lambda: fl.load(npy_path))  # load: local parse + create_from_data ingress
         # fl.flops.einsum_cost / fl.flops.svd_cost are @timed_dispatch but send
         # "flops.einsum_cost" / "flops.svd_cost" to the server — neither op is
         # in the server whitelist (flopscope._registry.REGISTRY has no "flops.*"
@@ -272,3 +277,23 @@ def test_flops_used_refreshed_on_close_without_summary():
 
     # ~2M FLOPs per 128³ matmul × 5 ⇒ ~10M server-side; was exactly 0 pre-fix.
     assert ctx.flops_used > 1_000_000, "flops_used not refreshed from server on close"
+
+
+def test_connection_setup_is_overhead_not_residual():
+    """First-op connection setup + version handshake must land in overhead, not
+    the participant's billed residual. Locks the absorption Layer 1 guarantees."""
+    import flopscope as fl
+    from flopscope._connection import reset_connection
+
+    # The _reset_client autouse fixture already clears the connection; this is left
+    # explicit so the intent (cold connect+handshake inside the context) is obvious.
+    reset_connection()
+    with fl.BudgetContext(flop_budget=10**12) as ctx:
+        a = fl.ones((8, 8))  # first op triggers lazy connect + handshake
+        _ = fl.dot(a, a)
+
+    assert ctx.flopscope_overhead_time_s > 0
+    # residual is pure inter-op Python; connect+handshake+ops all run inside a
+    # dispatch_span, so no round-trip time lands here. Bound matches the loosest
+    # stable sibling (test_worker_tolist_not_billed).
+    assert ctx.residual_wall_time_s < 0.05

--- a/flopscope-client/tests/test_budget_timing_integration.py
+++ b/flopscope-client/tests/test_budget_timing_integration.py
@@ -227,8 +227,12 @@ def test_every_op_family_increments_dispatch():
         _grew(lambda: fl.einsum("ij,jk->ik", a, b))  # einsum() special-case
         with tempfile.TemporaryDirectory() as _tmpdir:
             npy_path = os.path.join(_tmpdir, "state.npy")
-            _grew(lambda: fl.save(npy_path, a))  # save: _fetch_data egress + local write
-            _grew(lambda: fl.load(npy_path))  # load: local parse + create_from_data ingress
+            _grew(
+                lambda: fl.save(npy_path, a)
+            )  # save: _fetch_data egress + local write
+            _grew(
+                lambda: fl.load(npy_path)
+            )  # load: local parse + create_from_data ingress
         # fl.flops.einsum_cost / fl.flops.svd_cost are @timed_dispatch but send
         # "flops.einsum_cost" / "flops.svd_cost" to the server — neither op is
         # in the server whitelist (flopscope._registry.REGISTRY has no "flops.*"
@@ -282,8 +286,9 @@ def test_flops_used_refreshed_on_close_without_summary():
 def test_connection_setup_is_overhead_not_residual():
     """First-op connection setup + version handshake must land in overhead, not
     the participant's billed residual. Locks the absorption Layer 1 guarantees."""
-    import flopscope as fl
     from flopscope._connection import reset_connection
+
+    import flopscope as fl
 
     # The _reset_client autouse fixture already clears the connection; this is left
     # explicit so the intent (cold connect+handshake inside the context) is obvious.

--- a/flopscope-client/tests/test_io_dispatch_attribution.py
+++ b/flopscope-client/tests/test_io_dispatch_attribution.py
@@ -54,3 +54,38 @@ def test_array_ingress_is_dispatch_not_residual(monkeypatch):
     grew = dispatch.total_dispatch_ns() - before
 
     assert grew >= _DELAY * 1e9 * 0.5
+
+
+def test_send_recv_self_times_transport_as_dispatch(monkeypatch):
+    """Connection.send_recv must attribute its own transport to dispatch, so even
+    an UNDECORATED caller never bills the round-trip to residual (structural floor)."""
+    import msgpack
+
+    from flopscope._connection import Connection
+
+    ok = msgpack.packb(
+        {"status": "ok", "result": {"id": "a0", "shape": [2, 2], "dtype": "float64"}},
+        use_bin_type=True,
+    )
+
+    class _FakeSock:
+        def send(self, data):  # noqa: ARG002
+            pass
+
+        def recv(self):
+            time.sleep(_DELAY)
+            return ok
+
+    conn = Connection()
+    monkeypatch.setattr(conn, "_ensure_connected", lambda: _FakeSock())
+    monkeypatch.setattr(conn, "_ensure_handshaked", lambda: None)
+
+    dispatch.reset_dispatch()
+    before = dispatch.total_dispatch_ns()
+    resp = conn.send_recv(b"ignored-request")
+    grew = dispatch.total_dispatch_ns() - before
+
+    assert resp["result"]["id"] == "a0"
+    assert grew >= _DELAY * 1e9 * 0.5, (
+        "send_recv transport not self-timed into dispatch"
+    )

--- a/flopscope-client/tests/test_io_dispatch_attribution.py
+++ b/flopscope-client/tests/test_io_dispatch_attribution.py
@@ -1,0 +1,56 @@
+"""Unit tests (server-free) for client/server boundary timing attribution.
+
+Billing rule: residual = wall − dispatch (only residual is billed). A round-trip
+that grows `total_dispatch_ns` is absorbed into overhead and NOT billed. These
+tests inject fakes so they need no server (and no numpy — the client is numpy-free).
+"""
+
+import struct
+import time
+
+import flopscope as fnp
+import flopscope._connection as conn_mod
+import flopscope._dispatch as dispatch
+from flopscope import _codec
+
+_DELAY = 0.03  # 30 ms simulated transfer/compute per round-trip
+
+
+class _FakeConn:
+    """Replaces the connection singleton; every round-trip costs _DELAY and
+    returns a valid stored-array-handle response."""
+
+    def send_recv(self, raw):  # noqa: ARG002 - request body irrelevant to the fake
+        time.sleep(_DELAY)
+        return {"result": {"id": "a0", "shape": [8, 8], "dtype": "float64"}}
+
+
+def test_load_ingress_is_dispatch_not_residual(tmp_path, monkeypatch):
+    """flops.load must bill its parse + transfer to dispatch/overhead, not the
+    participant's residual. Regression for the _io send_recv-outside-span leak."""
+    monkeypatch.setattr(conn_mod, "_connection", _FakeConn())
+
+    flat = [float(i) for i in range(64)]
+    npy = tmp_path / "w.npy"
+    npy.write_bytes(_codec.write_npy("float64", (8, 8), struct.pack("<64d", *flat)))
+
+    dispatch.reset_dispatch()
+    before = dispatch.total_dispatch_ns()
+    fnp.load(str(npy))
+    grew = dispatch.total_dispatch_ns() - before
+
+    assert grew >= _DELAY * 1e9 * 0.5, (
+        "load() ingress not attributed to dispatch — it leaks into billed residual"
+    )
+
+
+def test_array_ingress_is_dispatch_not_residual(monkeypatch):
+    """Control: fnp.array(list) already attributes its ingress to dispatch."""
+    monkeypatch.setattr(conn_mod, "_connection", _FakeConn())
+
+    dispatch.reset_dispatch()
+    before = dispatch.total_dispatch_ns()
+    fnp.array([[float(i) for i in range(8)] for _ in range(8)])
+    grew = dispatch.total_dispatch_ns() - before
+
+    assert grew >= _DELAY * 1e9 * 0.5

--- a/flopscope-client/tests/test_io_dispatch_attribution.py
+++ b/flopscope-client/tests/test_io_dispatch_attribution.py
@@ -8,9 +8,10 @@ tests inject fakes so they need no server (and no numpy — the client is numpy-
 import struct
 import time
 
-import flopscope as fnp
 import flopscope._connection as conn_mod
 import flopscope._dispatch as dispatch
+
+import flopscope as fnp
 from flopscope import _codec
 
 _DELAY = 0.03  # 30 ms simulated transfer/compute per round-trip
@@ -60,7 +61,6 @@ def test_send_recv_self_times_transport_as_dispatch(monkeypatch):
     """Connection.send_recv must attribute its own transport to dispatch, so even
     an UNDECORATED caller never bills the round-trip to residual (structural floor)."""
     import msgpack
-
     from flopscope._connection import Connection
 
     ok = msgpack.packb(

--- a/flopscope-client/tests/test_no_bare_send_recv_outside_span.py
+++ b/flopscope-client/tests/test_no_bare_send_recv_outside_span.py
@@ -1,0 +1,111 @@
+"""Regression guard: every `send_recv` call site in the client must sit inside a
+dispatch span, so its transport + local marshaling is attributed to flopscope
+overhead (dispatch) and never billed to the participant's residual.
+
+A `<expr>.send_recv(...)` call is "span-covered" when ANY of:
+  1. its nearest enclosing function is decorated `@timed_dispatch`, OR
+  2. the call is lexically inside a `with dispatch_span():` block, OR
+  3. its nearest enclosing function is wrapped via `timed_dispatch(<fn>)` in the
+     same module (the `return timed_dispatch(proxy)` factory pattern).
+
+Sibling of tests/test_no_bare_numpy_in_counted_ops.py in the core package — same
+AST-guard idea, applied to the client/server boundary instead of in-process numpy.
+"""
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "flopscope"
+
+
+def _attach_parents(tree: ast.AST) -> None:
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            child._parent = node  # type: ignore[attr-defined]
+
+
+def _is_timed_dispatch_decorated(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for d in fn.decorator_list:
+        if isinstance(d, ast.Name) and d.id == "timed_dispatch":
+            return True
+        if isinstance(d, ast.Attribute) and d.attr == "timed_dispatch":
+            return True
+    return False
+
+
+# NOTE: file-scoped (not closure-scoped). If one file ever had two different
+# inner functions sharing a name where only one is wrapped, both would pass.
+# Fine for the current codebase, where each file uses the name exactly once.
+def _timed_dispatch_wrapped_names(tree: ast.AST) -> set:
+    """Names X appearing as `timed_dispatch(X)` — the proxy-factory pattern."""
+    names = set()
+    for n in ast.walk(tree):
+        if (
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "timed_dispatch"
+            and n.args
+            and isinstance(n.args[0], ast.Name)
+        ):
+            names.add(n.args[0].id)
+    return names
+
+
+def _is_dispatch_span_with(node: ast.AST) -> bool:
+    if not isinstance(node, ast.With):
+        return False
+    for item in node.items:
+        ctx = item.context_expr
+        if isinstance(ctx, ast.Call):
+            f = ctx.func
+            if isinstance(f, ast.Name) and f.id == "dispatch_span":
+                return True
+            if isinstance(f, ast.Attribute) and f.attr == "dispatch_span":
+                return True
+    return False
+
+
+def _ancestors(node: ast.AST):
+    cur = getattr(node, "_parent", None)
+    while cur is not None:
+        yield cur
+        cur = getattr(cur, "_parent", None)
+
+
+def _send_recv_calls(tree: ast.AST):
+    for n in ast.walk(tree):
+        if (
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "send_recv"
+        ):
+            yield n
+
+
+def test_no_bare_send_recv_outside_dispatch_span():
+    offenders = []
+    for path in sorted(_SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        _attach_parents(tree)
+        wrapped = _timed_dispatch_wrapped_names(tree)
+        for call in _send_recv_calls(tree):
+            covered = False
+            enclosing = None
+            for anc in _ancestors(call):
+                if _is_dispatch_span_with(anc):
+                    covered = True
+                    break
+                if isinstance(anc, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    enclosing = anc
+                    covered = _is_timed_dispatch_decorated(anc) or anc.name in wrapped
+                    break
+            if not covered:
+                rel = path.relative_to(_SRC.parent.parent)
+                where = enclosing.name if enclosing else "<module>"
+                offenders.append(f"{rel}:{call.lineno} in {where}()")
+    assert not offenders, (
+        "send_recv() call(s) outside a dispatch span — their wall time leaks "
+        "into the participant's billed residual. Decorate the enclosing function "
+        "with @timed_dispatch, or wrap the call in `with dispatch_span():`.\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary

`flops.load` / `Module.load` / `Module.from_file` shipped a freshly-loaded array buffer to the server through the one `send_recv` call site in the client that was **not** inside a dispatch span. As a result, the transfer *and* the local `.npy`/`.npz` codec parse were billed to the participant's `residual_wall_time_s` (the scored bucket: `C_m = flops_used + λ·residual`) instead of flopscope's unbilled overhead. The cost scaled with array size (e.g. large weights loaded in `setup()`), and a load that hit the 30s socket timeout billed the full 30s.

This closes the leak on two axes and guards it:

- **`_io` ingress → overhead.** `load`/`_ingest`/`save`/`savez`/`savez_compressed` are now timed into the dispatch accumulator, so their transfer + local codec work counts as overhead — consistent with how `array()`/`einsum()` already treat their local marshaling.
- **Transport floor in `Connection.send_recv`.** The whole round-trip (lazy connect, version handshake, send/recv, decode, and the timeout/error paths) is self-timed into dispatch, so no caller — current or future — can leak transport into residual. Nested spans are de-duplicated by the existing baseline/delta accounting, so there is no double-counting.
- **Regression guard.** A new AST test fails if any `send_recv` call site is reintroduced outside a dispatch span (sibling of the in-process `test_no_bare_numpy_in_counted_ops` guard).

`residual = wall − dispatch` is unchanged; this only moves framework dispatch/transport time from the billed bucket into overhead. No change to FLOP costs, and no change to the in-process backend. Client-only.

## Test plan

- [x] Server-free unit tests: `flops.load` and a bare `Connection.send_recv` each grow the dispatch accumulator (both failed before this change); the `array()` control was already correct.
- [x] AST guard passes on the fixed tree and fails on a reintroduced bare `send_recv`.
- [x] Integration (real server): `test_every_op_family_increments_dispatch` extended with `save`/`load`; new test locks first-op connect+handshake into overhead, not residual.
- [x] Full `flopscope-client` suite: 904 passed, 3 skipped, 3 xfailed.
- [x] `scripts/sync_client.py --check` clean; in-process guard unaffected.
