### PR TITLE
fix(server): connection-lifetime handle store — fix warm-child handle aliasing (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,9 +308,9 @@ jobs:
           uv sync --all-extras
           cd flopscope-server && uv sync
 
-      - name: Run server version-handshake tests
+      - name: Run full flopscope-server test suite
         run: |
-          cd flopscope-server && uv run pytest tests/test_version_handshake.py -v --tb=short
+          cd flopscope-server && uv run pytest tests/ -v --tb=short
 
       - name: Run full client test suite
         run: |

--- a/flopscope-server/src/flopscope_server/_connection_store.py
+++ b/flopscope-server/src/flopscope_server/_connection_store.py
@@ -1,0 +1,25 @@
+"""ConnectionStore — connection-lifetime handle storage (arrays + RNG generators).
+
+Owned by :class:`flopscope_server._server.FlopscopeServer` for the lifetime of
+the server process (= one worker = the warm participant subprocess's single ZMQ
+connection). Injected into each per-MLP :class:`flopscope_server._session.Session`
+so that handles minted at module-import / ``setup()`` time survive across MLPs.
+
+Memory is bounded by the flopscope-client's GC-driven frees (weakref.finalize ->
+batched ``free``) plus the :data:`flopscope_server._array_store.MAX_ARRAY_COUNT`
+backstop — NOT by per-session clearing. ``budget_open``/``budget_close`` reset
+only the FLOP counter (the ``Session``'s ``BudgetContext``), never this store.
+"""
+
+from __future__ import annotations
+
+from flopscope_server._array_store import ArrayStore
+from flopscope_server._generator_store import GeneratorStore
+
+
+class ConnectionStore:
+    """Bundles the array + generator stores that live for the server connection."""
+
+    def __init__(self) -> None:
+        self.arrays = ArrayStore()
+        self.generators = GeneratorStore()

--- a/flopscope-server/src/flopscope_server/_generator_store.py
+++ b/flopscope-server/src/flopscope_server/_generator_store.py
@@ -1,0 +1,77 @@
+"""GeneratorStore — in-process mapping from handle IDs to RNG Generator objects.
+
+Mirrors :mod:`flopscope_server._array_store`: handle ids come from a
+PROCESS-GLOBAL monotonic counter so they are never reused across budget
+sessions. A generator created at module-import / ``setup()`` time (held by the
+warm participant subprocess across MLPs) therefore keeps a stable, unambiguous
+handle for the connection lifetime — it can never silently alias a generator
+minted in a later session. No size cap (generators are few; matches the prior
+per-Session behaviour which had none).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Process-global monotonic counter (mirrors _array_store._next_handle_id).
+# Never reset in production; reset only in tests for deterministic handle names.
+_next_gen_id = 0
+
+
+def _alloc_gen() -> str:
+    """Allocate the next unique generator handle id from the process-global counter."""
+    global _next_gen_id
+    # Single-threaded server (one ZMQ REP loop), so no lock is needed.
+    handle = f"g{_next_gen_id}"
+    _next_gen_id += 1
+    return handle
+
+
+def _reset_gen_counter() -> None:
+    """Reset the global generator counter. TEST-ONLY (production never resets)."""
+    global _next_gen_id
+    _next_gen_id = 0
+
+
+class GeneratorStore:
+    """Maps string handle IDs (``g0``, ``g1`` …) to RNG ``Generator`` objects.
+
+    Handle IDs come from a process-global monotonic counter (see
+    :func:`_alloc_gen`), so IDs are unique across all GeneratorStore instances
+    and budget sessions for the lifetime of the server process.
+    """
+
+    def __init__(self) -> None:
+        self._gens: dict[str, Any] = {}
+
+    def put(self, gen: Any) -> str:
+        """Store *gen* and return its handle ID."""
+        handle = _alloc_gen()
+        self._gens[handle] = gen
+        return handle
+
+    def get(self, handle: str) -> Any:
+        """Return the ``Generator`` for *handle*.
+
+        Raises
+        ------
+        KeyError
+            If *handle* is not a known generator handle.
+        """
+        if handle not in self._gens:
+            raise KeyError(f"Generator handle {handle!r} not found in store")
+        return self._gens[handle]
+
+    def free(self, handles: list[str]) -> None:
+        """Remove generators by handle; silently ignore unknown handles."""
+        for handle in handles:
+            self._gens.pop(handle, None)
+
+    def clear(self) -> None:
+        """Remove all generators from the store."""
+        self._gens.clear()
+
+    @property
+    def count(self) -> int:
+        """Number of generators currently in the store."""
+        return len(self._gens)

--- a/flopscope-server/src/flopscope_server/_server.py
+++ b/flopscope-server/src/flopscope_server/_server.py
@@ -10,6 +10,7 @@ import msgpack
 import zmq
 
 import flopscope
+from flopscope_server._connection_store import ConnectionStore
 from flopscope_server._protocol import (
     InvalidRequestError,
     decode_request,
@@ -46,6 +47,10 @@ class FlopscopeServer:
         self._session: Session | None = None
         self._handler: RequestHandler | None = None
         self._last_activity: float = 0.0
+        # Array + generator handle storage lives for the whole connection
+        # (process), not the per-MLP budget session, so module-level handles
+        # survive across MLPs (issue #107). Injected into every Session below.
+        self._conn_store = ConnectionStore()
 
     # ------------------------------------------------------------------
     # Public API
@@ -239,7 +244,7 @@ class FlopscopeServer:
         if flop_budget is None:
             kwargs = msg.get("kwargs") or {}
             flop_budget = kwargs.get("flop_budget", 1_000_000)
-        self._session = Session(flop_budget=flop_budget)
+        self._session = Session(flop_budget=flop_budget, conn_store=self._conn_store)
         self._handler = RequestHandler(self._session)
         self._last_activity = monotonic()
 

--- a/flopscope-server/src/flopscope_server/_session.py
+++ b/flopscope-server/src/flopscope_server/_session.py
@@ -1,4 +1,4 @@
-"""Session — ties together ArrayStore, BudgetContext, and CommsTracker for a single participant session."""
+"""Session — ties together ConnectionStore, BudgetContext, and CommsTracker for a single participant session."""
 
 from __future__ import annotations
 
@@ -7,23 +7,35 @@ from typing import Any
 import numpy as np
 
 import flopscope as flops
-from flopscope_server._array_store import ArrayStore
 from flopscope_server._comms_tracker import CommsTracker
+from flopscope_server._connection_store import ConnectionStore
 
 
 class Session:
-    """A single participant session combining ArrayStore, BudgetContext, and CommsTracker.
+    """A single participant session combining ConnectionStore, BudgetContext, and CommsTracker.
 
     Parameters
     ----------
     flop_budget : int
         Maximum number of FLOPs allowed for this session.
+    conn_store : ConnectionStore | None
+        Connection-lifetime store (arrays + generators). When provided the
+        server shares ONE store across all per-MLP sessions so that
+        module-level / ``setup()``-time handles survive across MLPs
+        (issue #107). When ``None`` (standalone / unit-test use) a private
+        ``ConnectionStore`` is created so a bare ``Session`` still works in
+        isolation.
     """
 
-    def __init__(self, flop_budget: int) -> None:
-        self._store = ArrayStore()
-        self._generators: dict[str, Any] = {}
-        self._gen_counter: int = 0
+    def __init__(
+        self, flop_budget: int, conn_store: ConnectionStore | None = None
+    ) -> None:
+        # The array + generator stores live for the CONNECTION, not the budget
+        # session. The server injects one shared ConnectionStore across all MLPs
+        # so module-level / setup()-time handles survive (issue #107). When none
+        # is injected (standalone / unit-test use) a private one is created so a
+        # bare Session still works in isolation.
+        self._conn = conn_store if conn_store is not None else ConnectionStore()
         self._comms_tracker = CommsTracker()
         self._budget_ctx = flops.BudgetContext(
             flop_budget=flop_budget,
@@ -67,46 +79,24 @@ class Session:
         return self._comms_tracker
 
     # ------------------------------------------------------------------
-    # Array operations (delegate to ArrayStore)
+    # Array operations (delegate to the connection store)
     # ------------------------------------------------------------------
 
     def store_array(self, arr: Any) -> str:
-        """Store *arr* and return its handle ID.
-
-        Delegates to :meth:`ArrayStore.put`.
-        """
-        return self._store.put(arr)
+        """Store *arr* and return its handle ID. Delegates to the connection store."""
+        return self._conn.arrays.put(arr)
 
     def get_array(self, handle: str) -> Any:
-        """Return the array for *handle*.
-
-        Delegates to :meth:`ArrayStore.get`.
-
-        Raises
-        ------
-        KeyError
-            If *handle* is not in the store.
-        """
-        return self._store.get(handle)
+        """Return the array for *handle*. Delegates to the connection store."""
+        return self._conn.arrays.get(handle)
 
     def array_metadata(self, handle: str) -> dict:
-        """Return metadata dict for *handle*.
-
-        Delegates to :meth:`ArrayStore.metadata`.
-
-        Raises
-        ------
-        KeyError
-            If *handle* is not in the store.
-        """
-        return self._store.metadata(handle)
+        """Return metadata dict for *handle*. Delegates to the connection store."""
+        return self._conn.arrays.metadata(handle)
 
     def free_arrays(self, handles: list) -> None:
-        """Remove arrays by handle; silently ignore unknown handles.
-
-        Delegates to :meth:`ArrayStore.free`.
-        """
-        self._store.free(handles)
+        """Remove arrays by handle; silently ignore unknown handles."""
+        self._conn.arrays.free(handles)
 
     # ------------------------------------------------------------------
     # Generator operations (server-side RNG handles)
@@ -114,10 +104,7 @@ class Session:
 
     def store_generator(self, gen: Any) -> str:
         """Store an RNG ``Generator`` and return its handle ID (``g0``, ``g1`` …)."""
-        handle = f"g{self._gen_counter}"
-        self._generators[handle] = gen
-        self._gen_counter += 1
-        return handle
+        return self._conn.generators.put(gen)
 
     def get_generator(self, handle: str) -> Any:
         """Return the ``Generator`` for *handle*.
@@ -127,9 +114,7 @@ class Session:
         KeyError
             If *handle* is not a known generator handle.
         """
-        if handle not in self._generators:
-            raise KeyError(f"Generator handle {handle!r} not found in store")
-        return self._generators[handle]
+        return self._conn.generators.get(handle)
 
     # ------------------------------------------------------------------
     # Budget
@@ -156,7 +141,7 @@ class Session:
     # ------------------------------------------------------------------
 
     def close(self) -> dict:
-        """Close the session, exiting the BudgetContext and clearing the ArrayStore.
+        """Close the session, exiting the BudgetContext.
 
         Returns
         -------
@@ -183,8 +168,10 @@ class Session:
         )
         budget_summary = self._budget_ctx.summary(by_namespace=show_namespaces)
         comms_summary = self._comms_tracker.summary()
-        self._store.clear()
-        self._generators.clear()
+        # The array + generator stores are owned by the connection, not the
+        # session, so they are intentionally NOT cleared here — module-level
+        # handles must survive across MLPs (issue #107). Memory is bounded by
+        # client GC-frees + ArrayStore.MAX_ARRAY_COUNT.
         self._is_open = False
 
         return {

--- a/flopscope-server/tests/conftest.py
+++ b/flopscope-server/tests/conftest.py
@@ -5,13 +5,15 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _reset_handle_counter():
-    """Reset the process-global handle counter before each test.
+    """Reset the process-global array + generator handle counters before each test.
 
-    This ensures tests that assert exact handle names (e.g. "a0") remain
-    deterministic.  Production NEVER calls this — the counter is only reset
+    This ensures tests that assert exact handle names (e.g. "a0", "g0") remain
+    deterministic.  Production NEVER calls these — the counters are only reset
     here for test isolation.
     """
     import flopscope_server._array_store as mod
+    import flopscope_server._generator_store as gmod
 
     mod._reset_handle_counter()
+    gmod._reset_gen_counter()
     yield

--- a/flopscope-server/tests/test_connection_store.py
+++ b/flopscope-server/tests/test_connection_store.py
@@ -1,0 +1,30 @@
+"""Tests for ConnectionStore — written first (TDD)."""
+
+import numpy as np
+from flopscope_server._array_store import ArrayStore
+from flopscope_server._connection_store import ConnectionStore
+from flopscope_server._generator_store import GeneratorStore
+
+
+def test_bundles_array_and_generator_stores():
+    conn = ConnectionStore()
+    assert isinstance(conn.arrays, ArrayStore)
+    assert isinstance(conn.generators, GeneratorStore)
+
+
+def test_array_and_generator_stores_are_independent():
+    conn = ConnectionStore()
+    a = conn.arrays.put(np.array([1, 2, 3]))
+    g = conn.generators.put(np.random.default_rng(0))
+    assert a == "a0"
+    assert g == "g0"
+    np.testing.assert_array_equal(conn.arrays.get(a), np.array([1, 2, 3]))
+    assert conn.generators.get(g) is not None
+
+
+def test_each_connection_store_has_its_own_dicts():
+    c1 = ConnectionStore()
+    c2 = ConnectionStore()
+    c1.arrays.put(np.array([1]))
+    assert c1.arrays.count == 1
+    assert c2.arrays.count == 0  # independent dicts

--- a/flopscope-server/tests/test_generator_store.py
+++ b/flopscope-server/tests/test_generator_store.py
@@ -1,0 +1,83 @@
+"""Tests for GeneratorStore — written first (TDD)."""
+
+import numpy as np
+import pytest
+from flopscope_server._generator_store import GeneratorStore
+
+
+@pytest.fixture()
+def store():
+    return GeneratorStore()
+
+
+def test_put_returns_handle(store):
+    handle = store.put(np.random.default_rng(0))
+    assert handle == "g0"
+
+
+def test_get_returns_same_object(store):
+    gen = np.random.default_rng(0)
+    handle = store.put(gen)
+    assert store.get(handle) is gen
+
+
+def test_sequential_ids(store):
+    gens = [store.put(np.random.default_rng(i)) for i in range(3)]
+    assert gens == ["g0", "g1", "g2"]
+
+
+def test_ids_are_process_global_across_instances():
+    # No autouse reset between these two stores within one test: ids must NOT
+    # restart at g0 for the second store (process-global monotonic counter).
+    s1 = GeneratorStore()
+    h0 = s1.put(np.random.default_rng(0))
+    s2 = GeneratorStore()
+    h1 = s2.put(np.random.default_rng(1))
+    assert h0 == "g0"
+    assert h1 == "g1"  # continues across instances, never reused
+
+
+def test_get_missing_raises_keyerror_with_handle_and_message(store):
+    try:
+        store.get("g99")
+    except KeyError as exc:
+        assert "g99" in str(exc)
+        assert "not found in store" in str(exc)
+    else:
+        pytest.fail("Expected KeyError for missing handle")
+
+
+def test_ids_keep_incrementing_after_free(store):
+    # Freeing a handle must NOT rewind the process-global counter — the next id
+    # continues monotonically (the counter lives in the module, not the dict).
+    h0 = store.put(np.random.default_rng(0))
+    store.free([h0])
+    h1 = store.put(np.random.default_rng(1))
+    assert h0 == "g0"
+    assert h1 == "g1"
+
+
+def test_free_removes_handle(store):
+    handle = store.put(np.random.default_rng(0))
+    store.free([handle])
+    with pytest.raises(KeyError):
+        store.get(handle)
+
+
+def test_free_unknown_handle_is_silent(store):
+    store.free(["nonexistent"])  # must not raise
+
+
+def test_free_empty_list_is_silent(store):
+    store.free([])  # must not raise
+
+
+def test_count_reflects_size(store):
+    assert store.count == 0
+    h0 = store.put(np.random.default_rng(0))
+    assert store.count == 1
+    store.free([h0])
+    assert store.count == 0
+    store.put(np.random.default_rng(1))
+    store.clear()
+    assert store.count == 0

--- a/flopscope-server/tests/test_request_handler.py
+++ b/flopscope-server/tests/test_request_handler.py
@@ -185,14 +185,14 @@ def test_handle_fetch_slice(handler, session):
 def test_handle_fetch_slice_does_not_allocate_new_handle(handler, session):
     arr = np.arange(10, dtype=np.float64)
     handle = session.store_array(arr)
-    initial_count = session._store.count
+    initial_count = session._conn.arrays.count
 
     first = handler.handle({"op": "fetch_slice", "id": handle, "slices": [[2, 5]]})
     second = handler.handle({"op": "fetch_slice", "id": handle, "slices": [[4, 7]]})
 
     assert first["status"] == "ok"
     assert second["status"] == "ok"
-    assert session._store.count == initial_count
+    assert session._conn.arrays.count == initial_count
 
 
 # ---------------------------------------------------------------------------

--- a/flopscope-server/tests/test_server.py
+++ b/flopscope-server/tests/test_server.py
@@ -19,10 +19,17 @@ SERVER_URL = "tcp://127.0.0.1:15555"
 
 
 def _send(sock: zmq.Socket, msg: dict) -> dict:
-    """Send a msgpack request and return the decoded response."""
+    """Send a msgpack request and return the decoded response.
+
+    Decode with ``strict_map_key=False`` to match how the real consumers decode
+    server responses — the flopscope-client (``_protocol.py``) and the whestbench
+    worker both pass ``strict_map_key=False``. The ``budget_close`` summary's
+    ``by_namespace`` breakdown legitimately uses a ``None`` key for unlabeled ops,
+    which the strict default rejects.
+    """
     sock.send(msgpack.packb(msg, use_bin_type=True))
     raw = sock.recv()
-    return msgpack.unpackb(raw, raw=False)
+    return msgpack.unpackb(raw, raw=False, strict_map_key=False)
 
 
 # ---------------------------------------------------------------------------

--- a/flopscope-server/tests/test_server.py
+++ b/flopscope-server/tests/test_server.py
@@ -382,11 +382,24 @@ def test_handle_persists_across_budget_sessions(server_and_client):
     assert resp["status"] == "ok"
     floor_id = resp["result"]["id"]
     assert resp["result"]["shape"] == []
+
+    # Burn FLOPs in MLP #1 so the per-MLP budget reset is observable in MLP #2.
+    ones_resp = _send(client, {"op": "ones", "args": [(8,)], "kwargs": {}})
+    _send(client, {"op": "exp", "args": [ones_resp["result"]["id"]], "kwargs": {}})
+    mlp1_status = _send(client, {"op": "budget_status"})
+    assert mlp1_status["result"]["flops_used"] > 0
     _send(client, {"op": "budget_close"})
 
     # MLP #2 on the same connection: a new array must NOT reuse floor's id, and
     # the floor handle must still resolve to its original 0-d array.
     _send(client, {"op": "budget_open", "flop_budget": 1_000_000})
+
+    # Per-MLP budget integrity: each budget_open starts a FRESH FLOP counter —
+    # MLP #1's spend must NOT carry over (only the handle store persists, not
+    # the budget). This is the dual of the persistence invariant below.
+    mlp2_status = _send(client, {"op": "budget_status"})
+    assert mlp2_status["result"]["flops_used"] == 0
+    assert mlp2_status["result"]["flops_remaining"] == 1_000_000
 
     weights_arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype="float32")
     resp = _send(

--- a/flopscope-server/tests/test_server.py
+++ b/flopscope-server/tests/test_server.py
@@ -356,3 +356,77 @@ def test_fetch_contributes_no_kernel():
     handler.handle({"op": "fetch", "id": h})
     assert handler.kernel_ns == 0
     session.close()
+
+
+def test_handle_persists_across_budget_sessions(server_and_client):
+    """A handle minted in MLP #1's budget session resolves in MLP #2's session.
+
+    Mirrors PR #108's tests/integration/test_flopscope_session_handle_lifetime.py
+    assertion (c): the warm child holds a module-level handle across a
+    budget_close/budget_open, and maximum(var_c, floor) must succeed.
+    """
+    _server, client = server_and_client
+
+    # MLP #1: create a 0-d "floor" array (scalar 0.0), capture its handle, close.
+    _send(client, {"op": "budget_open", "flop_budget": 1_000_000})
+    floor_arr = np.array(0.0, dtype="float32")
+    resp = _send(
+        client,
+        {
+            "op": "create_from_data",
+            "data": floor_arr.tobytes(),
+            "dtype": "float32",
+            "shape": [],
+        },
+    )
+    assert resp["status"] == "ok"
+    floor_id = resp["result"]["id"]
+    assert resp["result"]["shape"] == []
+    _send(client, {"op": "budget_close"})
+
+    # MLP #2 on the same connection: a new array must NOT reuse floor's id, and
+    # the floor handle must still resolve to its original 0-d array.
+    _send(client, {"op": "budget_open", "flop_budget": 1_000_000})
+
+    weights_arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype="float32")
+    resp = _send(
+        client,
+        {
+            "op": "create_from_data",
+            "data": weights_arr.tobytes(),
+            "dtype": "float32",
+            "shape": [5],
+        },
+    )
+    assert resp["status"] == "ok"
+    weights_id = resp["result"]["id"]
+    assert weights_id != floor_id  # monotonic id, never reused
+
+    # floor_id must still resolve to its original 0-d array
+    fetched = _send(client, {"op": "fetch", "id": floor_id})
+    assert fetched["status"] == "ok", fetched
+    assert fetched["shape"] == []  # still the original 0-d floor, not aliased
+    assert fetched["dtype"] == "float32"
+
+    # maximum(var_c, floor) across the budget boundary must succeed
+    var_c_arr = np.array([-1.0, 0.5, 2.0], dtype="float32")
+    resp = _send(
+        client,
+        {
+            "op": "create_from_data",
+            "data": var_c_arr.tobytes(),
+            "dtype": "float32",
+            "shape": [3],
+        },
+    )
+    assert resp["status"] == "ok"
+    var_c_id = resp["result"]["id"]
+
+    result = _send(
+        client,
+        {"op": "maximum", "args": [var_c_id, floor_id], "kwargs": {}},
+    )
+    assert result["status"] == "ok", result
+    assert result["result"]["shape"] == [3]
+
+    _send(client, {"op": "budget_close"})

--- a/flopscope-server/tests/test_session.py
+++ b/flopscope-server/tests/test_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from flopscope_server._connection_store import ConnectionStore
 from flopscope_server._session import Session
 
 import flopscope as flops
@@ -271,3 +272,51 @@ def test_close_surfaces_recorded_compute_time(session):
     )
     summary = session.close()
     assert summary["comms_summary"]["total_compute_time_ns"] == 5000
+
+
+# ---------------------------------------------------------------------------
+# Connection-lifetime store (fix #1, issue #107)
+# ---------------------------------------------------------------------------
+
+
+def test_close_does_not_clear_injected_store():
+    """A handle stored in session 1 survives close() when a ConnectionStore is shared."""
+    conn = ConnectionStore()
+    s1 = Session(flop_budget=100_000, conn_store=conn)
+    handle = s1.store_array(np.array([1.0, 2.0, 3.0]))
+    s1.close()
+    # The store is owned by the connection, not the session — handle still resolves.
+    np.testing.assert_array_equal(conn.arrays.get(handle), np.array([1.0, 2.0, 3.0]))
+
+
+def test_handle_resolves_in_a_later_session_sharing_the_store():
+    """The warm-child shape: session 2 (same ConnectionStore) can read session 1's handle."""
+    conn = ConnectionStore()
+    s1 = Session(flop_budget=100_000, conn_store=conn)
+    floor = s1.store_array(np.float32(1e-12))
+    s1.close()
+
+    s2 = Session(flop_budget=100_000, conn_store=conn)
+    later = s2.store_array(np.arange(5))
+    assert later != floor  # process-global monotonic id, never reused
+    np.testing.assert_array_equal(s2.get_array(floor), np.float32(1e-12))
+    s2.close()
+
+
+def test_generator_handle_survives_across_sessions_sharing_the_store():
+    conn = ConnectionStore()
+    s1 = Session(flop_budget=100_000, conn_store=conn)
+    g = s1.store_generator(np.random.default_rng(0))
+    s1.close()
+
+    s2 = Session(flop_budget=100_000, conn_store=conn)
+    assert s2.get_generator(g) is not None
+    s2.close()
+
+
+def test_bare_session_still_works_with_private_store():
+    """No injected store -> Session makes its own ConnectionStore (standalone use)."""
+    s = Session(flop_budget=100_000)
+    h = s.store_array(np.array([1]))
+    np.testing.assert_array_equal(s.get_array(h), np.array([1]))
+    s.close()

--- a/flopscope-server/tests/test_session.py
+++ b/flopscope-server/tests/test_session.py
@@ -215,15 +215,15 @@ def test_close_marks_session_closed():
     assert s.is_open is False
 
 
-def test_close_frees_arrays():
+def test_close_does_not_clear_bare_session_store():
+    # A bare Session owns a private ConnectionStore. close() exits the budget
+    # but does NOT clear the store — handles are connection-lifetime, not
+    # session-lifetime (issue #107). The array remains resolvable afterward.
     s = Session(flop_budget=1000)
     handle = s.store_array(np.array([1, 2, 3]))
     s.close()
-    # After close, the store should be cleared — getting the array should fail
-    # We verify indirectly: re-opening the store would reset it.
-    # Since session is closed, get_array is undefined behavior, but we can
-    # verify is_open is False and the internal store was cleared.
     assert s.is_open is False
+    np.testing.assert_array_equal(s._conn.arrays.get(handle), np.array([1, 2, 3]))
 
 
 def test_close_twice_raises_runtime_error():


### PR DESCRIPTION
## Summary
- Decouples the flopscope server's array + RNG-generator handle stores from the per-MLP budget session so they live for the **connection/process lifetime**. `budget_open`/`budget_close` now manage only the FLOP counter; `Session.close()` no longer clears the stores.
- Fixes the **warm-child handle-aliasing** bug (#107, submission 311267): a flopscope handle minted at module-import/`setup()` time (e.g. `_VAR_FLOOR = fnp.float32(1e-12)`) now survives across MLPs instead of being cleared/aliased → `ESTIMATOR_EXCEPTION` (or silently-wrong scores pre-#138).
- New `ConnectionStore` (owned by `FlopscopeServer`, injected into each `Session`) bundling the existing `ArrayStore` + a new `GeneratorStore` (process-global monotonic ids, mirroring the #138 array-counter pattern — closes the same latent aliasing for RNG generators). `RequestHandler` is unchanged.
- Memory is bounded by #138's client GC-frees + the `MAX_ARRAY_COUNT` backstop, not by per-session clearing.
- Pairs with #138 (Fix A+B); intended to ship together as **0.8.0rc2**.

## Test Plan
- [x] New `flopscope-server` unit tests: `GeneratorStore`, `ConnectionStore`, 4 `Session` persistence tests, end-to-end `test_handle_persists_across_budget_sessions` (real ZMQ over TCP, mirrors PR #108 assertion (c)) + a per-MLP budget-reset assertion (store persists, budget does not).
- [x] Full `flopscope-server` suite: **240 passed**; cross-package client↔server parity (`test_client_server_parity` + `test_serialization_parity` + `test_public_api_client_reachability`): **24 passed**; `check_version_sync`: OK (8 locations at 0.8.0rc1 — rc2 bump deferred to release).
- [x] `ruff check` + `ruff format --check` clean; gitlint clean on `origin/main..HEAD`.
- [ ] After merge: cut `0.8.0rc2`; in whestbench, uniform rc1→rc2 bump + remove the `xfail` from `tests/integration/test_flopscope_session_handle_lifetime.py` (PR #108) → flips to xpass; re-grade submission 311267.

Refs: #107, #108 (diagnosis + regression test), #138 (companion array-leak fix).
