### PR TITLE
fix(client+server): release server array handles on GC; never reuse handle ids

### DIFF
--- a/flopscope-client/src/flopscope/_connection.py
+++ b/flopscope-client/src/flopscope/_connection.py
@@ -8,7 +8,8 @@ import time
 import zmq
 
 from flopscope._dispatch import dispatch_span
-from flopscope._protocol import decode_response
+from flopscope._handles import drain_pending
+from flopscope._protocol import decode_response, encode_free
 from flopscope.errors import raise_from_response
 
 _DEFAULT_URL = "ipc:///tmp/flopscope.sock"
@@ -35,6 +36,7 @@ class Connection:
         self._context: zmq.Context | None = None
         self._socket: zmq.Socket | None = None
         self._handshake_done: bool = False
+        self._flushing_frees: bool = False
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -104,6 +106,37 @@ class Connection:
             )
         self._handshake_done = True
 
+    def _flush_pending_frees(self) -> None:
+        """Release GC'd server handles, batched onto the current round-trip.
+
+        Enqueued handle ids (from RemoteArray finalizers) are sent as a single
+        ``free`` op before the real request. Called from inside send_recv's
+        ``dispatch_span`` so the tiny round-trip bills as flopscope overhead,
+        not participant residual. Best-effort: on ANY error the socket is reset
+        so the REQ/REP state machine is clean for the request that follows.
+
+        Lost-on-error: drain_pending() clears the queue BEFORE the send, so if
+        the free send/recv fails, those handle ids are discarded (never
+        re-enqueued). The server handles then linger until the session closes.
+        Intentional — a missed free is a slow memory reclaim, not a correctness
+        bug, and re-enqueuing risks unbounded growth on a persistently bad socket.
+        """
+        if self._flushing_frees:
+            return
+        handles = drain_pending()
+        if not handles:
+            return
+        self._flushing_frees = True
+        try:
+            sock = self._ensure_connected()
+            self._ensure_handshaked()
+            sock.send(encode_free(handles))
+            sock.recv()  # consume {status:ok}; content ignored
+        except Exception:
+            self._reset_socket()
+        finally:
+            self._flushing_frees = False
+
     def send_recv(self, raw_request: bytes) -> dict:
         """Send *raw_request* and return the decoded response dict.
 
@@ -123,6 +156,7 @@ class Connection:
         from flopscope.errors import FlopscopeServerError
 
         with dispatch_span():
+            self._flush_pending_frees()
             sock = self._ensure_connected()
             self._ensure_handshaked()
 

--- a/flopscope-client/src/flopscope/_handles.py
+++ b/flopscope-client/src/flopscope/_handles.py
@@ -1,0 +1,28 @@
+"""Deferred release of server-side array handles.
+
+A RemoteArray finalizer ENQUEUES its handle here (pure append, no I/O — safe at
+GC time and during interpreter shutdown). Connection.send_recv drains the queue
+onto the next op's round-trip (see _connection.py), so frees ride existing
+traffic and the strict REQ/REP socket is never used mid-op.
+"""
+from __future__ import annotations
+
+_pending: set[str] = set()
+
+
+def enqueue_free(handle_id: str) -> None:
+    """Mark a server handle for release. Pure; no I/O. Finalizer-safe."""
+    _pending.add(handle_id)
+
+
+def drain_pending() -> list[str]:
+    """Return a snapshot of pending handles and clear the queue."""
+    if not _pending:
+        return []
+    snapshot = list(_pending)
+    _pending.clear()
+    return snapshot
+
+
+def pending_count() -> int:
+    return len(_pending)

--- a/flopscope-client/src/flopscope/_handles.py
+++ b/flopscope-client/src/flopscope/_handles.py
@@ -5,6 +5,7 @@ GC time and during interpreter shutdown). Connection.send_recv drains the queue
 onto the next op's round-trip (see _connection.py), so frees ride existing
 traffic and the strict REQ/REP socket is never used mid-op.
 """
+
 from __future__ import annotations
 
 _pending: set[str] = set()

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -12,7 +12,6 @@ import weakref
 from typing import Any
 
 from flopscope._dispatch import timed_dispatch
-from flopscope._handles import enqueue_free
 from flopscope._math_compat import prod as _prod
 
 # ---------------------------------------------------------------------------
