### PR TITLE
feat(client): make array immutability self-explanatory and documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ flops.budget_summary()  # 6,231,041 FLOPs
 
 Blocked operations (I/O, config, and system calls) raise a helpful `AttributeError` with a link to the docs.
 
+flopscope arrays are **immutable** (like JAX): item assignment such as `arr[i] = ...` or `arr[i] += ...` raises `TypeError`. Build results functionally instead — collect the pieces and `fnp.stack(...)` them, or use a whole-array update (`arr = arr + x`). See the [Immutable arrays](https://aicrowd.github.io/flopscope/docs/getting-started/competition/#immutable-arrays) guide.
+
 ## Quick Start
 
 ### Installation

--- a/examples/12_save_load_mlp.py
+++ b/examples/12_save_load_mlp.py
@@ -51,4 +51,15 @@ with flops.BudgetContext(flop_budget=10_000_000) as budget:
     after = restored(x)
     print("restored sizes:", restored.sizes)
     print("outputs identical after save/load:", before.tolist() == after.tolist())
+
+    # Accumulating across inputs: flopscope arrays are immutable, so in-place
+    # item assignment is not supported --
+    #   totals[i] += restored(xi)   # TypeError: flopscope arrays are immutable
+    # Collect per-step results in a Python list and fnp.stack(...) them once;
+    # whole-array ops (sum, divide) are fine.
+    batch = [fnp.random.randn(8) for _ in range(4)]
+    stacked = fnp.stack([restored(xi) for xi in batch])  # (4, 4) immutable array
+    mean_out = fnp.sum(stacked, axis=0) / len(batch)
+    print("mean output over batch:", mean_out.tolist())
+
     print(budget.summary())

--- a/flopscope-client/README.md
+++ b/flopscope-client/README.md
@@ -48,6 +48,17 @@ with flops.BudgetContext(flop_budget=1_000_000):
 
 On the first request, the client performs a version handshake with the server. A version mismatch raises `ConnectionError` with both versions in the error message — keep `flopscope-server` and `flopscope-client` on the same release.
 
+## Differences from NumPy
+
+The API mirrors NumPy, with one semantic difference worth knowing up front: **flopscope arrays are immutable** (like [JAX](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html#in-place-updates)). Item assignment and indexed in-place updates raise `TypeError`:
+
+```python
+arr[i] = value      # TypeError: flopscope arrays are immutable
+arr[i] += value     # same error — desugars to arr[i] = arr[i] + value
+```
+
+Build results functionally instead — collect the pieces in a list and `fnp.stack(...)` them, or use a whole-array update (`arr = arr + x`, which rebinds rather than mutates). See the [Immutable arrays](https://aicrowd.github.io/flopscope/docs/getting-started/competition/#immutable-arrays) guide for the accumulation recipe.
+
 ## When to choose this over the main `flopscope` install
 
 | Scenario | Install |

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -460,7 +460,12 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
 
     def __setitem__(self, key, value):
         raise TypeError(
-            "flopscope arrays are immutable. Cannot assign to array elements."
+            "flopscope arrays are immutable, so item assignment (arr[i] = ...) "
+            "and indexed in-place updates (arr[i] += ...) are not supported. "
+            "Build the result functionally instead: collect the pieces in a "
+            "list and combine them with fnp.stack(...) / fnp.concatenate(...), "
+            "or use a whole-array update (arr = arr + x). See "
+            "https://aicrowd.github.io/flopscope/docs/getting-started/competition/#immutable-arrays"
         )
 
     # -- operator overloads (dispatch to server) ----------------------------

--- a/flopscope-client/tests/test_bugfixes_round3.py
+++ b/flopscope-client/tests/test_bugfixes_round3.py
@@ -456,6 +456,24 @@ class TestFix6SetitemError:
         with pytest.raises(TypeError, match="immutable"):
             arr[0:2] = [1, 2]
 
+    def test_setitem_error_is_actionable(self):
+        """The immutable error must tell participants HOW to fix it.
+
+        A sandboxed participant only ever sees this as a traceback, so the
+        message must carry problem + cause + fix + docs link (the Elm/Rust
+        three-tier model) rather than a dead end. Guards against regressing
+        back to a bare "cannot assign" message.
+        """
+        from flopscope._remote_array import RemoteArray
+
+        arr = RemoteArray(handle_id="a0", shape=(3,), dtype="float64")
+        with pytest.raises(TypeError) as exc:
+            arr[0] = 5
+        msg = str(exc.value)
+        assert "immutable" in msg  # names the cause
+        assert "fnp.stack" in msg  # points to the functional alternative
+        assert "http" in msg  # links to the docs
+
 
 # =========================================================================
 # Fix 8: ZMQ socket reset after timeout

--- a/website/content/docs/getting-started/competition.mdx
+++ b/website/content/docs/getting-started/competition.mdx
@@ -164,6 +164,39 @@ in submitted code. Likewise, passing a non-serializable argument (a generator,
 lambda, or custom object) to any op raises `RemoteSerializationError` remotely —
 pass materialized arrays or built-ins instead.
 
+## Immutable arrays
+
+flopscope arrays are **immutable**, like [JAX](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html#in-place-updates) arrays. Item assignment and indexed in-place updates raise `TypeError`:
+
+```python
+layer_sums[i] = value      # TypeError: flopscope arrays are immutable
+layer_sums[i] += value     # same error — see why below
+```
+
+The `+=` is a red herring: `layer_sums[i] += value` desugars to
+`layer_sums[i] = layer_sums[i] + value`, so it is the *indexed assignment* that
+fails, not the addition. Whole-array `+=` (no index on the left) is fine.
+
+Build results functionally instead. Collect the pieces and stack them once:
+
+```python
+sums = []
+for x in batches:
+    sums.append(fnp.sum(fnp.asarray(x, dtype=fnp.float64), axis=0))
+layer_sums = fnp.stack(sums)          # one immutable array, fully counted
+```
+
+...or keep a running total with a whole-array update:
+
+```python
+layer_total = layer_total + fnp.sum(...)   # rebinds the name; no index on the left
+```
+
+This is also a local-vs-remote difference: the in-process `flopscope` backend is
+a NumPy subclass and currently tolerates `arr[i] = ...`, but the remote backend
+AIcrowd grades on rejects it. Write the functional form so local runs and graded
+runs behave identically.
+
 ## When things go wrong
 
 If you hit `BudgetExhaustedError`, see [Budget Planning & Debugging](/docs/guides/budget-planning) for a systematic approach to diagnosing overruns and reducing costs.


### PR DESCRIPTION
## What

flopscope arrays are immutable, but participants only discovered this through a bare `TypeError: ... cannot assign to array elements` traceback, and the constraint was undocumented in every onboarding surface. This PR makes the failure self-explanatory and documents the constraint. **No semantics change.**

## Why

The participant-facing failure was:

```
TypeError: flopscope arrays are immutable. Cannot assign to array elements.
```

triggered by `layer_sums[i] += ...` (which desugars to `layer_sums[i] = layer_sums[i] + ...`, so the *indexed assignment* is what fails, not the `+=`). Two things compounded it:

1. The error stated the problem but not the fix — a dead-end traceback for sandboxed participants.
2. The in-process reference backend (`flopscope`, a `numpy.ndarray` subclass) **tolerates** `arr[i] = ...`, while the eval client (`flopscope-client`) rejects it. So mutating code passes in local dev and fails only in remote grading, intermittently, depending on code path. This is the same local-vs-remote class as the already-documented callback ops.

## Changes (no behavior change)

- **Actionable error** — `flopscope-client/src/flopscope/_remote_array.py`: the `__setitem__` message now carries problem + cause + fix + docs link (collect + `fnp.stack`, or whole-array `arr = arr + x`). Pinned by a new test, `test_setitem_error_is_actionable`.
- **Docs** — `website/content/docs/getting-started/competition.mdx`: new "Immutable arrays" section beside the existing local-vs-remote gotcha, with the accumulation recipe and the `+=` desugaring explanation.
- **READMEs** — "Differences from NumPy" note in the main and client READMEs (which previously advertised "identical API" / "drop-in" with no caveat).
- **Example** — `examples/12_save_load_mlp.py`: demonstrates immutable accumulation (the participant's exact scenario).

## Verification

- `cd flopscope-client && uv run pytest tests/test_bugfixes_round3.py` → 56 passed (incl. the new actionable-message test).
- Adversarial `match="immutable"` assertion still satisfied (message still contains "immutable").
- `ruff check .` + `ruff format --check .` clean; `gitlint` clean.
- `uv run python examples/12_save_load_mlp.py` runs to completion (exit 0).

## Deferred follow-ups

- Make the in-process reference also reject `arr[i] = ...` so local dev fails fast and identically (removes the divergence at the source).
- A blessed functional scatter helper (`fnp.at_add`, JAX `.at[].add` style) for participants who genuinely need indexed accumulation.
