### PR TITLE
fix(release): prerelease-robust version-sync + client/server handshake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,10 @@ jobs:
           uv sync --all-extras
           cd flopscope-server && uv sync
 
+      - name: Run server version-handshake tests
+        run: |
+          cd flopscope-server && uv run pytest tests/test_version_handshake.py -v --tb=short
+
       - name: Run full client test suite
         run: |
           cd flopscope-client && uv run pytest tests/ -v --tb=short

--- a/flopscope-client/tests/test_version_handshake.py
+++ b/flopscope-client/tests/test_version_handshake.py
@@ -104,3 +104,25 @@ def test_send_recv_triggers_handshake_first():
     # Order matters: hello first, then the real op.
     assert msgpack.unpackb(sock.sent[0], raw=False)["op"] == "hello"
     assert msgpack.unpackb(sock.sent[1], raw=False)["op"] == "budget_status"
+
+
+def test_handshake_sends_stripped_prerelease_version(monkeypatch):
+    """The client sends its +local-stripped PUBLIC version (rc kept) in the hello.
+
+    A prerelease like 0.8.0rc0 carrying a dynamic +local build tag must be sent
+    as "0.8.0rc0" so it string-matches the server's stripped version — the rc
+    suffix is preserved, only the +local segment is dropped.
+    """
+    import flopscope
+
+    monkeypatch.setattr(flopscope, "__version__", "0.8.0rc0+np9.9")
+    server_ok = msgpack.packb(
+        {"status": "ok", "server_version": "0.8.0rc0"}, use_bin_type=True
+    )
+    sock = _FakeSocket([server_ok])
+    conn = _make_connection(sock)
+
+    conn._ensure_handshaked()
+    assert conn._handshake_done is True
+    hello = msgpack.unpackb(sock.sent[0], raw=False)
+    assert hello["kwargs"]["client_version"] == "0.8.0rc0"

--- a/flopscope-server/tests/test_version_handshake.py
+++ b/flopscope-server/tests/test_version_handshake.py
@@ -90,3 +90,35 @@ def test_hello_works_before_budget_open():
     assert decoded["server_version"] == client_version
     # And no session was opened as a side effect.
     assert server._session is None
+
+
+def test_handle_hello_prerelease_version_uses_string_compare(monkeypatch):
+    """A prerelease server version (e.g. 0.8.0rc0) is matched by full public version.
+
+    Guards that the handshake string-compares the +local-stripped version and
+    never int-parses X.Y.Z (which would raise on the `rc` suffix), and that the
+    full prerelease is significant: rc0 vs rc1 (and rc0 vs the final release) is
+    a genuine mismatch, not a same-core match.
+    """
+    monkeypatch.setattr(flopscope, "__version__", "0.8.0rc0+np9.9")
+    server = FlopscopeServer.__new__(FlopscopeServer)
+    server._session = None
+    server._handler = None
+    server._last_activity = 0.0
+
+    # Same public prerelease → ok; the +np9.9 local segment is stripped server-side.
+    ok = msgpack.unpackb(
+        server._handle_hello({"op": "hello", "kwargs": {"client_version": "0.8.0rc0"}}),
+        raw=False,
+    )
+    assert ok["status"] == "ok"
+    assert ok["server_version"] == "0.8.0rc0"
+
+    # rc0 vs rc1 and rc0 vs the final release must both be VersionMismatch.
+    for other in ("0.8.0rc1", "0.8.0"):
+        err = msgpack.unpackb(
+            server._handle_hello({"op": "hello", "kwargs": {"client_version": other}}),
+            raw=False,
+        )
+        assert err["status"] == "error", other
+        assert err["error_type"] == "VersionMismatch", other

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -7,7 +7,7 @@ Run from the repo root:
 Exits 0 if all eight version locations agree, 1 otherwise:
   - pyproject.toml [project].version            (root)
   - pyproject.toml [server] extra -> "flopscope-server==X.Y.Z"