@@ -326,7 +325,18 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
         if handle_id is not None:
             # Release the server handle when this proxy is GC'd. The callback
             # takes handle_id (NOT self), so it never resurrects the instance.
-            weakref.finalize(self, enqueue_free, handle_id)
+            # The import is deferred AND guarded: cross-package parity/integration
+            # tests exec this module by file path with `flopscope` resolving to
+            # the full package (which has no `_handles`). There the GC-free is not
+            # needed, so we skip the finalizer rather than fail construction. In
+            # the real client venv `_handles` always resolves, so the leak fix is
+            # active. (ModuleNotFoundError only — a broken `_handles` still raises.)
+            try:
+                from flopscope._handles import enqueue_free
+            except ModuleNotFoundError:
+                pass
+            else:
+                weakref.finalize(self, enqueue_free, handle_id)
 
     # -- cached metadata (no round-trip) ------------------------------------
 

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -8,9 +8,11 @@ operations are dispatched to the server transparently.
 from __future__ import annotations
 
 import struct
+import weakref
 from typing import Any
 
 from flopscope._dispatch import timed_dispatch
+from flopscope._handles import enqueue_free
 from flopscope._math_compat import prod as _prod
 
 # ---------------------------------------------------------------------------
@@ -312,13 +314,19 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
         Element data-type string (e.g. ``"float64"``).
     """
 
-    __slots__ = ("_handle_id", "_shape", "_dtype", "_symmetry")
+    # __weakref__ makes instances weak-referenceable (required for the
+    # weakref.finalize below that releases the server handle on GC).
+    __slots__ = ("_handle_id", "_shape", "_dtype", "_symmetry", "__weakref__")
 
     def __init__(self, handle_id: str, shape: tuple, dtype: str, symmetry=None) -> None:
         self._handle_id = handle_id
         self._shape = tuple(shape)
         self._dtype = dtype
         self._symmetry = symmetry
+        if handle_id is not None:
+            # Release the server handle when this proxy is GC'd. The callback
+            # takes handle_id (NOT self), so it never resurrects the instance.
+            weakref.finalize(self, enqueue_free, handle_id)
 
     # -- cached metadata (no round-trip) ------------------------------------
 

--- a/flopscope-client/tests/conftest.py
+++ b/flopscope-client/tests/conftest.py
@@ -21,3 +21,15 @@ def _reset_weights():
     yield
     reset_weights()
     weights_module._WARNED_MESSAGES.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_pending_handles():
+    """Isolate the module-global free queue: RemoteArray GC enqueues handle ids
+    into flopscope._handles, and tests asserting exact send sequences must start
+    from an empty queue. Drains before AND after each test."""
+    from flopscope import _handles
+
+    _handles.drain_pending()
+    yield
+    _handles.drain_pending()

--- a/flopscope-client/tests/test_array_free.py
+++ b/flopscope-client/tests/test_array_free.py
@@ -1,0 +1,22 @@
+"""Client-side server-handle release (free-on-GC) — queue, finalizer, flush."""
+
+from __future__ import annotations
+
+import gc
+
+import msgpack
+
+
+def test_enqueue_drain_count_roundtrip():
+    from flopscope import _handles
+
+    _handles.drain_pending()  # start clean
+    assert _handles.pending_count() == 0
+    _handles.enqueue_free("a0")
+    _handles.enqueue_free("a1")
+    _handles.enqueue_free("a0")  # dedup
+    assert _handles.pending_count() == 2
+    snap = _handles.drain_pending()
+    assert set(snap) == {"a0", "a1"}
+    assert _handles.pending_count() == 0  # cleared by drain
+    assert _handles.drain_pending() == []  # empty is safe

--- a/flopscope-client/tests/test_array_free.py
+++ b/flopscope-client/tests/test_array_free.py
@@ -23,8 +23,9 @@ def test_enqueue_drain_count_roundtrip():
 
 
 def test_remote_array_enqueues_handle_on_gc():
-    from flopscope import _handles
     from flopscope._remote_array import RemoteArray
+
+    from flopscope import _handles
 
     _handles.drain_pending()
     arr = RemoteArray(handle_id="a7", shape=(2, 2), dtype="float32")
@@ -35,8 +36,9 @@ def test_remote_array_enqueues_handle_on_gc():
 
 
 def test_remote_scalar_does_not_enqueue():
-    from flopscope import _handles
     from flopscope._remote_array import RemoteScalar
+
+    from flopscope import _handles
 
     _handles.drain_pending()
     s = RemoteScalar(value=1.5, dtype="float64")
@@ -60,9 +62,10 @@ class _FakeSocket:
 
 
 def test_send_recv_flushes_pending_frees_first():
-    from flopscope import _handles
     from flopscope._connection import Connection
     from flopscope._protocol import encode_request
+
+    from flopscope import _handles
 
     _handles.drain_pending()
     _handles.enqueue_free("a0")
@@ -71,7 +74,9 @@ def test_send_recv_flushes_pending_frees_first():
     sock = _FakeSocket(
         [
             msgpack.packb({"status": "ok"}, use_bin_type=True),  # reply to free
-            msgpack.packb({"status": "ok", "result": 7}, use_bin_type=True),  # reply to op
+            msgpack.packb(
+                {"status": "ok", "result": 7}, use_bin_type=True
+            ),  # reply to op
         ]
     )
     conn = Connection()
@@ -90,12 +95,15 @@ def test_send_recv_flushes_pending_frees_first():
 
 
 def test_send_recv_no_frees_sends_only_the_op():
-    from flopscope import _handles
     from flopscope._connection import Connection
     from flopscope._protocol import encode_request
 
+    from flopscope import _handles
+
     _handles.drain_pending()
-    sock = _FakeSocket([msgpack.packb({"status": "ok", "result": 1}, use_bin_type=True)])
+    sock = _FakeSocket(
+        [msgpack.packb({"status": "ok", "result": 1}, use_bin_type=True)]
+    )
     conn = Connection()
     conn._socket = sock
     conn._handshake_done = True

--- a/flopscope-client/tests/test_array_free.py
+++ b/flopscope-client/tests/test_array_free.py
@@ -20,3 +20,26 @@ def test_enqueue_drain_count_roundtrip():
     assert set(snap) == {"a0", "a1"}
     assert _handles.pending_count() == 0  # cleared by drain
     assert _handles.drain_pending() == []  # empty is safe
+
+
+def test_remote_array_enqueues_handle_on_gc():
+    from flopscope import _handles
+    from flopscope._remote_array import RemoteArray
+
+    _handles.drain_pending()
+    arr = RemoteArray(handle_id="a7", shape=(2, 2), dtype="float32")
+    assert _handles.pending_count() == 0  # alive -> not enqueued
+    del arr
+    gc.collect()
+    assert _handles.drain_pending() == ["a7"]
+
+
+def test_remote_scalar_does_not_enqueue():
+    from flopscope import _handles
+    from flopscope._remote_array import RemoteScalar
+
+    _handles.drain_pending()
+    s = RemoteScalar(value=1.5, dtype="float64")
+    del s
+    gc.collect()
+    assert _handles.pending_count() == 0  # no server handle -> nothing to free

--- a/flopscope-client/tests/test_array_free.py
+++ b/flopscope-client/tests/test_array_free.py
@@ -43,3 +43,63 @@ def test_remote_scalar_does_not_enqueue():
     del s
     gc.collect()
     assert _handles.pending_count() == 0  # no server handle -> nothing to free
+
+
+class _FakeSocket:
+    """Records sends, replays scripted recvs (mirrors test_version_handshake)."""
+
+    def __init__(self, recv_payloads):
+        self.sent = []
+        self._recv_payloads = list(recv_payloads)
+
+    def send(self, payload):
+        self.sent.append(payload)
+
+    def recv(self):
+        return self._recv_payloads.pop(0)
+
+
+def test_send_recv_flushes_pending_frees_first():
+    from flopscope import _handles
+    from flopscope._connection import Connection
+    from flopscope._protocol import encode_request
+
+    _handles.drain_pending()
+    _handles.enqueue_free("a0")
+    _handles.enqueue_free("a1")
+
+    sock = _FakeSocket(
+        [
+            msgpack.packb({"status": "ok"}, use_bin_type=True),  # reply to free
+            msgpack.packb({"status": "ok", "result": 7}, use_bin_type=True),  # reply to op
+        ]
+    )
+    conn = Connection()
+    conn._socket = sock
+    conn._handshake_done = True  # bypass the lazy hello
+
+    resp = conn.send_recv(encode_request("some_op"))
+    assert resp["status"] == "ok"
+
+    first = msgpack.unpackb(sock.sent[0], raw=False)
+    assert first["op"] == "free"
+    assert set(first["kwargs"]["handles"]) == {"a0", "a1"}
+    second = msgpack.unpackb(sock.sent[1], raw=False)
+    assert second["op"] == "some_op"
+    assert _handles.pending_count() == 0
+
+
+def test_send_recv_no_frees_sends_only_the_op():
+    from flopscope import _handles
+    from flopscope._connection import Connection
+    from flopscope._protocol import encode_request
+
+    _handles.drain_pending()
+    sock = _FakeSocket([msgpack.packb({"status": "ok", "result": 1}, use_bin_type=True)])
+    conn = Connection()
+    conn._socket = sock
+    conn._handshake_done = True
+
+    conn.send_recv(encode_request("op2"))
+    assert len(sock.sent) == 1
+    assert msgpack.unpackb(sock.sent[0], raw=False)["op"] == "op2"

--- a/flopscope-client/tests/test_array_leak_regression.py
+++ b/flopscope-client/tests/test_array_leak_regression.py
@@ -1,0 +1,95 @@
+"""Real client+server regression for the array-handle leak (sub 310969).
+
+A low server array-store cap + a Monte-Carlo-style loop that allocates far more
+intermediates than the cap. With the free-on-GC fix the live count stays bounded
+and the loop completes; without it the server raises MemoryError well before the
+loop ends.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+_WORKTREE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CLIENT_SRC = os.path.join(_WORKTREE, "flopscope-client", "src")
+_SERVER_SRC = os.path.join(_WORKTREE, "flopscope-server", "src")
+_REAL_SRC = os.path.join(_WORKTREE, "src")
+_SERVER_VENV_PYTHON = os.path.join(_WORKTREE, "flopscope-server", ".venv", "bin", "python")
+_ROOT_VENV_PYTHON = os.path.join(_WORKTREE, ".venv", "bin", "python")
+_VENV_PYTHON = _SERVER_VENV_PYTHON if os.path.exists(_SERVER_VENV_PYTHON) else _ROOT_VENV_PYTHON
+
+for _p in (_CLIENT_SRC,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SERVER_URL = "tcp://127.0.0.1:15561"  # distinct port from test_full_integration
+_SERVER_SCRIPT = f"""
+import sys
+sys.path.insert(0, {_REAL_SRC!r})
+sys.path.insert(0, {_SERVER_SRC!r})
+from flopscope_server._server import FlopscopeServer
+server = FlopscopeServer(url={_SERVER_URL!r})
+print("SERVER_READY", flush=True)
+server.run()
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _low_cap_server():
+    env = {**os.environ, "FLOPSCOPE_SERVER_URL": _SERVER_URL, "FLOPSCOPE_MAX_ARRAY_COUNT": "2000"}
+    os.environ["FLOPSCOPE_SERVER_URL"] = _SERVER_URL
+    proc = subprocess.Popen(
+        [_VENV_PYTHON, "-c", _SERVER_SCRIPT],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    line = proc.stdout.readline()
+    if "SERVER_READY" not in line:
+        # Surface the subprocess's stderr — a missing server venv / import error
+        # otherwise shows up as an empty stdout line with no diagnostic.
+        proc.kill()
+        err = proc.stderr.read()
+        pytest.fail(f"server failed to start: stdout={line!r} stderr={err!r}")
+    time.sleep(0.3)  # allow the ZMQ socket to finish binding before clients connect
+    yield proc
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+@pytest.fixture(autouse=True)
+def _reset_client():
+    from flopscope._budget import _reset_global_default
+    from flopscope._connection import reset_connection
+
+    reset_connection()
+    _reset_global_default()
+    yield
+    reset_connection()
+    _reset_global_default()
+
+
+def test_monte_carlo_loop_does_not_leak_handles():
+    import flopscope as we
+    import flopscope.numpy as fnp
+
+    # 4000 iterations >> the 2000 cap. Each iter creates a transpose + matmul +
+    # maximum (several handles) and drops the previous ones. Without free-on-GC,
+    # live handles climb past 2000 and the server raises MemoryError; with it,
+    # the live count stays at the working-set size and the loop completes.
+    with we.BudgetContext(flop_budget=10**18):
+        w = fnp.zeros((16, 16))
+        acc = fnp.zeros(16)
+        for _ in range(4000):
+            acc = fnp.maximum(0.0, w.T @ acc)
+        assert fnp.asarray(acc).tolist() == [0.0] * 16

--- a/flopscope-client/tests/test_array_leak_regression.py
+++ b/flopscope-client/tests/test_array_leak_regression.py
@@ -5,6 +5,7 @@ intermediates than the cap. With the free-on-GC fix the live count stays bounded
 and the loop completes; without it the server raises MemoryError well before the
 loop ends.
 """
+
 from __future__ import annotations
 
 import os
@@ -19,9 +20,13 @@ _WORKTREE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 _CLIENT_SRC = os.path.join(_WORKTREE, "flopscope-client", "src")
 _SERVER_SRC = os.path.join(_WORKTREE, "flopscope-server", "src")
 _REAL_SRC = os.path.join(_WORKTREE, "src")
-_SERVER_VENV_PYTHON = os.path.join(_WORKTREE, "flopscope-server", ".venv", "bin", "python")
+_SERVER_VENV_PYTHON = os.path.join(
+    _WORKTREE, "flopscope-server", ".venv", "bin", "python"
+)
 _ROOT_VENV_PYTHON = os.path.join(_WORKTREE, ".venv", "bin", "python")
-_VENV_PYTHON = _SERVER_VENV_PYTHON if os.path.exists(_SERVER_VENV_PYTHON) else _ROOT_VENV_PYTHON
+_VENV_PYTHON = (
+    _SERVER_VENV_PYTHON if os.path.exists(_SERVER_VENV_PYTHON) else _ROOT_VENV_PYTHON
+)
 
 for _p in (_CLIENT_SRC,):
     if _p not in sys.path:
@@ -41,7 +46,11 @@ server.run()
 
 @pytest.fixture(scope="module", autouse=True)
 def _low_cap_server():
-    env = {**os.environ, "FLOPSCOPE_SERVER_URL": _SERVER_URL, "FLOPSCOPE_MAX_ARRAY_COUNT": "2000"}
+    env = {
+        **os.environ,
+        "FLOPSCOPE_SERVER_URL": _SERVER_URL,
+        "FLOPSCOPE_MAX_ARRAY_COUNT": "2000",
+    }
     os.environ["FLOPSCOPE_SERVER_URL"] = _SERVER_URL
     proc = subprocess.Popen(
         [_VENV_PYTHON, "-c", _SERVER_SCRIPT],
@@ -69,8 +78,9 @@ def _low_cap_server():
 
 @pytest.fixture(autouse=True)
 def _reset_client():
-    from flopscope._budget import _reset_global_default
     from flopscope._connection import reset_connection
+
+    from flopscope._budget import _reset_global_default
 
     reset_connection()
     _reset_global_default()

--- a/flopscope-client/tests/test_bugfixes_round3.py
+++ b/flopscope-client/tests/test_bugfixes_round3.py
@@ -505,6 +505,17 @@ class TestFix8ZmqSocketReset:
         conn._socket = mock_sock
         conn._handshake_done = True  # skip handshake; exercise the send/recv reset path
 
+        # send_recv flushes pending frees FIRST; a handle GC-enqueued by an earlier
+        # test would make the flush send on this mock (zmq.Again) and reset the
+        # socket, surfacing a handshake ConnectionError instead of the expected
+        # FlopscopeServerError. Force any deferred finalizer + drain so the queue is
+        # empty and the mock's zmq.Again hits the real op, not the free flush.
+        import gc
+
+        from flopscope import _handles
+
+        gc.collect()
+        _handles.drain_pending()
         with pytest.raises(FlopscopeServerError, match="timeout"):
             conn.send_recv(b"test")
         # Socket should be reset
@@ -522,6 +533,14 @@ class TestFix8ZmqSocketReset:
         conn._socket = mock_sock
         conn._handshake_done = True  # skip handshake; exercise the send/recv reset path
 
+        # See test_send_recv_resets_on_timeout: drain any GC-enqueued frees so the
+        # send_recv flush is a no-op and the mock's zmq.Again hits the real op.
+        import gc
+
+        from flopscope import _handles
+
+        gc.collect()
+        _handles.drain_pending()
         with pytest.raises(FlopscopeServerError, match="timeout"):
             conn.send_recv(b"test")
         assert conn._socket is None

--- a/flopscope-client/tests/test_connection.py
+++ b/flopscope-client/tests/test_connection.py
@@ -320,6 +320,14 @@ class TestSendRecv:
         conn._socket = mock_socket
         conn._handshake_done = True  # bypass the lazy version handshake
 
+        # Drain any GC-enqueued frees so send_recv's flush is a no-op; otherwise it
+        # would call mock_socket.send an extra time and break assert_called_once.
+        import gc
+
+        from flopscope import _handles
+
+        gc.collect()
+        _handles.drain_pending()
         raw = encode_request("test_op")
         result = conn.send_recv(raw)
         assert result["status"] == "ok"

--- a/flopscope-client/tests/test_version_handshake.py
+++ b/flopscope-client/tests/test_version_handshake.py
@@ -96,6 +96,14 @@ def test_send_recv_triggers_handshake_first():
     sock = _FakeSocket([server_ok_hello, server_ok_op])
     conn = _make_connection(sock)
 
+    # Drain any GC-enqueued frees so send_recv's flush is a no-op; otherwise it
+    # would consume a scripted recv (and an extra send) before the real op.
+    import gc
+
+    from flopscope import _handles
+
+    gc.collect()
+    _handles.drain_pending()
     # An arbitrary "op" request — not a hello — should still get handshaked first.
     op_request = msgpack.packb({"op": "budget_status"}, use_bin_type=True)
     response = conn.send_recv(op_request)

--- a/flopscope-server/src/flopscope_server/_array_store.py
+++ b/flopscope-server/src/flopscope_server/_array_store.py
@@ -5,23 +5,44 @@ from __future__ import annotations
 import os
 from typing import Any
 
-import numpy as np
-
 #: Maximum number of arrays allowed in a single store (configurable via env var).
 MAX_ARRAY_COUNT = int(os.environ.get("FLOPSCOPE_MAX_ARRAY_COUNT", "100000"))
+
+# Handle ids are allocated from a PROCESS-GLOBAL monotonic counter (not reset
+# per ArrayStore/session). This guarantees ids are never reused across sessions,
+# so a stale free for a handle from a closed session can never alias a live
+# handle in a new session (ArrayStore.free silently ignores unknown ids). The
+# client frees handles on GC, and GC of a prior-session proxy can fire during a
+# later session — global ids make that safe. The counter is unbounded, but a
+# server process serves one submission, so it stays far below any int limit.
+_next_handle_id = 0
+
+
+def _alloc_handle() -> str:
+    """Allocate the next unique handle id from the process-global counter."""
+    global _next_handle_id
+    # Single-threaded server (one ZMQ REP loop), so no lock is needed.
+    handle = f"a{_next_handle_id}"
+    _next_handle_id += 1
+    return handle
+
+
+def _reset_handle_counter() -> None:
+    """Reset the global handle counter. TEST-ONLY (production never resets)."""
+    global _next_handle_id
+    _next_handle_id = 0
 
 
 class ArrayStore:
     """Simple store that maps string handle IDs to numpy arrays.
 
-    Handle IDs are monotonically increasing strings of the form "a0", "a1",
-    "a2", … The counter never resets, so IDs remain unique across put/free
-    cycles.
+    Handle IDs are allocated from a process-global monotonic counter (see
+    :func:`_alloc_handle`), so IDs remain unique across all ArrayStore instances
+    and sessions for the lifetime of the server process.
     """
 
     def __init__(self) -> None:
         self._arrays: dict[str, Any] = {}
-        self._counter: int = 0
 
     # ------------------------------------------------------------------
     # Core operations
@@ -37,9 +58,8 @@ class ArrayStore:
         """
         if len(self._arrays) >= MAX_ARRAY_COUNT:
             raise MemoryError(f"array store limit reached: {MAX_ARRAY_COUNT} arrays")
-        handle = f"a{self._counter}"
+        handle = _alloc_handle()
         self._arrays[handle] = arr
-        self._counter += 1
         return handle
 
     def get(self, handle: str) -> Any:

--- a/flopscope-server/tests/conftest.py
+++ b/flopscope-server/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest fixtures for flopscope-server tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_handle_counter():
+    """Reset the process-global handle counter before each test.
+
+    This ensures tests that assert exact handle names (e.g. "a0") remain
+    deterministic.  Production NEVER calls this — the counter is only reset
+    here for test isolation.
+    """
+    import flopscope_server._array_store as mod
+
+    mod._reset_handle_counter()
+    yield

--- a/flopscope-server/tests/test_array_store.py
+++ b/flopscope-server/tests/test_array_store.py
@@ -219,3 +219,22 @@ def test_metadata_0d_shape(store):
 def test_metadata_missing_raises_keyerror(store):
     with pytest.raises(KeyError):
         store.metadata("a999")
+
+
+# ---------------------------------------------------------------------------
+# Cross-session handle uniqueness (Fix B regression test)
+# ---------------------------------------------------------------------------
+
+
+def test_handles_unique_across_stores():
+    """Handle ids must NOT reset per ArrayStore/session — two stores (simulating
+    two sessions) must mint distinct ids, so a stale free can't alias a live
+    handle in a new session."""
+    import flopscope_server._array_store as mod
+
+    mod._reset_handle_counter()
+    s1 = ArrayStore()
+    h1 = s1.put(np.array([1.0]))
+    s2 = ArrayStore()
+    h2 = s2.put(np.array([2.0]))
+    assert h1 != h2, f"handle reuse across stores: {h1!r} == {h2!r}"


### PR DESCRIPTION
## Summary

Fixes the flopscope array-handle leak (root-caused from AIcrowd submission 310969). The client minted a server-side array handle for **every** op and **never freed it**, so iterative / Monte-Carlo estimators climbed the server's `MAX_ARRAY_COUNT` (100k) cap and died with `MemoryError: array store limit reached` — surfaced to participants as a cryptic redacted `ESTIMATOR_EXCEPTION`. In-process flopscope has no array store, so the same code passed there; the failure only reproduces against a real client+server.

### Client — free-on-GC (`flopscope-client`)
- New `_handles.py`: a module-level pending-free queue (`enqueue_free` / `drain_pending` / `pending_count`) — pure Python, no I/O, so it's safe to touch from a finalizer at GC time / interpreter shutdown.
- `RemoteArray` registers a `weakref.finalize` (added `__weakref__` to `__slots__`) that enqueues its handle on GC. The callback takes `handle_id` (not `self`), so it never resurrects the instance. `RemoteScalar` (no handle) and RNG proxies are excluded.
- `Connection.send_recv` flushes a single **batched** `free` op at the start of each round-trip, **inside the existing `dispatch_span`** (so the tiny round-trip bills as flopscope overhead, not participant residual) and **between ops** (respecting the strict REQ/REP socket). Best-effort: on any flush error the socket is reset so REQ/REP stays clean; drained-then-lost handles simply linger until session close (a slow reclaim, not a correctness bug).

### Server — handle-id uniqueness (`flopscope-server`)
- The array-store handle counter is now **process-global** (it was reset to 0 per `budget_open`/session). Without this, free-on-GC introduced a **use-after-free**: a prior-session `RemoteArray` GC'd *during a new session* enqueued e.g. `"a0"`, and the flush freed the *new* session's live `"a0"` (ids reset per session). Process-global ids are never reused, so a stale free hits a non-existent handle and is silently ignored — restoring the intended "a stale id can never alias a live array" invariant. The `MAX_ARRAY_COUNT` cap (on the live count) is unchanged.

## Tests
- `flopscope-client/tests/test_array_free.py` — queue, finalizer-on-GC, `RemoteScalar` exclusion, batched flush ordering (numpy-free unit tests). Added an autouse `_reset_pending_handles` fixture in the client `conftest.py` for queue isolation.
- `flopscope-client/tests/test_array_leak_regression.py` — **real client+server**, low cap (`FLOPSCOPE_MAX_ARRAY_COUNT=2000`) + a 4000-iteration Monte-Carlo loop. Completes with the fix; with the finalizer disabled it reproduces the exact 310969 failure (`MemoryError: array store limit reached: 2000 arrays`).
- `flopscope-server/tests/test_array_store.py::test_handles_unique_across_stores` + autouse counter-reset fixture (preserves existing exact-id assertions).

### Verification (local)
- client suite: **1346 passed**, 0 errors
- server suite: **221 passed** (1 pre-existing, unrelated `test_budget_close_returns_summary` msgpack failure — present on `main` too)
- `make test-integration`: **34 passed**, incl. `test_budget_context_isolates_errors` (the use-after-free repro)
- in-process `make test`: 0 failed / 0 errored

## Release
The version bump to **0.8.0rc2** + PyPI publish is intentionally **not** in this PR — handled separately.