### PR TITLE
docs(readme): link the ARC White-Box Estimation Challenge next to the badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <div align="center">
 
+[![ARC Challenge](https://img.shields.io/badge/AIcrowd-ARC%20Challenge-F0524D.svg)](https://www.aicrowd.com/challenges/arc-white-box-estimation-challenge-2026)
 [![PyPI version](https://img.shields.io/pypi/v/flopscope.svg)](https://pypi.org/project/flopscope/)
 [![CI](https://github.com/AIcrowd/flopscope/actions/workflows/ci.yml/badge.svg)](https://github.com/AIcrowd/flopscope/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://aicrowd.github.io/flopscope/)
@@ -14,7 +15,7 @@
 
 </div>
 
-*Built for the [ARC Whitebox Estimation Challenge](https://aicrowd.com) by [AIcrowd](https://aicrowd.com)*
+*Built for the [ARC Whitebox Estimation Challenge](https://www.aicrowd.com/challenges/arc-white-box-estimation-challenge-2026) by [AIcrowd](https://aicrowd.com)*
 
 ---
 


### PR DESCRIPTION
Adds an **AIcrowd · ARC Challenge** badge at the front of the README badge row linking to the challenge page, and fixes the tagline link ("ARC Whitebox Estimation Challenge") which pointed at the generic `https://aicrowd.com` instead of the challenge.

Challenge: https://www.aicrowd.com/challenges/arc-white-box-estimation-challenge-2026