-  - src/flopscope/__init__.py __version__       (leading X.Y.Z only)
+  - src/flopscope/__init__.py __version__       (full version)
   - flopscope-server/pyproject.toml version
   - flopscope-server/src/flopscope_server/__init__.py __version__
   - flopscope-server/pyproject.toml dependencies -> "flopscope==X.Y.Z"
@@ -22,16 +22,24 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-_VERSION_RE = re.compile(r'__version__\s*=\s*f?"([0-9]+\.[0-9]+\.[0-9]+)')
-_CROSS_PIN_RE = re.compile(r'"flopscope==([0-9]+\.[0-9]+\.[0-9]+)"')
-_SERVER_EXTRA_RE = re.compile(r'"flopscope-server==([0-9]+\.[0-9]+\.[0-9]+)"')
-# Matches the `version = "X.Y.Z"` line under `[project]` in pyproject.toml.
+# The PEP 440 *public* version: core X.Y.Z plus an optional prerelease/post/dev
+# segment, e.g. "0.8.0", "0.8.0rc0", "0.8.0rc1", "0.8.0.post1". The trailing
+# class deliberately EXCLUDES `+`, so a local segment is ignored: src/flopscope/
+# __init__.py carries a dynamic `f"0.7.0+np{_np.__version__}"` local version, and
+# lockstep is about the public version, not the per-environment numpy build.
+# `cz bump --prerelease rc` writes the same public version to every location, so
+# we capture and compare the full public version (incl. the rc suffix): rc0 vs
+# rc1 across packages is real drift, but `0.7.0` vs `0.7.0+np2.2` is not.
+_VER = r"[0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.]*"
+
+_VERSION_RE = re.compile(rf'__version__\s*=\s*f?"({_VER})')
+_CROSS_PIN_RE = re.compile(rf'"flopscope==({_VER})"')
+_SERVER_EXTRA_RE = re.compile(rf'"flopscope-server==({_VER})"')
+# Matches the `version = "X.Y.Z[suffix]"` line under `[project]` in pyproject.toml.
 # Anchored at line start to skip the `requires-python = "..."` line and the
 # dependency lines below. The flopscope project keeps a single top-level
 # `version = ...` in each pyproject.toml; we don't try to be a full TOML parser.
-_PYPROJECT_VERSION_RE = re.compile(
-    r'^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"', re.MULTILINE
-)
+_PYPROJECT_VERSION_RE = re.compile(rf'^version\s*=\s*"({_VER})"', re.MULTILINE)
 
 
 def _read_pyproject_version(path: Path) -> str:
@@ -49,7 +57,7 @@ def _read_pyproject_version(path: Path) -> str:
 
 
 def _read_init_version(path: Path) -> str:
-    """Extract leading X.Y.Z from an __version__ assignment, ignoring +suffix."""
+    """Extract the full version (incl. any PEP 440 prerelease suffix) from __version__."""
     text = path.read_text()
     m = _VERSION_RE.search(text)
     if m is None:

--- a/tests/test_check_version_sync.py
+++ b/tests/test_check_version_sync.py
@@ -155,3 +155,57 @@ def test_server_extra_pin_drift_detected(repo_copy: Path):
     )
     result = _run(repo_copy)
     assert result.returncode != 0
+
+
+_ALL_VERSION_FILES = [
+    "pyproject.toml",
+    "src/flopscope/__init__.py",
+    "flopscope-server/pyproject.toml",
+    "flopscope-server/src/flopscope_server/__init__.py",
+    "flopscope-client/pyproject.toml",
+    "flopscope-client/src/flopscope/__init__.py",
+]
+
+
+def _rewrite_all_versions(repo: Path, old: str, new: str) -> None:
+    """Replace every occurrence of `old` with `new` across all version files."""
+    for rel in _ALL_VERSION_FILES:
+        p = repo / rel
+        p.write_text(p.read_text().replace(old, new))
+
+
+def _prerelease(version: str) -> str:
+    """A realistic next-minor release candidate, e.g. 0.7.0 -> 0.8.0rc0."""
+    major, minor = version.split(".")[:2]
+    return f"{major}.{int(minor) + 1}.0rc0"
+
+
+def test_prerelease_in_sync_passes(repo_copy: Path):
+    """All eight locations at the same PEP 440 prerelease (e.g. 0.8.0rc0) is in sync.
+
+    The pre-generalization regexes required `X.Y.Z` immediately followed by `"`,
+    so a prerelease suffix made the pyproject/cross-pin reads raise. This guards
+    that `cz bump --prerelease rc` versions validate cleanly.
+    """
+    current = _current_version(repo_copy)
+    pre = _prerelease(current)
+    _rewrite_all_versions(repo_copy, current, pre)
+    result = _run(repo_copy)
+    assert result.returncode == 0, (
+        f"prerelease version {pre} should validate in sync.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert pre in result.stdout
+
+
+def test_prerelease_drift_detected(repo_copy: Path):
+    """rc0 vs rc1 must be caught — the check compares the full prerelease, not the X.Y.Z core."""
+    current = _current_version(repo_copy)
+    pre = _prerelease(current)  # e.g. 0.8.0rc0
+    _rewrite_all_versions(repo_copy, current, pre)
+    init = repo_copy / "flopscope-client" / "src" / "flopscope" / "__init__.py"
+    init.write_text(init.read_text().replace(pre, pre[:-1] + "1"))  # rc0 -> rc1
+    result = _run(repo_copy)
+    assert result.returncode != 0, (
+        f"rc0 vs rc1 drift should be detected.\nstdout:\n{result.stdout}"
+    )


### PR DESCRIPTION
Release prep so a `cz bump --prerelease rc` (→ `v0.8.0rc0`) doesn't trip any version tooling. No version bump here — that lands separately. The repo has never cut a prerelease (all tags `v0.2.0`→`v0.7.0` are final), so these paths were untested.

## 1. `check_version_sync.py` — prerelease-aware
Its pyproject-version and cross-pin regexes required a `"` immediately after `X.Y.Z`, so on `0.8.0rc0` they returned `None` and the script raised `ValueError`. It runs in `make ci`, the pre-push hook, and CI's `client-server-sync` job, so an rc bump would block the push and redden CI. Fix: capture/compare the PEP 440 **public** version — `X.Y.Z` plus an optional prerelease/post/dev segment — across all **8** locations (root + both sub-packages + the two cross-pins). Two subtleties:
- `rc0` vs `rc1` across packages is now real drift (full public-version compare, not just the `X.Y.Z` core).
- The class **excludes `+`**, so a *local* segment is ignored — `src/flopscope/__init__.py` carries a dynamic `f"0.7.0+np{_np.__version__}"`; lockstep is the public version, not the per-env numpy build. (Running the generalized check on the real repo is what surfaced this.)

New tests set all eight locations to `0.8.0rc0` (incl. both sub-packages) and assert in-sync, and catch `rc0` vs `rc1` as drift.

## 2. Client↔server version handshake — prerelease-robustness + CI gating
The runtime handshake (`_connection.py` / `_server.py`) already string-compares `__version__.split("+",1)[0]` (no int-parsing), so it's prerelease-safe — but that wasn't tested, and the **server** test suite never ran in CI. Added:
- A server-side test: a prerelease server version matches an `rc0` client, and `rc0` vs `rc1`/final is a `VersionMismatch` (locks the string-compare, no `int("0rc0")` crash).
- A client-side test: the client sends its `+local`-stripped public version (`0.8.0rc0`) in the `hello`.
- A CI step (`client-server-integration` job) running the server handshake test file, so the server side is now gated. (The full server suite isn't wired in — it has a pre-existing failure on py3.14; out of scope.)

After this merges, cutting the rc is just `cz bump --prerelease rc` (+ `make relock`) with no tooling choking on the suffix.