### PR TITLE
flopscope client↔native parity: harness + RemoteArray surface + dtype + immutability (0.8.0rc3 content)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,17 +262,16 @@ jobs:
         run: uv run pytest tests/numpy_compat/ --pyargs numpy.random.tests.test_random -n auto -q
 
   client-parity:
-    # NON-BLOCKING parity monitor: runs NumPy's own suite + native-feature smoke
-    # against the flopscope CLIENT (ZMQ proxy + live server). Expected to fail
-    # until the Phase-2 fixes land (e.g. flopscope.accounting), so the whole job
-    # is continue-on-error and never gates CI. A single `uv sync --all-extras`
-    # gives the root venv pyzmq/msgpack for both the client (test process) and
-    # the server subprocess (the fixture falls back to the root venv in CI).
+    # GATE: targeted participant-parity tests must be green (rc3+).
+    # The full numpy-suite measurement runs non-blocking after the gate step
+    # (make test-client-parity-measure recipe lines start with `-` so they
+    # never fail the build). A single `uv sync --all-extras` gives the root
+    # venv pyzmq/msgpack for both the client (test process) and the server
+    # subprocess (the fixture falls back to the root venv in CI).
     if: needs.detect-impact.outputs.run_numpy_compat == 'true'
     needs: [detect-impact]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    continue-on-error: true
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -288,8 +287,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: "Client-parity: NumPy suite + native-feature smoke against the client"
+      - name: "Client-parity GATE: targeted participant-parity tests"
         run: make test-client-parity
+
+      - name: "Client-parity measurement (non-blocking): numpy's own suite vs the client"
+        run: make test-client-parity-measure
 
   client-server-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,36 @@ jobs:
       - name: "NumPy compat: random"
         run: uv run pytest tests/numpy_compat/ --pyargs numpy.random.tests.test_random -n auto -q
 
+  client-parity:
+    # NON-BLOCKING parity monitor: runs NumPy's own suite + native-feature smoke
+    # against the flopscope CLIENT (ZMQ proxy + live server). Expected to fail
+    # until the Phase-2 fixes land (e.g. flopscope.accounting), so the whole job
+    # is continue-on-error and never gates CI. A single `uv sync --all-extras`
+    # gives the root venv pyzmq/msgpack for both the client (test process) and
+    # the server subprocess (the fixture falls back to the root venv in CI).
+    if: needs.detect-impact.outputs.run_numpy_compat == 'true'
+    needs: [detect-impact]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    continue-on-error: true
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: "Client-parity: NumPy suite + native-feature smoke against the client"
+        run: make test-client-parity
+
   client-server-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,9 +233,10 @@ jobs:
       - name: Generate API docs (untracked; tests validate them)
         run: uv run python scripts/generate_api_docs.py
 
-      - name: Run tests with coverage
-        run: uv run pytest --cov=flopscope --cov-fail-under=85
-
+      # The full flopscope suite is already covered by the `test` job for this
+      # exact py/numpy matrix (3.12 x {2.2,2.3,2.4}); re-running it here is pure
+      # redundancy and only exposes this gate to unrelated flakes. This job runs
+      # the NumPy-borrowed compat suites only.
       - name: "NumPy compat: core umath"
         run: uv run pytest tests/numpy_compat/ --pyargs numpy._core.tests.test_umath -n auto -q
 

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,22 @@ test-numpy-compat:  ## Run NumPy's own tests against flopscope
 		          numpy.polynomial.tests.test_polynomial \
 		          numpy.random.tests.test_random
 
+.PHONY: test-client-parity
+test-client-parity:  ## Run NumPy's own tests against the flopscope CLIENT (+ live server)
+	$(UV) pytest tests/client_compat/ -n auto -q \
+		--pyargs numpy._core.tests.test_umath \
+		          numpy._core.tests.test_ufunc \
+		          numpy._core.tests.test_numeric \
+		          numpy.linalg.tests.test_linalg \
+		          numpy.fft.tests.test_pocketfft \
+		          numpy.fft.tests.test_helper \
+		          numpy.polynomial.tests.test_polynomial \
+		          numpy.random.tests.test_random
+
+.PHONY: client-parity-inventory
+client-parity-inventory:  ## Run the client-parity harness and emit the categorized failure inventory
+	$(UV) python scripts/client_parity_inventory.py
+
 # ---------------------------------------------------------------------------
 # Docs  (mirrors: CI → docs job)
 # ---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,19 @@ test-numpy-compat:  ## Run NumPy's own tests against flopscope
 		          numpy.random.tests.test_random
 
 .PHONY: test-client-parity
-test-client-parity:  ## Run NumPy's own tests against the flopscope CLIENT (+ live server)
-	$(UV) pytest tests/client_compat/ --ignore=tests/client_compat/methods -n auto -q
+test-client-parity:  ## GATE: targeted client-parity tests (must be green)
+	$(UV) pytest tests/client_compat/ \
+		--ignore=tests/client_compat/methods \
+		--ignore=tests/client_compat/test_numpy_function_classes.py \
+		-n auto -q
+	$(UV) pytest tests/client_compat/methods/ \
+		--ignore=tests/client_compat/methods/test_numpy_classes.py \
+		-n auto -q
 
-.PHONY: test-client-parity-methods
-test-client-parity-methods:  ## Run numpy's ndarray METHOD/operator tests against the client (methods mode)
-	$(UV) pytest tests/client_compat/methods/ -n auto -q
+.PHONY: test-client-parity-measure
+test-client-parity-measure:  ## MEASUREMENT (non-blocking): numpy's own suite vs the client
+	-$(UV) pytest tests/client_compat/test_numpy_function_classes.py -n auto -q
+	-$(UV) pytest tests/client_compat/methods/test_numpy_classes.py -n auto -q
 
 .PHONY: client-parity-inventory
 client-parity-inventory:  ## Run the client-parity harness and emit the categorized failure inventory

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ test-client-parity:  ## Run NumPy's own tests against the flopscope CLIENT (+ li
 		          numpy.polynomial.tests.test_polynomial \
 		          numpy.random.tests.test_random
 
+.PHONY: test-client-parity-methods
+test-client-parity-methods:  ## Run numpy's ndarray METHOD/operator tests against the client (methods mode)
+	$(UV) pytest tests/client_compat/methods/ -n auto -q
+
 .PHONY: client-parity-inventory
 client-parity-inventory:  ## Run the client-parity harness and emit the categorized failure inventory
 	$(UV) python scripts/client_parity_inventory.py

--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,7 @@ test-numpy-compat:  ## Run NumPy's own tests against flopscope
 
 .PHONY: test-client-parity
 test-client-parity:  ## Run NumPy's own tests against the flopscope CLIENT (+ live server)
-	$(UV) pytest tests/client_compat/ --ignore=tests/client_compat/methods -n auto -q \
-		--pyargs numpy._core.tests.test_umath \
-		          numpy._core.tests.test_ufunc \
-		          numpy._core.tests.test_numeric \
-		          numpy.linalg.tests.test_linalg \
-		          numpy.fft.tests.test_pocketfft \
-		          numpy.fft.tests.test_helper \
-		          numpy.polynomial.tests.test_polynomial \
-		          numpy.random.tests.test_random
+	$(UV) pytest tests/client_compat/ --ignore=tests/client_compat/methods -n auto -q
 
 .PHONY: test-client-parity-methods
 test-client-parity-methods:  ## Run numpy's ndarray METHOD/operator tests against the client (methods mode)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-numpy-compat:  ## Run NumPy's own tests against flopscope
 
 .PHONY: test-client-parity
 test-client-parity:  ## Run NumPy's own tests against the flopscope CLIENT (+ live server)
-	$(UV) pytest tests/client_compat/ -n auto -q \
+	$(UV) pytest tests/client_compat/ --ignore=tests/client_compat/methods -n auto -q \
 		--pyargs numpy._core.tests.test_umath \
 		          numpy._core.tests.test_ufunc \
 		          numpy._core.tests.test_numeric \

--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -76,6 +76,7 @@ ndarray = RemoteArray
 # Submodules (imported so ``fnp.linalg``, ``fnp.random``, ``fnp.fft`` work)
 # ---------------------------------------------------------------------------
 from flopscope import (
+    accounting,  # noqa: E402, F401
     fft,  # noqa: E402, F401
     flops,  # noqa: E402, F401
     linalg,  # noqa: E402, F401

--- a/flopscope-client/src/flopscope/_dtypes.py
+++ b/flopscope-client/src/flopscope/_dtypes.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from flopscope._remote_array import _DTYPE_INFO
+from flopscope._remote_array import _DTYPE_INFO, _resolve_dtype_wire_name
 
 # Public attribute name -> canonical wire name (keys of _DTYPE_INFO).
 _PUBLIC_TO_WIRE = {
@@ -111,17 +111,16 @@ class _DType:
 def _normalize_dtype(spec: Any) -> str:
     """Return the canonical wire dtype string for *spec*.
 
-    Accepts a ``_DtypeLabel``, a ``_DType``, or a (possibly aliased) string.
-    Raises ``TypeError`` for anything else.
+    Accepts a ``_DtypeLabel`` / ``_DType``, a (possibly aliased) string, a Python
+    builtin type (``float``/``int``/``bool``/``complex``), a numpy scalar type
+    (``np.float64``), or a numpy dtype / new-style DType object — resolved by the
+    numpy-free duck-typed resolver. Raises ``TypeError`` for anything else.
     """
-    name = getattr(spec, "_flopscope_dtype_name", None)
-    if isinstance(name, str):
-        return name
-    if isinstance(spec, str):
-        wire = _STRING_ALIASES.get(spec)
-        if wire is None:
-            raise TypeError(f"Unknown dtype: {spec!r}")
+    wire = _resolve_dtype_wire_name(spec)
+    if wire is not None:
         return wire
+    if isinstance(spec, str):
+        raise TypeError(f"Unknown dtype: {spec!r}")
     raise TypeError(f"Cannot interpret {spec!r} as a flopscope dtype")
 
 

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -21,6 +21,16 @@ from flopscope._math_compat import prod as _prod
 #: Maps dtype string to (struct format char, byte width).
 #: Complex types use their float-component format char; _bytes_to_list
 #: handles pairing them into Python complex numbers.
+_RAW_BUFFER_MSG = (
+    "'{attr}' exposes a pointer to the array's local memory buffer, which does "
+    "not exist for a flopscope RemoteArray — the data lives on the remote grading "
+    "server, not in this process. If you genuinely need the bytes locally, "
+    "materialize first with arr.tolist() or numpy.asarray(arr)."
+)
+
+#: Maps dtype string to (struct format char, byte width).
+#: Complex types use their float-component format char; _bytes_to_list
+#: handles pairing them into Python complex numbers.
 _DTYPE_INFO: dict[str, tuple[str, int]] = {
     "float64": ("d", 8),
     "float32": ("f", 4),
@@ -840,6 +850,23 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
         if len(args) == 1:
             return flat[args[0]]
         raise TypeError("RemoteArray.item() supports item() or item(flat_index)")
+
+    # --- raw-buffer pointer properties: raise a clear error (rc3 parity) ---
+    @property
+    def data(self):
+        raise AttributeError(_RAW_BUFFER_MSG.format(attr="data"))
+
+    @property
+    def ctypes(self):
+        raise AttributeError(_RAW_BUFFER_MSG.format(attr="ctypes"))
+
+    @property
+    def __array_interface__(self):
+        raise AttributeError(_RAW_BUFFER_MSG.format(attr="__array_interface__"))
+
+    @property
+    def __array_struct__(self):
+        raise AttributeError(_RAW_BUFFER_MSG.format(attr="__array_struct__"))
 
     # RemoteArray is not hashable (same as numpy arrays)
     __hash__ = None  # type: ignore[assignment]

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -56,6 +56,21 @@ _PY_TYPE_TO_WIRE: dict[type, str] = {
 }
 
 
+def _flatten_to_list(nested):
+    """Flatten arbitrarily-nested lists (RemoteArray.tolist() output) to a flat list."""
+    out: list = []
+
+    def _rec(x):
+        if isinstance(x, list):
+            for e in x:
+                _rec(e)
+        else:
+            out.append(x)
+
+    _rec(nested)
+    return out
+
+
 def _resolve_dtype_wire_name(spec: Any) -> str | None:
     """Return the canonical wire dtype name for a dtype-like *spec*, else None.
 
@@ -670,6 +685,96 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
 
     def copy(self):
         return self._dispatch_op("copy", self)
+
+    # --- read-only ndarray methods bridged to server ops (rc3 parity) ---
+    def all(self, *args, **kwargs):
+        return self._dispatch_op("all", self, *args, **kwargs)
+
+    def any(self, *args, **kwargs):
+        return self._dispatch_op("any", self, *args, **kwargs)
+
+    def argmax(self, *args, **kwargs):
+        return self._dispatch_op("argmax", self, *args, **kwargs)
+
+    def argmin(self, *args, **kwargs):
+        return self._dispatch_op("argmin", self, *args, **kwargs)
+
+    def argpartition(self, *args, **kwargs):
+        return self._dispatch_op("argpartition", self, *args, **kwargs)
+
+    def argsort(self, *args, **kwargs):
+        return self._dispatch_op("argsort", self, *args, **kwargs)
+
+    def choose(self, *args, **kwargs):
+        return self._dispatch_op("choose", self, *args, **kwargs)
+
+    def clip(self, *args, **kwargs):
+        return self._dispatch_op("clip", self, *args, **kwargs)
+
+    def compress(self, condition, *args, **kwargs):
+        # ndarray method: a.compress(condition, axis=...) == np.compress(condition, a, axis=...)
+        return self._dispatch_op("compress", condition, self, *args, **kwargs)
+
+    def conj(self, *args, **kwargs):
+        return self._dispatch_op("conj", self, *args, **kwargs)
+
+    def conjugate(self, *args, **kwargs):
+        return self._dispatch_op("conjugate", self, *args, **kwargs)
+
+    def cumprod(self, *args, **kwargs):
+        return self._dispatch_op("cumprod", self, *args, **kwargs)
+
+    def cumsum(self, *args, **kwargs):
+        return self._dispatch_op("cumsum", self, *args, **kwargs)
+
+    def diagonal(self, *args, **kwargs):
+        return self._dispatch_op("diagonal", self, *args, **kwargs)
+
+    def nonzero(self, *args, **kwargs):
+        return self._dispatch_op("nonzero", self, *args, **kwargs)
+
+    def prod(self, *args, **kwargs):
+        return self._dispatch_op("prod", self, *args, **kwargs)
+
+    def repeat(self, *args, **kwargs):
+        return self._dispatch_op("repeat", self, *args, **kwargs)
+
+    def round(self, *args, **kwargs):
+        return self._dispatch_op("round", self, *args, **kwargs)
+
+    def searchsorted(self, *args, **kwargs):
+        return self._dispatch_op("searchsorted", self, *args, **kwargs)
+
+    def squeeze(self, *args, **kwargs):
+        return self._dispatch_op("squeeze", self, *args, **kwargs)
+
+    def std(self, *args, **kwargs):
+        return self._dispatch_op("std", self, *args, **kwargs)
+
+    def swapaxes(self, *args, **kwargs):
+        return self._dispatch_op("swapaxes", self, *args, **kwargs)
+
+    def take(self, *args, **kwargs):
+        return self._dispatch_op("take", self, *args, **kwargs)
+
+    def trace(self, *args, **kwargs):
+        return self._dispatch_op("trace", self, *args, **kwargs)
+
+    def var(self, *args, **kwargs):
+        return self._dispatch_op("var", self, *args, **kwargs)
+
+    def item(self, *args):
+        # No server op: materialize and index (numpy .item() common cases).
+        flat = _flatten_to_list(self.tolist())
+        if not args:
+            if len(flat) != 1:
+                raise ValueError(
+                    "can only convert an array of size 1 to a Python scalar"
+                )
+            return flat[0]
+        if len(args) == 1:
+            return flat[args[0]]
+        raise TypeError("RemoteArray.item() supports item() or item(flat_index)")
 
     # RemoteArray is not hashable (same as numpy arrays)
     __hash__ = None  # type: ignore[assignment]

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -616,6 +616,40 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
     def __abs__(self):
         return self._dispatch_op("abs", self)
 
+    # --- bitwise / shift operators (rc3 parity) ---
+    def __and__(self, other):
+        return self._dispatch_op("bitwise_and", self, other)
+
+    def __rand__(self, other):
+        return self._dispatch_op("bitwise_and", other, self)
+
+    def __or__(self, other):
+        return self._dispatch_op("bitwise_or", self, other)
+
+    def __ror__(self, other):
+        return self._dispatch_op("bitwise_or", other, self)
+
+    def __xor__(self, other):
+        return self._dispatch_op("bitwise_xor", self, other)
+
+    def __rxor__(self, other):
+        return self._dispatch_op("bitwise_xor", other, self)
+
+    def __invert__(self):
+        return self._dispatch_op("invert", self)
+
+    def __lshift__(self, other):
+        return self._dispatch_op("left_shift", self, other)
+
+    def __rlshift__(self, other):
+        return self._dispatch_op("left_shift", other, self)
+
+    def __rshift__(self, other):
+        return self._dispatch_op("right_shift", self, other)
+
+    def __rrshift__(self, other):
+        return self._dispatch_op("right_shift", other, self)
+
     # Comparisons (dispatch to server -- element-wise, returning RemoteArray)
     def __eq__(self, other):
         # Only dispatch to server for array/RemoteArray comparisons

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -512,6 +512,34 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
             result = result[0]
         return bool(result)
 
+    # --- conversion / protocol dunders (rc3 parity) ---
+    def __contains__(self, item):
+        return item in _flatten_to_list(self.tolist())
+
+    def __complex__(self):
+        return complex(float(self))
+
+    def __index__(self):
+        return int(self)
+
+    def __divmod__(self, other):
+        return (self // other, self % other)
+
+    def __rdivmod__(self, other):
+        return (other // self, other % self)
+
+    def __copy__(self):
+        return self  # immutable proxy: a copy is the same handle
+
+    def __deepcopy__(self, memo):
+        return self
+
+    def __array__(self, dtype=None):
+        import numpy as _np
+
+        arr = _np.asarray(self.tolist())
+        return arr if dtype is None else arr.astype(dtype)
+
     def __iter__(self):
         if not self._shape:
             raise TypeError("iteration over a 0-d array")
@@ -612,6 +640,9 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
 
     def __neg__(self):
         return self._dispatch_op("negative", self)
+
+    def __pos__(self):
+        return self._dispatch_op("positive", self)
 
     def __abs__(self):
         return self._dispatch_op("abs", self)

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -112,6 +112,42 @@ def _resolve_dtype_wire_name(spec: Any) -> str | None:
     return None
 
 
+def _dtype_itemsize(dtype_name: str) -> int:
+    return _DTYPE_INFO[dtype_name][1]
+
+
+def _c_strides(shape, itemsize):
+    strides = []
+    acc = itemsize
+    for d in reversed(shape):
+        strides.append(acc)
+        acc *= d
+    return tuple(reversed(strides))
+
+
+class _RemoteFlags:
+    """Read-only numpy-flags-like view over a remote array's layout."""
+
+    def __init__(self, shape, strides, itemsize):
+        c_contig = strides == _c_strides(shape, itemsize)
+        self._d = {
+            "C_CONTIGUOUS": c_contig,
+            "F_CONTIGUOUS": c_contig and len(shape) <= 1,
+            "OWNDATA": False,
+            "WRITEABLE": False,  # client RemoteArray is immutable
+            "ALIGNED": True,
+        }
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def __getattr__(self, name):
+        upper = name.upper()
+        if upper in self._d:
+            return self._d[upper]
+        raise AttributeError(name)
+
+
 def _bytes_to_list(data: bytes, shape: tuple[int, ...], dtype: str) -> Any:
     """Convert raw *data* bytes into a (possibly nested) Python list.
 
@@ -445,6 +481,18 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
     def nbytes(self) -> int:
         _, item_size = _DTYPE_INFO[self._dtype]
         return self.size * item_size
+
+    @property
+    def itemsize(self) -> int:
+        return _dtype_itemsize(self._dtype)
+
+    @property
+    def strides(self) -> tuple:
+        return _c_strides(self._shape, self.itemsize)
+
+    @property
+    def flags(self):
+        return _RemoteFlags(self._shape, self.strides, self.itemsize)
 
     @property
     def T(self):

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -41,6 +41,51 @@ _DTYPE_INFO: dict[str, tuple[str, int]] = {
 #: dtypes that are stored as pairs of real components.
 _COMPLEX_DTYPES = frozenset({"complex64", "complex128"})
 
+# Accepted dtype string spellings -> canonical wire name (keys of _DTYPE_INFO
+# plus the "bool_" alias). Kept here (not flopscope._dtypes) so _encode_arg can
+# resolve dtype-like args without a circular import.
+_DTYPE_ALIASES: dict[str, str] = {name: name for name in _DTYPE_INFO}
+_DTYPE_ALIASES["bool_"] = "bool"
+
+# Python builtin types -> wire dtype (numpy's defaults).
+_PY_TYPE_TO_WIRE: dict[type, str] = {
+    float: "float64",
+    int: "int64",
+    bool: "bool",
+    complex: "complex128",
+}
+
+
+def _resolve_dtype_wire_name(spec: Any) -> str | None:
+    """Return the canonical wire dtype name for a dtype-like *spec*, else None.
+
+    Numpy-free + duck-typed, so it recognizes — without importing numpy — every
+    dtype spelling a participant (or numpy's own code) may pass:
+
+    * flopscope dtype labels/objects (``_flopscope_dtype_name``);
+    * dtype string spellings (``"float64"``, ``"bool_"``);
+    * Python builtin types (``float``/``int``/``bool``/``complex``);
+    * numpy scalar TYPE objects (``np.float64`` -> ``__name__`` == "float64");
+    * numpy dtype objects / numpy 2.x new-style DType instances
+      (``np.dtype("float64")`` / a ``Float64DType`` -> ``.name`` == "float64").
+
+    Exotic/unsupported dtypes (e.g. ``longdouble``, structured) return ``None``;
+    the caller decides whether to reject or fall through.
+    """
+    name = getattr(spec, "_flopscope_dtype_name", None)
+    if isinstance(name, str):
+        return name
+    if isinstance(spec, str):
+        return _DTYPE_ALIASES.get(spec)
+    if isinstance(spec, type):
+        if spec in _PY_TYPE_TO_WIRE:
+            return _PY_TYPE_TO_WIRE[spec]
+        return _DTYPE_ALIASES.get(getattr(spec, "__name__", ""))
+    nm = getattr(spec, "name", None)
+    if isinstance(nm, str):
+        return _DTYPE_ALIASES.get(nm)
+    return None
+
 
 def _bytes_to_list(data: bytes, shape: tuple[int, ...], dtype: str) -> Any:
     """Convert raw *data* bytes into a (possibly nested) Python list.
@@ -923,15 +968,18 @@ def _encode_arg(arg):
         return {"__rs__": arg.handle_id}
     if isinstance(arg, RemoteSeedSequence):
         return {"__seq__": arg.handle_id}
-    # Dtype objects (_DtypeLabel / _DType) serialize to their wire name.
-    # Duck-typed to avoid importing flopscope._dtypes (circular).
-    _dtype_name = getattr(arg, "_flopscope_dtype_name", None)
-    if isinstance(_dtype_name, str):
-        return _dtype_name
     from flopscope._perm_group import SymmetryGroup
 
     if isinstance(arg, SymmetryGroup):
         return {"__symmetry_group__": arg.to_payload()}
+    # Dtype-like args serialize to their canonical wire-name string: flopscope
+    # dtype labels/objects, Python builtin types (``float``), numpy scalar types
+    # (``np.float64``), and numpy dtype / new-style DType objects. Strings pass
+    # through unchanged below (the server accepts dtype strings directly).
+    if not isinstance(arg, str):
+        _wire = _resolve_dtype_wire_name(arg)
+        if _wire is not None:
+            return _wire
     if isinstance(arg, (list, tuple)):
         return [_encode_arg(item) for item in arg]
     return arg

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -428,6 +428,12 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
         return self._symmetry
 
     @property
+    def is_symmetric(self) -> bool:
+        """True if this array carries symmetry metadata (mirrors native
+        SymmetricTensor.is_symmetric)."""
+        return self._symmetry is not None
+
+    @property
     def ndim(self) -> int:
         return len(self._shape)
 

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -580,8 +580,18 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
     def __contains__(self, item):
         return item in _flatten_to_list(self.tolist())
 
+    @timed_dispatch
     def __complex__(self):
-        return complex(float(self))
+        # Fetch the scalar and call complex() directly: routing through
+        # float(self) would raise for a genuinely complex size-1 array
+        # (e.g. fnp.array([1 + 2j])), unlike NumPy's complex(arr).
+        if self.size != 1:
+            raise TypeError("only size-1 arrays can be converted to Python scalars")
+        data, shape, dtype = self._fetch_data()
+        result = _bytes_to_list(data, shape, dtype)
+        while isinstance(result, list):
+            result = result[0]
+        return complex(result)
 
     def __index__(self):
         return int(self)
@@ -637,6 +647,54 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
             "or use a whole-array update (arr = arr + x). See "
             "https://aicrowd.github.io/flopscope/docs/getting-started/competition/#immutable-arrays"
         )
+
+    # In-place operators raise, mirroring native FlopscopeArray. Without these,
+    # `a += b` would fall back to __add__ and silently rebind `a` on the client
+    # while raising locally — breaking local==eval immutability parity.
+    def _raise_inplace(self, verb: str, sym: str, func: str):
+        raise TypeError(
+            f"in-place {verb} (arr {sym} x) is not supported; flopscope arrays "
+            f"are immutable. Use arr = fnp.{func}(arr, x) instead."
+        )
+
+    def __iadd__(self, other):
+        self._raise_inplace("add", "+=", "add")
+
+    def __isub__(self, other):
+        self._raise_inplace("subtract", "-=", "subtract")
+
+    def __imul__(self, other):
+        self._raise_inplace("multiply", "*=", "multiply")
+
+    def __itruediv__(self, other):
+        self._raise_inplace("divide", "/=", "true_divide")
+
+    def __ifloordiv__(self, other):
+        self._raise_inplace("floor divide", "//=", "floor_divide")
+
+    def __imod__(self, other):
+        self._raise_inplace("mod", "%=", "mod")
+
+    def __ipow__(self, other):
+        self._raise_inplace("power", "**=", "power")
+
+    def __imatmul__(self, other):
+        self._raise_inplace("matmul", "@=", "matmul")
+
+    def __iand__(self, other):
+        self._raise_inplace("bitwise-and", "&=", "bitwise_and")
+
+    def __ior__(self, other):
+        self._raise_inplace("bitwise-or", "|=", "bitwise_or")
+
+    def __ixor__(self, other):
+        self._raise_inplace("bitwise-xor", "^=", "bitwise_xor")
+
+    def __ilshift__(self, other):
+        self._raise_inplace("left shift", "<<=", "left_shift")
+
+    def __irshift__(self, other):
+        self._raise_inplace("right shift", ">>=", "right_shift")
 
     # -- operator overloads (dispatch to server) ----------------------------
 

--- a/flopscope-client/src/flopscope/accounting.py
+++ b/flopscope-client/src/flopscope/accounting.py
@@ -1,0 +1,14 @@
+"""flopscope.accounting — FLOP cost-estimation helpers (client surface).
+
+Mirrors the native ``flopscope.accounting`` public namespace; cost helpers are
+re-exported from the client's ``flops`` module.
+"""
+
+from flopscope.flops import (  # noqa: F401
+    einsum_cost,
+    pointwise_cost,
+    reduction_cost,
+    svd_cost,
+)
+
+__all__ = ["pointwise_cost", "reduction_cost", "einsum_cost", "svd_cost"]

--- a/flopscope-client/src/flopscope/numpy/__init__.py
+++ b/flopscope-client/src/flopscope/numpy/__init__.py
@@ -18,3 +18,15 @@ __all__ = list(_flopscope.__all__)
 from flopscope._getattr import make_module_getattr as _make_module_getattr  # noqa: E402,I001
 
 __getattr__ = _make_module_getattr("", "flopscope.numpy")
+
+# Re-export the real submodule packages so `import flopscope.numpy.linalg` works.
+# We must also register them in sys.modules under the flopscope.numpy.* keys so
+# that `import flopscope.numpy.linalg` (dot-import syntax) resolves correctly.
+import sys as _sys  # noqa: E402
+
+from flopscope import fft, linalg, random, stats  # noqa: E402,F401
+
+_sys.modules.setdefault("flopscope.numpy.fft", fft)
+_sys.modules.setdefault("flopscope.numpy.linalg", linalg)
+_sys.modules.setdefault("flopscope.numpy.random", random)
+_sys.modules.setdefault("flopscope.numpy.stats", stats)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ exclude_lines = [
 pythonVersion = "3.10"
 typeCheckingMode = "standard"
 include = ["src", "tests"]
+# The client-parity harness imports the CLIENT flopscope package
+# (flopscope-client/src), a different package root added to sys.path at runtime
+# that this native-rooted pyright config cannot resolve. It runs as its own
+# pytest process; exclude it from static analysis. (Defaults preserved.)
+exclude = ["**/node_modules", "**/__pycache__", "**/.*", "tests/client_compat"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ version_files = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--ignore=tests/numpy_compat -n auto"
+addopts = "--ignore=tests/numpy_compat --ignore=tests/client_compat -n auto"
 filterwarnings = [
     # flopscope's own tests call configure() on the in-process backend
     # legitimately; the participant-facing no-op notice is just noise here.

--- a/scripts/client_parity_inventory.py
+++ b/scripts/client_parity_inventory.py
@@ -1,9 +1,12 @@
 """Run the client-parity harness and emit a categorized failure inventory.
 
-Runs the full ``tests/client_compat/`` suite (NumPy's own tests routed to the
-flopscope CLIENT, plus the native-feature smoke + audit-gap probes) and parses
-the JUnit XML it emits. JUnit is used (not ``--report-log``) because it ships
-with pytest — no extra dependency / lockfile churn for a measurement-only tool.
+Runs the local wrapper test files (NumPy's own test classes subclassed as local
+files so the autouse server/budget fixture fires and ops route to the flopscope
+CLIENT) and parses the JUnit XML it emits. Running NumPy's suites via ``--pyargs``
+instead would collect them from site-packages, outside the conftest scope, so
+the fixture never fires and the measurement degrades to a native-vs-native no-op.
+JUnit is used (not ``--report-log``) because it ships with pytest — no extra
+dependency / lockfile churn for a measurement-only tool.
 
 Output: a markdown report with the run totals and every failing test grouped by
 exception signature, split into candidate **fix-now** (a real participant-usable
@@ -26,15 +29,15 @@ import sys
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 
-SUITES = [
-    "numpy._core.tests.test_umath",
-    "numpy._core.tests.test_ufunc",
-    "numpy._core.tests.test_numeric",
-    "numpy.linalg.tests.test_linalg",
-    "numpy.fft.tests.test_pocketfft",
-    "numpy.fft.tests.test_helper",
-    "numpy.polynomial.tests.test_polynomial",
-    "numpy.random.tests.test_random",
+# Local wrapper test files that subclass NumPy's own test classes so the autouse
+# server/budget fixture actually fires. Running NumPy's suites via ``--pyargs``
+# instead collects them from site-packages — outside the conftest's scope — so
+# the budget fixture never activates, the patch wrapper sees no active
+# BudgetContext, and every op delegates back to native NumPy (a native-vs-native
+# no-op). These wrapper files are what genuinely exercises the CLIENT.
+SUITE_FILES = [
+    "tests/client_compat/test_numpy_function_classes.py",
+    "tests/client_compat/methods/test_numpy_classes.py",
 ]
 
 _JUNIT = "/tmp/client_parity_junit.xml"
@@ -50,15 +53,13 @@ def run() -> None:
         "uv",
         "run",
         "pytest",
-        "tests/client_compat/",
+        *SUITE_FILES,
         "-p",
         "no:cacheprovider",
         "-n",
         "auto",
         "-q",
         f"--junit-xml={_JUNIT}",
-        "--pyargs",
-        *SUITES,
     ]
     # check=False: a non-zero exit (failures exist) is the normal measurement case.
     subprocess.run(cmd, check=False)

--- a/scripts/client_parity_inventory.py
+++ b/scripts/client_parity_inventory.py
@@ -1,0 +1,129 @@
+"""Run the client-parity harness and emit a categorized failure inventory.
+
+Runs the full ``tests/client_compat/`` suite (NumPy's own tests routed to the
+flopscope CLIENT, plus the native-feature smoke + audit-gap probes) and parses
+the JUnit XML it emits. JUnit is used (not ``--report-log``) because it ships
+with pytest — no extra dependency / lockfile churn for a measurement-only tool.
+
+Output: a markdown report with the run totals and every failing test grouped by
+exception signature, split into candidate **fix-now** (a real participant-usable
+API gap) vs candidate **xfail** (by-design: immutability / budget / size-cap;
+proxy-internal: memory-layout / strides). This feeds the Phase-1 decision gate;
+it does NOT fix anything.
+
+Note on coverage: the numpy suite exercises the patched numpy *functions* against
+native ndarrays, so it does NOT surface RemoteArray operator/method/namespace
+gaps (bitwise &, .argsort, flopscope.numpy package). Those are catalogued
+directly in tests/client_compat/test_audit_gaps.py and
+test_native_feature_smoke.py; this report points at them.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+
+SUITES = [
+    "numpy._core.tests.test_umath",
+    "numpy._core.tests.test_ufunc",
+    "numpy._core.tests.test_numeric",
+    "numpy.linalg.tests.test_linalg",
+    "numpy.fft.tests.test_pocketfft",
+    "numpy.fft.tests.test_helper",
+    "numpy.polynomial.tests.test_polynomial",
+    "numpy.random.tests.test_random",
+]
+
+_JUNIT = "/tmp/client_parity_junit.xml"
+_BY_DESIGN = re.compile(
+    r"immutable|budget|too large|exceeds .* limit|contiguous|strides|server-side",
+    re.IGNORECASE,
+)
+_EXC = re.compile(r"([A-Za-z_][\w.]*(?:Error|Exception|Warning)): ([^\n]*)")
+
+
+def run() -> None:
+    cmd = [
+        "uv", "run", "pytest", "tests/client_compat/",
+        "-p", "no:cacheprovider", "-n", "auto", "-q",
+        f"--junit-xml={_JUNIT}",
+        "--pyargs", *SUITES,
+    ]
+    # check=False: a non-zero exit (failures exist) is the normal measurement case.
+    subprocess.run(cmd, check=False)
+
+
+def _signature(message: str, text: str) -> str:
+    blob = f"{message}\n{text}"
+    m = _EXC.search(blob)
+    if not m:
+        return "UNKNOWN"
+    exc, msg = m.group(1), m.group(2).strip()
+    # Normalize volatile bits so similar failures group together.
+    msg = re.sub(r"0x[0-9a-fA-F]+", "0xADDR", msg)
+    msg = re.sub(r"\d[\d,]*", "N", msg)
+    return f"{exc}: {msg[:90]}"
+
+
+def parse() -> dict:
+    tree = ET.parse(_JUNIT)
+    root = tree.getroot()
+    suites = root.findall(".//testsuite") or [root]
+    totals = {k: 0 for k in ("tests", "failures", "errors", "skipped")}
+    fails: dict[str, list[str]] = defaultdict(list)
+    for ts in suites:
+        for k in totals:
+            totals[k] += int(ts.get(k, 0))
+        for tc in ts.findall("testcase"):
+            node = f"{tc.get('classname', '')}::{tc.get('name', '')}"
+            for tag in ("failure", "error"):
+                el = tc.find(tag)
+                if el is not None:
+                    sig = _signature(el.get("message", ""), el.text or "")
+                    fails[sig].append(node)
+    return {"totals": totals, "fails": fails}
+
+
+def report(data: dict) -> None:
+    t = data["totals"]
+    fails = data["fails"]
+    n_fail = sum(len(v) for v in fails.values())
+    passed = t["tests"] - t["failures"] - t["errors"] - t["skipped"]
+    print("# Client-parity failure inventory\n")
+    print(
+        f"Run totals: {t['tests']} collected — ~{passed} passed, "
+        f"{t['failures']} failed, {t['errors']} errored, {t['skipped']} skipped.\n"
+    )
+    print(
+        f"Distinct failure signatures: {len(fails)}; total failing tests: {n_fail}.\n"
+    )
+    fix_now, xfail = [], []
+    for sig, nodes in sorted(fails.items(), key=lambda kv: -len(kv[1])):
+        (xfail if _BY_DESIGN.search(sig) else fix_now).append((sig, nodes))
+    for title, group in [("CANDIDATE fix-now", fix_now), ("CANDIDATE xfail", xfail)]:
+        print(f"\n## {title}\n")
+        if not group:
+            print("_(none)_")
+        for sig, nodes in group:
+            print(f"- [{len(nodes):4d}] {sig}")
+            print(f"      e.g. {nodes[:3]}")
+    print("\n## Operator / method / namespace gaps (not surfaced by the numpy suite)\n")
+    print(
+        "The numpy suite operates on native ndarrays, so RemoteArray dunders/"
+        "methods and the flopscope.numpy package structure are NOT exercised "
+        "here. See tests/client_compat/test_audit_gaps.py (bitwise & | ^ ~ << >>, "
+        ".argsort/.diagonal, dtype=type-object, flopscope.numpy submodule import) "
+        "and test_native_feature_smoke.py (flopscope.accounting) for those gaps."
+    )
+
+
+def main() -> int:
+    run()
+    report(parse())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/client_parity_inventory.py
+++ b/scripts/client_parity_inventory.py
@@ -17,6 +17,7 @@ gaps (bitwise &, .argsort, flopscope.numpy package). Those are catalogued
 directly in tests/client_compat/test_audit_gaps.py and
 test_native_feature_smoke.py; this report points at them.
 """
+
 from __future__ import annotations
 
 import re
@@ -46,10 +47,18 @@ _EXC = re.compile(r"([A-Za-z_][\w.]*(?:Error|Exception|Warning)): ([^\n]*)")
 
 def run() -> None:
     cmd = [
-        "uv", "run", "pytest", "tests/client_compat/",
-        "-p", "no:cacheprovider", "-n", "auto", "-q",
+        "uv",
+        "run",
+        "pytest",
+        "tests/client_compat/",
+        "-p",
+        "no:cacheprovider",
+        "-n",
+        "auto",
+        "-q",
         f"--junit-xml={_JUNIT}",
-        "--pyargs", *SUITES,
+        "--pyargs",
+        *SUITES,
     ]
     # check=False: a non-zero exit (failures exist) is the normal measurement case.
     subprocess.run(cmd, check=False)
@@ -71,7 +80,7 @@ def parse() -> dict:
     tree = ET.parse(_JUNIT)
     root = tree.getroot()
     suites = root.findall(".//testsuite") or [root]
-    totals = {k: 0 for k in ("tests", "failures", "errors", "skipped")}
+    totals = dict.fromkeys(("tests", "failures", "errors", "skipped"), 0)
     fails: dict[str, list[str]] = defaultdict(list)
     for ts in suites:
         for k in totals:

--- a/src/flopscope/_ndarray.py
+++ b/src/flopscope/_ndarray.py
@@ -693,6 +693,28 @@ class FlopscopeArray(_np.ndarray):
             "immutable. Use fnp.partition(arr, kth) to create a copy."
         )
 
+    # fill/put/resize are C-level ndarray mutators that write the buffer
+    # directly, bypassing __setitem__ — without explicit overrides, native
+    # arrays would stay mutable here (and diverge from the client, which has no
+    # such methods).
+    def fill(self, *args: Any, **kwargs: Any) -> None:
+        raise ValueError(
+            "in-place fill is not supported; flopscope arrays are immutable. "
+            "Use fnp.full(shape, value) or fnp.full_like(arr, value) instead."
+        )
+
+    def put(self, *args: Any, **kwargs: Any) -> None:
+        raise ValueError(
+            "in-place put is not supported; flopscope arrays are immutable. "
+            "Build the result functionally instead."
+        )
+
+    def resize(self, *args: Any, **kwargs: Any) -> None:
+        raise ValueError(
+            "in-place resize is not supported; flopscope arrays are immutable. "
+            "Use fnp.reshape(arr, new_shape) to create a reshaped copy."
+        )
+
     # ----- Binary arithmetic -----
 
     def __add__(self, other: Any) -> FlopscopeArray:

--- a/src/flopscope/_ndarray.py
+++ b/src/flopscope/_ndarray.py
@@ -668,68 +668,30 @@ class FlopscopeArray(_np.ndarray):
     def nonzero(self, *args: Any, **kwargs: Any) -> tuple[FlopscopeArray, ...]:  # type: ignore[override]
         return _me().nonzero(self, *args, **kwargs)
 
-    # In-place sort/partition: NumPy mutates self and returns None.
-    # Charge FLOPs through me.sort/partition, then copy result into self.
-    # Guard against in-place mutation that would silently break symmetry.
+    # flopscope arrays are immutable: item assignment and in-place mutation
+    # are not supported.  Raise descriptive errors that match the client.
 
-    def _check_inplace_breaks_symmetry(self, op_name):
-        """Refuse in-place ops that would invalidate SymmetricTensor metadata.
-
-        ``self._symmetry`` is set by SymmetricTensor; plain FlopscopeArrays
-        do not have it (or it's None). Guarding via getattr keeps this
-        method valid on both subclasses without a forward reference.
-        """
-        sym = getattr(self, "_symmetry", None)
-        if sym is not None:
-            raise ValueError(
-                f"in-place {op_name} on a SymmetricTensor would break "
-                f"symmetry on axes {sym.axes}; call fnp.{op_name}(arr) for "
-                f"an unsymmetric copy instead."
-            )
+    def __setitem__(self, key: Any, value: Any) -> None:
+        raise TypeError(
+            "flopscope arrays are immutable, so item assignment (arr[i] = ...) "
+            "and indexed in-place updates (arr[i] += ...) are not supported. "
+            "Build the result functionally instead: collect the pieces in a "
+            "list and combine them with fnp.stack(...) / fnp.concatenate(...), "
+            "or use a whole-array update (arr = arr + x). See "
+            "https://aicrowd.github.io/flopscope/docs/getting-started/competition/#immutable-arrays"
+        )
 
     def sort(self, *args: Any, **kwargs: Any) -> None:
-        self._check_inplace_breaks_symmetry("sort")
-        result = _me().sort(self, *args, **kwargs)
-        # Strip both self and result before np.copyto: keeps the
-        # invariant ("never pass a flopscope subclass to a raw NumPy call")
-        # explicit even though np.copyto is currently NOT in the
-        # __array_function__ allowlist.
-        _np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))
+        raise ValueError(
+            "in-place sort is not supported; flopscope arrays are immutable. "
+            "Use fnp.sort(arr) to create a sorted copy."
+        )
 
     def partition(self, kth: Any, *args: Any, **kwargs: Any) -> None:
-        self._check_inplace_breaks_symmetry("partition")
-        result = _me().partition(self, kth, *args, **kwargs)
-        _np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))
-
-    def _inplace_from_result(self, result, op_name):
-        """Apply ``result`` into ``self`` in place; refuse if the
-        operation would destroy or weaken symmetry metadata.
-
-        Compare ``self.symmetry`` and ``result.symmetry`` directly via
-        ``SymmetryGroup.__eq__`` (PR #51 made these value-equal with an
-        identity short-circuit and per-instance canonical-action cache).
-        Scalar in-place ops (``a += 1.0``) keep every group identically,
-        so the comparison passes via the identity short-circuit and the
-        copy proceeds cleanly.
-
-        ``_to_base_ndarray(self)`` is required around ``np.copyto``
-        because ``np.copyto`` could otherwise dispatch via
-        ``__array_function__`` if it ever lands in the allowlist --
-        without the strip, the call would recurse back through flopscope.
-        """
-        self_sym = getattr(self, "_symmetry", None)
-        result_sym = getattr(result, "_symmetry", None)
-        if self_sym is not None:
-            if self_sym != result_sym:
-                raise ValueError(
-                    f"in-place {op_name} would destroy or weaken symmetry "
-                    f"metadata on axes {self_sym.axes} (result symmetry: "
-                    f"{result_sym.axes if result_sym is not None else None}); "
-                    f"use ``self = fnp.{op_name}(self, other)`` to accept the "
-                    f"new result explicitly."
-                )
-        _np.copyto(_to_base_ndarray(self), _to_base_ndarray(result))
-        return self
+        raise ValueError(
+            "in-place partition is not supported; flopscope arrays are "
+            "immutable. Use fnp.partition(arr, kth) to create a copy."
+        )
 
     # ----- Binary arithmetic -----
 
@@ -740,8 +702,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().add(other, self)
 
     def __iadd__(self, other: Any) -> FlopscopeArray:
-        result = _me().add(self, other)
-        return self._inplace_from_result(result, "add")
+        raise TypeError(
+            "in-place add (arr += x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.add(arr, x) instead."
+        )
 
     def __sub__(self, other: Any) -> FlopscopeArray:  # type: ignore[override]
         return _me().subtract(self, other)
@@ -750,8 +714,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().subtract(other, self)
 
     def __isub__(self, other: Any) -> FlopscopeArray:
-        result = _me().subtract(self, other)
-        return self._inplace_from_result(result, "subtract")
+        raise TypeError(
+            "in-place subtract (arr -= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.subtract(arr, x) instead."
+        )
 
     def __mul__(self, other: Any) -> FlopscopeArray:
         return _me().multiply(self, other)
@@ -760,8 +726,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().multiply(other, self)
 
     def __imul__(self, other: Any) -> FlopscopeArray:
-        result = _me().multiply(self, other)
-        return self._inplace_from_result(result, "multiply")
+        raise TypeError(
+            "in-place multiply (arr *= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.multiply(arr, x) instead."
+        )
 
     def __truediv__(self, other: Any) -> FlopscopeArray:  # type: ignore[override]
         return _me().true_divide(self, other)
@@ -770,8 +738,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().true_divide(other, self)
 
     def __itruediv__(self, other: Any) -> FlopscopeArray:
-        result = _me().true_divide(self, other)
-        return self._inplace_from_result(result, "true_divide")
+        raise TypeError(
+            "in-place divide (arr /= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.true_divide(arr, x) instead."
+        )
 
     def __floordiv__(self, other: Any) -> FlopscopeArray:  # type: ignore[override]
         return _me().floor_divide(self, other)
@@ -780,8 +750,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().floor_divide(other, self)
 
     def __ifloordiv__(self, other: Any) -> FlopscopeArray:
-        result = _me().floor_divide(self, other)
-        return self._inplace_from_result(result, "floor_divide")
+        raise TypeError(
+            "in-place floor divide (arr //= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.floor_divide(arr, x) instead."
+        )
 
     def __mod__(self, other: Any) -> FlopscopeArray:
         return _me().mod(self, other)
@@ -790,8 +762,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().mod(other, self)
 
     def __imod__(self, other: Any) -> FlopscopeArray:
-        result = _me().mod(self, other)
-        return self._inplace_from_result(result, "mod")
+        raise TypeError(
+            "in-place mod (arr %= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.mod(arr, x) instead."
+        )
 
     def __pow__(self, other: Any) -> FlopscopeArray:
         return _me().power(self, other)
@@ -800,8 +774,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().power(other, self)
 
     def __ipow__(self, other: Any) -> FlopscopeArray:
-        result = _me().power(self, other)
-        return self._inplace_from_result(result, "power")
+        raise TypeError(
+            "in-place power (arr **= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.power(arr, x) instead."
+        )
 
     def __matmul__(self, other: Any) -> FlopscopeArray:
         return _me().matmul(self, other)
@@ -810,16 +786,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().matmul(other, self)
 
     def __imatmul__(self, other: Any) -> FlopscopeArray:
-        # __imatmul__ is special: matmul output shape may differ from
-        # self.shape, in which case in-place mutation is impossible.
-        # CPython's documented in-place fallback rebinds the name to the
-        # new (out-of-place) result. NumPy raises ValueError on shape
-        # mismatch; we follow the CPython fallback so typical pipelines
-        # using ``A @= B`` to grow state work cleanly.
-        result = _me().matmul(self, other)
-        if result.shape != self.shape:
-            return result
-        return self._inplace_from_result(result, "matmul")
+        raise TypeError(
+            "in-place matmul (arr @= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.matmul(arr, x) instead."
+        )
 
     # ----- Unary arithmetic -----
 
@@ -868,8 +838,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().bitwise_and(other, self)
 
     def __iand__(self, other: Any) -> FlopscopeArray:
-        result = _me().bitwise_and(self, other)
-        return self._inplace_from_result(result, "bitwise_and")
+        raise TypeError(
+            "in-place bitwise and (arr &= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.bitwise_and(arr, x) instead."
+        )
 
     def __or__(self, other: Any) -> FlopscopeArray:
         return _me().bitwise_or(self, other)
@@ -878,8 +850,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().bitwise_or(other, self)
 
     def __ior__(self, other: Any) -> FlopscopeArray:
-        result = _me().bitwise_or(self, other)
-        return self._inplace_from_result(result, "bitwise_or")
+        raise TypeError(
+            "in-place bitwise or (arr |= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.bitwise_or(arr, x) instead."
+        )
 
     def __xor__(self, other: Any) -> FlopscopeArray:
         return _me().bitwise_xor(self, other)
@@ -888,8 +862,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().bitwise_xor(other, self)
 
     def __ixor__(self, other: Any) -> FlopscopeArray:
-        result = _me().bitwise_xor(self, other)
-        return self._inplace_from_result(result, "bitwise_xor")
+        raise TypeError(
+            "in-place bitwise xor (arr ^= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.bitwise_xor(arr, x) instead."
+        )
 
     def __lshift__(self, other: Any) -> FlopscopeArray:
         return _me().left_shift(self, other)
@@ -898,8 +874,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().left_shift(other, self)
 
     def __ilshift__(self, other: Any) -> FlopscopeArray:
-        result = _me().left_shift(self, other)
-        return self._inplace_from_result(result, "left_shift")
+        raise TypeError(
+            "in-place left shift (arr <<= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.left_shift(arr, x) instead."
+        )
 
     def __rshift__(self, other: Any) -> FlopscopeArray:
         return _me().right_shift(self, other)
@@ -908,8 +886,10 @@ class FlopscopeArray(_np.ndarray):
         return _me().right_shift(other, self)
 
     def __irshift__(self, other: Any) -> FlopscopeArray:
-        result = _me().right_shift(self, other)
-        return self._inplace_from_result(result, "right_shift")
+        raise TypeError(
+            "in-place right shift (arr >>= x) is not supported; flopscope arrays are "
+            "immutable. Use arr = fnp.right_shift(arr, x) instead."
+        )
 
 
 def wrap_module_returns(module, skip_names=None, check_module=True):

--- a/tests/client_compat/_coerce.py
+++ b/tests/client_compat/_coerce.py
@@ -29,16 +29,34 @@ def _materialize(x):
     return x.tolist() if hasattr(x, "tolist") else float(x)
 
 
+class _CoercingConstructor:
+    """Materialize a leading RemoteArray, then delegate to a numpy constructor.
+
+    Implemented as a CLASS INSTANCE, not a function, on purpose: numpy's tests
+    store constructors as class attributes (e.g. ``self.array = np.array`` then
+    ``self.array([[1, 3]], dtype=...)``). A plain function is a descriptor, so
+    Python would auto-bind ``self`` as the first positional argument — numpy then
+    sees ``array(self, data, dtype=...)`` and raises "dtype given by name and
+    position". Instances have no ``__get__``, so they are returned unbound and
+    receive only the caller's arguments. (Same rationale as the native harness's
+    ``_NonDescriptor``.)
+    """
+
+    def __init__(self, orig):
+        self._orig = orig
+        self.__name__ = getattr(orig, "__name__", "")
+        self.__qualname__ = getattr(orig, "__qualname__", self.__name__)
+        self.__doc__ = getattr(orig, "__doc__", None)
+
+    def __call__(self, obj, *args, **kwargs):
+        if _is_remote(obj):
+            obj = _materialize(obj)
+        return self._orig(obj, *args, **kwargs)
+
+
 def install() -> None:
     for name, orig in _ORIG.items():
-        def make(orig=orig):
-            def wrapper(obj, *args, **kwargs):
-                if _is_remote(obj):
-                    obj = _materialize(obj)
-                return orig(obj, *args, **kwargs)
-            return wrapper
-
-        setattr(np, name, make())
+        setattr(np, name, _CoercingConstructor(orig))
 
 
 def uninstall() -> None:

--- a/tests/client_compat/_coerce.py
+++ b/tests/client_compat/_coerce.py
@@ -13,6 +13,7 @@ wrappers own ``array``/``asarray``/``asanyarray`` (they do coercion, not client
 routing). ``_ORIG`` is snapshotted at import — before ``patch()`` — so the
 wrappers call the genuine numpy constructors and never recurse.
 """
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/client_compat/_coerce.py
+++ b/tests/client_compat/_coerce.py
@@ -1,0 +1,46 @@
+"""Make NumPy's assert/array helpers understand client RemoteArray results.
+
+We do NOT modify client code (Phase 1 is measurement only). Instead we wrap the
+numpy entry points that asserts route through (``asarray``/``asanyarray``/
+``array``) so a ``RemoteArray``/``RemoteScalar`` is materialized to a real
+ndarray via ``.tolist()``. ``np.testing.assert_*`` call ``asanyarray``/
+``asarray`` on their inputs, so wrapping those lets value/shape assertions work
+against remote handles.
+
+This is the OUTPUT side; the INPUT side (coercing ndarray args INTO the client)
+lives in ``_patch_client.py``. ``install()`` runs AFTER ``patch()`` so these
+wrappers own ``array``/``asarray``/``asanyarray`` (they do coercion, not client
+routing). ``_ORIG`` is snapshotted at import — before ``patch()`` — so the
+wrappers call the genuine numpy constructors and never recurse.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+_ORIG = {name: getattr(np, name) for name in ("asarray", "asanyarray", "array")}
+
+
+def _is_remote(x) -> bool:
+    return type(x).__name__ in ("RemoteArray", "RemoteScalar")
+
+
+def _materialize(x):
+    # RemoteArray -> nested lists; RemoteScalar -> python scalar.
+    return x.tolist() if hasattr(x, "tolist") else float(x)
+
+
+def install() -> None:
+    for name, orig in _ORIG.items():
+        def make(orig=orig):
+            def wrapper(obj, *args, **kwargs):
+                if _is_remote(obj):
+                    obj = _materialize(obj)
+                return orig(obj, *args, **kwargs)
+            return wrapper
+
+        setattr(np, name, make())
+
+
+def uninstall() -> None:
+    for name, orig in _ORIG.items():
+        setattr(np, name, orig)

--- a/tests/client_compat/_patch_client.py
+++ b/tests/client_compat/_patch_client.py
@@ -18,6 +18,7 @@ ufunc-typed names (e.g. ``np.add``) are skipped — their replacements are plain
 functions lacking ``.reduce``/``.outer``/``.nargs`` which numpy probes at
 collection time (same rationale as the native harness).
 """
+
 from __future__ import annotations
 
 import functools
@@ -25,7 +26,6 @@ import importlib
 import sys
 
 import numpy as np
-
 from flopscope._registry_data import FUNCTION_CATEGORIES
 
 # Originals we replaced, for unpatch().

--- a/tests/client_compat/_patch_client.py
+++ b/tests/client_compat/_patch_client.py
@@ -1,0 +1,150 @@
+"""Patch ``numpy.<fn>`` -> CLIENT ``flopscope.numpy.<fn>`` for the parity harness.
+
+Adapted from ``tests/numpy_compat/conftest.py::_patch_numpy``, but:
+
+1. The source is the **client** ``flopscope.numpy`` (a ZMQ proxy), not native
+   flopscope. There is NO ``_np`` freeze/rebind — the client has no internal
+   numpy to recurse into.
+2. Each patched op is wrapped with an **input coercer**. The client rejects real
+   ``numpy.ndarray`` arguments (``RemoteSerializationError`` — "pass a
+   materialized array"); native flopscope accepts them. NumPy's own tests build
+   inputs via ``np.array(...)`` (kept native — ``array`` is in ``_SKIP``), so
+   those inputs arrive as ``ndarray``. The wrapper converts ``ndarray`` ->
+   ``list`` / numpy-scalar -> python-scalar so the client accepts them, exactly
+   as a participant calling ``fnp.array(data)`` would. ``RemoteArray`` args pass
+   through untouched (the client accepts those).
+
+ufunc-typed names (e.g. ``np.add``) are skipped — their replacements are plain
+functions lacking ``.reduce``/``.outer``/``.nargs`` which numpy probes at
+collection time (same rationale as the native harness).
+"""
+from __future__ import annotations
+
+import functools
+import importlib
+import sys
+
+import numpy as np
+
+from flopscope._registry_data import FUNCTION_CATEGORIES
+
+# Originals we replaced, for unpatch().
+_PATCHED: dict[str, object] = {}
+
+# Names left for native numpy (descriptor/auto-bind issues at collection time)
+# or owned by _coerce (array/asarray/asanyarray do output coercion, not routing).
+_SKIP = {
+    "linalg.outer",
+    "array",
+    "arange",
+    "asarray",
+    "random.randint",
+    "random.shuffle",
+}
+
+
+def _to_client_arg(x):
+    """Coerce a numpy value to something the client backend accepts.
+
+    ndarray -> nested list; numpy scalar -> python scalar; list/tuple ->
+    same container with elements coerced (handles ``concatenate([a, b])``).
+    RemoteArray / RemoteScalar / python scalars pass through unchanged.
+    """
+    if isinstance(x, np.ndarray):
+        return x.tolist()
+    if isinstance(x, np.generic):  # np.float64, np.int64, np.bool_, ...
+        return x.item()
+    if isinstance(x, (list, tuple)):
+        return type(x)(_to_client_arg(e) for e in x)
+    return x
+
+
+def _input_coercing(client_fn, original_fn):
+    """Wrap a client op for global numpy patching.
+
+    Routes to the client ONLY when a BudgetContext is active (i.e. inside a
+    test body, where the harness has a live server + open budget). Outside a
+    test — during collection, module imports, numpy's own lazy init
+    (e.g. ``numpy.random.mtrand``), or the xdist controller process — there is
+    no active budget and no guaranteed server, so the wrapper behaves as the
+    ORIGINAL numpy function. Without this guard, numpy/pytest internals that
+    call a patched function at import time dispatch to a server that may not
+    exist and the whole session dies with a handshake timeout.
+    """
+
+    @functools.wraps(client_fn)
+    def wrapper(*args, **kwargs):
+        import flopscope._budget as _b
+
+        if _b._active_context is None:
+            return original_fn(*args, **kwargs)
+        return client_fn(
+            *[_to_client_arg(a) for a in args],
+            **{k: _to_client_arg(v) for k, v in kwargs.items()},
+        )
+
+    return wrapper
+
+
+def _client_numpy():
+    mod = sys.modules.get("flopscope.numpy")
+    if mod is None:
+        mod = importlib.import_module("flopscope.numpy")
+    return mod
+
+
+def patch() -> None:
+    fnp = _client_numpy()
+    for name, cat in FUNCTION_CATEGORIES.items():
+        if cat == "blacklisted" or name in _SKIP:
+            continue
+        parts = name.split(".")
+        if len(parts) > 2:
+            continue
+
+        # Resolve the client function (attribute access; flopscope.numpy.<sub>
+        # is reachable via getattr even though it is not an importable package).
+        try:
+            if len(parts) == 1:
+                we_fn = getattr(fnp, name)
+            else:
+                we_fn = getattr(getattr(fnp, parts[0]), parts[1])
+        except AttributeError:
+            continue
+
+        # Skip ufuncs: replacements lack .reduce/.outer/.nargs probed at
+        # collection time.
+        try:
+            if len(parts) == 1:
+                np_obj = getattr(np, name, None)
+            else:
+                np_obj = getattr(getattr(np, parts[0], None), parts[1], None)
+            if isinstance(np_obj, np.ufunc):
+                continue
+        except (AttributeError, TypeError):
+            pass
+
+        try:
+            if len(parts) == 1:
+                if hasattr(np, name):
+                    original = getattr(np, name)
+                    _PATCHED[name] = original
+                    setattr(np, name, _input_coercing(we_fn, original))
+            else:
+                sub = getattr(np, parts[0])
+                if hasattr(sub, parts[1]):
+                    original = getattr(sub, parts[1])
+                    _PATCHED[name] = original
+                    setattr(sub, parts[1], _input_coercing(we_fn, original))
+        except (AttributeError, TypeError):
+            continue
+
+
+def unpatch() -> None:
+    for name, original in _PATCHED.items():
+        parts = name.split(".")
+        if len(parts) == 1:
+            setattr(np, name, original)
+        elif len(parts) == 2:
+            setattr(getattr(np, parts[0]), parts[1], original)
+    _PATCHED.clear()

--- a/tests/client_compat/_patch_client.py
+++ b/tests/client_compat/_patch_client.py
@@ -70,9 +70,17 @@ def _input_coercing(client_fn, original_fn):
     ORIGINAL numpy function. Without this guard, numpy/pytest internals that
     call a patched function at import time dispatch to a server that may not
     exist and the whole session dies with a handshake timeout.
+
+    The wrapper introspects as the ORIGINAL numpy function
+    (``wraps(original_fn)``, not ``client_fn``): numpy submodules read function
+    metadata at import time — e.g. ``numpy.ma.extras`` does
+    ``np.apply_over_axes.__doc__.find('Notes')`` — and the client proxies carry
+    ``__doc__ is None``, which would crash that import. Copying numpy's
+    ``__doc__``/``__name__``/``__module__`` keeps that introspection working
+    while behavior still routes to the client.
     """
 
-    @functools.wraps(client_fn)
+    @functools.wraps(original_fn)
     def wrapper(*args, **kwargs):
         import flopscope._budget as _b
 

--- a/tests/client_compat/_server_fixture.py
+++ b/tests/client_compat/_server_fixture.py
@@ -1,4 +1,5 @@
 """Native flopscope-server subprocess for the client-parity harness."""
+
 from __future__ import annotations
 
 import os
@@ -57,7 +58,9 @@ FlopscopeServer(url={server_url!r}).run()
 """
     proc = subprocess.Popen(
         [_VENV_PYTHON, "-c", script],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
     line = proc.stdout.readline() if proc.stdout else ""
     if "SERVER_READY" not in line:

--- a/tests/client_compat/_server_fixture.py
+++ b/tests/client_compat/_server_fixture.py
@@ -1,0 +1,75 @@
+"""Native flopscope-server subprocess for the client-parity harness."""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+# tests/client_compat/ -> repo root is two levels up.
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CLIENT_SRC = os.path.join(_ROOT, "flopscope-client", "src")
+_SERVER_SRC = os.path.join(_ROOT, "flopscope-server", "src")
+_REAL_SRC = os.path.join(_ROOT, "src")
+_SERVER_VENV = os.path.join(_ROOT, "flopscope-server", ".venv", "bin", "python")
+_ROOT_VENV = os.path.join(_ROOT, ".venv", "bin", "python")
+_VENV_PYTHON = _SERVER_VENV if os.path.exists(_SERVER_VENV) else _ROOT_VENV
+
+# Base port for the harness; distinct from test_full_integration (15560).
+# When running under pytest-xdist, each worker (gw0, gw1, ...) gets its own
+# port offset so multiple workers don't collide on the same TCP address.
+_BASE_PORT = 15571
+
+
+def _worker_port() -> int:
+    """Return a per-xdist-worker port (base + worker index, or base if not xdist)."""
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+    if worker_id.startswith("gw"):
+        try:
+            return _BASE_PORT + int(worker_id[2:])
+        except ValueError:
+            pass
+    return _BASE_PORT
+
+
+def _make_server_url() -> str:
+    return f"tcp://127.0.0.1:{_worker_port()}"
+
+
+def ensure_client_on_path() -> None:
+    """Put the CLIENT flopscope first on sys.path (before native src/)."""
+    if _CLIENT_SRC not in sys.path:
+        sys.path.insert(0, _CLIENT_SRC)
+
+
+def start_server() -> subprocess.Popen:
+    server_url = _make_server_url()
+    os.environ["FLOPSCOPE_SERVER_URL"] = server_url
+
+    script = f"""
+import sys
+sys.path.insert(0, {_REAL_SRC!r})
+sys.path.insert(0, {_SERVER_SRC!r})
+from flopscope_server._server import FlopscopeServer
+print("SERVER_READY", flush=True)
+FlopscopeServer(url={server_url!r}).run()
+"""
+    proc = subprocess.Popen(
+        [_VENV_PYTHON, "-c", script],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    line = proc.stdout.readline() if proc.stdout else ""
+    if "SERVER_READY" not in line:
+        err = proc.stderr.read() if proc.stderr else ""
+        raise RuntimeError(f"flopscope-server failed to start: {line!r} / {err[:500]}")
+    time.sleep(0.3)
+    return proc
+
+
+def stop_server(proc: subprocess.Popen) -> None:
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()

--- a/tests/client_compat/conftest.py
+++ b/tests/client_compat/conftest.py
@@ -16,6 +16,37 @@ for _mod_name in list(sys.modules.keys()):
     if _mod_name == "flopscope" or _mod_name.startswith("flopscope."):
         del sys.modules[_mod_name]
 
+# Force NumPy's lazy RNG entropy init NOW, while numpy is still unpatched, so it
+# can never trigger a patched op (-> client dispatch) later. numpy.random's
+# SeedSequence.get_assembled_entropy calls functions the patch replaces; if that
+# init first runs after patching (e.g. mid-test with an open budget), it would
+# dispatch to the server. Doing it here caches the init under native numpy.
+import numpy as _np_warmup  # noqa: E402
+
+_np_warmup.random.default_rng()
+del _np_warmup
+
+
+def pytest_configure(config):
+    # Patch numpy -> client. (_coerce.install(), added in Task 3, runs after
+    # patch() so the RemoteArray->numpy coercion wins for array/asarray.)
+    from ._patch_client import patch
+
+    patch()
+
+
+def pytest_unconfigure(config):
+    from ._patch_client import unpatch
+
+    unpatch()
+
+
+@pytest.fixture()
+def _patch_active():
+    # patch() ran at configure; this fixture documents the dependency for tests
+    # that assert the swap is active.
+    yield
+
 
 @pytest.fixture(scope="session", autouse=True)
 def _server():

--- a/tests/client_compat/conftest.py
+++ b/tests/client_compat/conftest.py
@@ -26,16 +26,30 @@ def _server():
 
 @pytest.fixture(autouse=True)
 def _fresh_connection_and_budget():
-    """Reset client connection + budget state around every test.
+    """Reset client connection + budget state and open an ambient budget per test.
 
-    Does NOT open a BudgetContext — each test is responsible for that.
-    Mirrors the ``_reset_client`` fixture in flopscope-client/tests/test_full_integration.py.
+    The ambient ``BudgetContext`` is REQUIRED, not optional: unlike native
+    flopscope (which lazily uses a global-default budget for unbudgeted ops), the
+    CLIENT raises ``NoBudgetContextError: no active session`` if an op runs with
+    no active budget. NumPy's own test suite (which this harness runs against the
+    client) never opens a budget, so without this ambient context every NumPy
+    test would fail spuriously. ``10**15`` FLOPs is effectively unbounded for
+    NumPy's tiny test arrays; ``quiet=True`` suppresses per-test output.
+
+    Hand-written harness tests therefore must NOT open their own BudgetContext
+    (the client rejects nested contexts) — they rely on this ambient one.
     """
+    import flopscope
     from flopscope._connection import reset_connection
     from flopscope._budget import _reset_global_default
 
     reset_connection()
     _reset_global_default()
-    yield
-    reset_connection()
-    _reset_global_default()
+    ctx = flopscope.BudgetContext(flop_budget=10**15, quiet=True)
+    ctx.__enter__()
+    try:
+        yield
+    finally:
+        ctx.__exit__(None, None, None)
+        reset_connection()
+        _reset_global_default()

--- a/tests/client_compat/conftest.py
+++ b/tests/client_compat/conftest.py
@@ -28,17 +28,23 @@ del _np_warmup
 
 
 def pytest_configure(config):
-    # Patch numpy -> client. (_coerce.install(), added in Task 3, runs after
-    # patch() so the RemoteArray->numpy coercion wins for array/asarray.)
+    # Import _coerce FIRST so it snapshots the genuine numpy constructors before
+    # patch() runs. Then patch numpy -> client. Then install the RemoteArray ->
+    # numpy coercion AFTER patch() so it owns array/asarray/asanyarray (those do
+    # output coercion for asserts, not client routing).
+    from . import _coerce
     from ._patch_client import patch
 
     patch()
+    _coerce.install()
 
 
 def pytest_unconfigure(config):
+    from . import _coerce
     from ._patch_client import unpatch
 
     unpatch()
+    _coerce.uninstall()
 
 
 @pytest.fixture()

--- a/tests/client_compat/conftest.py
+++ b/tests/client_compat/conftest.py
@@ -1,4 +1,5 @@
 """Client-parity harness: run NumPy's suite against the flopscope CLIENT."""
+
 from __future__ import annotations
 
 import fnmatch
@@ -78,8 +79,9 @@ def _fresh_connection_and_budget():
     Hand-written harness tests therefore must NOT open their own BudgetContext
     (the client rejects nested contexts) — they rely on this ambient one.
     """
-    import flopscope
     from flopscope._connection import reset_connection
+
+    import flopscope
     from flopscope._budget import _reset_global_default
 
     reset_connection()

--- a/tests/client_compat/conftest.py
+++ b/tests/client_compat/conftest.py
@@ -1,11 +1,13 @@
 """Client-parity harness: run NumPy's suite against the flopscope CLIENT."""
 from __future__ import annotations
 
+import fnmatch
 import sys
 
 import pytest
 
 from ._server_fixture import ensure_client_on_path, start_server, stop_server
+from .xfails_client import XFAIL_PATTERNS
 
 # MUST happen before any `import flopscope`, so the client wins over native src/.
 # Also purge any already-cached native flopscope from sys.modules so the client
@@ -90,3 +92,12 @@ def _fresh_connection_and_budget():
         ctx.__exit__(None, None, None)
         reset_connection()
         _reset_global_default()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Mark known by-design client divergences as (non-strict) xfail."""
+    for item in items:
+        for pattern, reason in XFAIL_PATTERNS.items():
+            if fnmatch.fnmatch(item.nodeid, pattern) or pattern in item.nodeid:
+                item.add_marker(pytest.mark.xfail(reason=reason, strict=False))
+                break

--- a/tests/client_compat/conftest.py
+++ b/tests/client_compat/conftest.py
@@ -1,0 +1,41 @@
+"""Client-parity harness: run NumPy's suite against the flopscope CLIENT."""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from ._server_fixture import ensure_client_on_path, start_server, stop_server
+
+# MUST happen before any `import flopscope`, so the client wins over native src/.
+# Also purge any already-cached native flopscope from sys.modules so the client
+# package wins when this conftest is imported by an xdist worker that already
+# has the native src/ on sys.path.
+ensure_client_on_path()
+for _mod_name in list(sys.modules.keys()):
+    if _mod_name == "flopscope" or _mod_name.startswith("flopscope."):
+        del sys.modules[_mod_name]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _server():
+    proc = start_server()
+    yield proc
+    stop_server(proc)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_connection_and_budget():
+    """Reset client connection + budget state around every test.
+
+    Does NOT open a BudgetContext — each test is responsible for that.
+    Mirrors the ``_reset_client`` fixture in flopscope-client/tests/test_full_integration.py.
+    """
+    from flopscope._connection import reset_connection
+    from flopscope._budget import _reset_global_default
+
+    reset_connection()
+    _reset_global_default()
+    yield
+    reset_connection()
+    _reset_global_default()

--- a/tests/client_compat/methods/_patch_constructors.py
+++ b/tests/client_compat/methods/_patch_constructors.py
@@ -1,0 +1,116 @@
+"""Patch numpy array CONSTRUCTORS -> client RemoteArray for the methods mode.
+
+The function-mode harness keeps constructors native (so the function suite runs
+on real ndarrays). This mode does the opposite: it makes np.array/zeros/ones/...
+return client RemoteArrays, so numpy's own ndarray METHOD test classes exercise
+RemoteArray's surface. asarray/asanyarray are instead made *coercing* (the assert
+path goes through them), so numpy.testing.assert_* still works. Budget-guarded:
+outside an active BudgetContext we behave as native numpy (collection/import/xdist
+controller) so nothing dispatches to an absent server.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import numpy as np
+
+from .._coerce import _CoercingConstructor  # reuse the non-descriptor coercer
+
+# Constructors numpy's method test classes use to BUILD arrays -> return RemoteArray.
+_CONSTRUCTORS = (
+    "array",
+    "zeros",
+    "zeros_like",
+    "ones",
+    "ones_like",
+    "empty",
+    "empty_like",
+    "arange",
+    "full",
+    "eye",
+    "diag",
+)
+# Entry points numpy's assert helpers use to NORMALIZE -> coerce RemoteArray->ndarray.
+_COERCERS = ("asarray", "asanyarray")
+
+_PATCHED: dict[str, object] = {}
+
+
+def _to_client_arg(x):
+    if isinstance(x, np.ndarray):
+        return x.tolist()
+    if isinstance(x, np.generic):
+        return x.item()
+    if isinstance(x, (list, tuple)):
+        return type(x)(_to_client_arg(e) for e in x)
+    return x
+
+
+class _ConstructorToRemoteArray:
+    """Route a numpy constructor to the client (returning a RemoteArray) when a
+    budget is active, else native numpy. A CLASS INSTANCE (non-descriptor) so
+    numpy tests doing ``self.array = np.array`` don't auto-bind ``self``."""
+
+    def __init__(self, client_fn, original_fn):
+        self._client_fn = client_fn
+        self._orig = original_fn
+        self.__name__ = getattr(original_fn, "__name__", "")
+        self.__qualname__ = getattr(original_fn, "__qualname__", self.__name__)
+        self.__doc__ = getattr(original_fn, "__doc__", None)
+
+    def __call__(self, *args, **kwargs):
+        import flopscope._budget as _b
+
+        if _b._active_context is None:
+            return self._orig(*args, **kwargs)
+        return self._client_fn(
+            *[_to_client_arg(a) for a in args],
+            **{k: _to_client_arg(v) for k, v in kwargs.items()},
+        )
+
+
+def _client_numpy():
+    mod = sys.modules.get("flopscope.numpy")
+    if mod is None:
+        mod = importlib.import_module("flopscope.numpy")
+    return mod
+
+
+def patch() -> None:
+    """Install the construction-swap patch.  Idempotent: safe to call twice.
+
+    Called once from pytest_configure (early, before parent conftest runs) and
+    once from pytest_sessionstart (after all configure hooks, so we win over the
+    parent conftest's _coerce.install()).  On the second call _PATCHED already
+    holds the pre-patch originals, so we only re-setattr without re-snapshotting.
+    """
+    fnp = _client_numpy()
+    for name in _CONSTRUCTORS:
+        client_fn = getattr(fnp, name, None)
+        if client_fn is None or not hasattr(np, name):
+            continue
+        current = getattr(np, name)
+        if isinstance(current, _ConstructorToRemoteArray):
+            continue  # already ours; nothing to do
+        # Snapshot the pre-patch original only on the first install.
+        if name not in _PATCHED:
+            _PATCHED[name] = current
+        original = _PATCHED[name]
+        setattr(np, name, _ConstructorToRemoteArray(client_fn, original))
+    for name in _COERCERS:
+        if not hasattr(np, name):
+            continue
+        current = getattr(np, name)
+        if isinstance(current, _CoercingConstructor):
+            continue  # already wrapped
+        if name not in _PATCHED:
+            _PATCHED[name] = current
+        setattr(np, name, _CoercingConstructor(_PATCHED[name]))
+
+
+def unpatch() -> None:
+    for name, original in _PATCHED.items():
+        setattr(np, name, original)
+    _PATCHED.clear()

--- a/tests/client_compat/methods/conftest.py
+++ b/tests/client_compat/methods/conftest.py
@@ -1,4 +1,13 @@
-"""Methods mode: run numpy's ndarray method/operator tests against the CLIENT."""
+"""Methods mode: run numpy's ndarray method/operator tests against the CLIENT.
+
+This dir lives UNDER tests/client_compat/, so the parent (function-mode) conftest
+also loads here — fine for a methods-mode run (its function patches are harmless;
+the sessionstart re-patch below wins the np.array conflict). The REVERSE is unsafe:
+a function-mode run that collects this dir would globally construction-patch
+np.array and break the function suite. The `test-client-parity` Makefile target
+therefore passes `--ignore=tests/client_compat/methods`; run this dir only via
+`make test-client-parity-methods` (or an explicit path to it).
+"""
 
 from __future__ import annotations
 

--- a/tests/client_compat/methods/conftest.py
+++ b/tests/client_compat/methods/conftest.py
@@ -1,0 +1,77 @@
+"""Methods mode: run numpy's ndarray method/operator tests against the CLIENT."""
+
+from __future__ import annotations
+
+import fnmatch
+import sys
+
+import pytest
+
+from .._server_fixture import ensure_client_on_path, start_server, stop_server
+from ..xfails_client import XFAIL_PATTERNS
+
+ensure_client_on_path()
+for _mod_name in list(sys.modules.keys()):
+    if _mod_name == "flopscope" or _mod_name.startswith("flopscope."):
+        del sys.modules[_mod_name]
+
+import numpy as _np_warmup  # noqa: E402
+
+_np_warmup.random.default_rng()
+del _np_warmup
+
+
+def pytest_configure(config):
+    from . import _patch_constructors
+
+    _patch_constructors.patch()
+
+
+def pytest_sessionstart(session):
+    # Re-apply after all pytest_configure hooks have run (parent conftest's
+    # pytest_configure fires AFTER ours, since conftest hooks call child-first;
+    # parent's _coerce.install() overwrites our construction patch). Re-patching
+    # here — after all configure hooks — ensures we win.
+    from . import _patch_constructors
+
+    _patch_constructors.patch()
+
+
+def pytest_unconfigure(config):
+    from . import _patch_constructors
+
+    _patch_constructors.unpatch()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _server():
+    proc = start_server()
+    yield proc
+    stop_server(proc)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_connection_and_budget():
+    from flopscope._connection import reset_connection
+
+    import flopscope
+    from flopscope._budget import _reset_global_default
+
+    reset_connection()
+    _reset_global_default()
+    ctx = flopscope.BudgetContext(flop_budget=10**15, quiet=True)
+    ctx.__enter__()
+    try:
+        yield
+    finally:
+        ctx.__exit__(None, None, None)
+        reset_connection()
+        _reset_global_default()
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        for pattern, reason in XFAIL_PATTERNS.items():
+            if fnmatch.fnmatch(item.nodeid, pattern) or pattern in item.nodeid:
+                item.add_marker(pytest.mark.xfail(reason=reason, strict=False))
+                break

--- a/tests/client_compat/methods/test_conversion_dunders.py
+++ b/tests/client_compat/methods/test_conversion_dunders.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+
+def test_contains():
+    import numpy as np
+
+    a = np.array([1.0, 2.0, 3.0])
+    assert (2.0 in a) is True
+    assert (9.0 in a) is False
+
+
+def test_pos():
+    import numpy as np
+
+    assert (+np.array([1.0, -2.0])).tolist() == [1.0, -2.0]
+
+
+def test_complex_conv():
+    import numpy as np
+
+    assert complex(np.array([3.0])) == complex(3.0)
+
+
+def test_copy_and_deepcopy():
+    import copy
+
+    import numpy as np
+
+    a = np.array([1.0, 2.0])
+    assert copy.copy(a).tolist() == [1.0, 2.0]
+    assert copy.deepcopy(a).tolist() == [1.0, 2.0]

--- a/tests/client_compat/methods/test_metadata.py
+++ b/tests/client_compat/methods/test_metadata.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+def test_itemsize_matches():
+    import numpy as np
+
+    assert np.array([1.0, 2.0, 3.0]).itemsize == 8  # float64
+
+
+def test_strides_is_tuple():
+    import numpy as np
+
+    a = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    assert isinstance(a.strides, tuple) and len(a.strides) == 2
+
+
+def test_flags_contiguous_and_writeable():
+    import numpy as np
+
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"] is True
+    assert a.flags["WRITEABLE"] is False  # client RemoteArray is immutable

--- a/tests/client_compat/methods/test_methods_mode_health.py
+++ b/tests/client_compat/methods/test_methods_mode_health.py
@@ -1,0 +1,28 @@
+"""Guards the construction-patched methods mode: np.array() returns a client
+RemoteArray, an existing method works on it, and numpy asserts coerce it."""
+
+from __future__ import annotations
+
+
+def test_constructor_returns_remote_array():
+    import numpy as np
+
+    a = np.array([1, 2, 3])
+    assert type(a).__name__ == "RemoteArray", (
+        f"got {type(a)!r}; construction not patched"
+    )
+
+
+def test_existing_method_works_on_remote_array():
+    import numpy as np
+
+    a = np.array([1.0, 2.0, 3.0])
+    assert float(a.sum()) == 6.0
+
+
+def test_numpy_assert_coerces_remote_array():
+    import numpy as np
+
+    a = np.array([1.0, 2.0, 3.0])
+    b = np.array([4.0, 5.0, 6.0])
+    np.testing.assert_allclose(a + b, [5.0, 7.0, 9.0])

--- a/tests/client_compat/methods/test_numpy_classes.py
+++ b/tests/client_compat/methods/test_numpy_classes.py
@@ -15,11 +15,23 @@ from __future__ import annotations
 # imported by pytest's collector before pytest_configure / pytest_sessionstart).
 from numpy._core.tests.test_multiarray import (
     TestArgmax as _TestArgmax,
+)
+from numpy._core.tests.test_multiarray import (
     TestArgmin as _TestArgmin,
+)
+from numpy._core.tests.test_multiarray import (
     TestClip as _TestClip,
+)
+from numpy._core.tests.test_multiarray import (
     TestConversion as _TestConversion,
+)
+from numpy._core.tests.test_multiarray import (
     TestMethods as _TestMethods,
+)
+from numpy._core.tests.test_multiarray import (
     TestStats as _TestStats,
+)
+from numpy._core.tests.test_multiarray import (
     TestTake as _TestTake,
 )
 

--- a/tests/client_compat/methods/test_numpy_classes.py
+++ b/tests/client_compat/methods/test_numpy_classes.py
@@ -1,0 +1,52 @@
+"""Wrap numpy's ndarray method/operator test classes so they run inside this
+conftest's scope (budget context + construction patch active).
+
+Importing numpy's test module at module level happens *before* pytest_configure
+fires the construction patch, so numpy.ma and other stdlib-side imports resolve
+against native numpy.  The subclasses below are thin shells: they inherit every
+test_ method and pytest collects them as items *inside* tests/client_compat/methods/,
+which means the _server and _fresh_connection_and_budget autouse fixtures apply and
+np.array/zeros/... are routed to RemoteArray during the test body.
+"""
+
+from __future__ import annotations
+
+# Import BEFORE the construction patch fires (module import order: this file is
+# imported by pytest's collector before pytest_configure / pytest_sessionstart).
+from numpy._core.tests.test_multiarray import (
+    TestArgmax as _TestArgmax,
+    TestArgmin as _TestArgmin,
+    TestClip as _TestClip,
+    TestConversion as _TestConversion,
+    TestMethods as _TestMethods,
+    TestStats as _TestStats,
+    TestTake as _TestTake,
+)
+
+
+class TestMethodsClient(_TestMethods):
+    """numpy.ndarray TestMethods exercised against RemoteArray."""
+
+
+class TestArgmaxClient(_TestArgmax):
+    """numpy.ndarray TestArgmax exercised against RemoteArray."""
+
+
+class TestArgminClient(_TestArgmin):
+    """numpy.ndarray TestArgmin exercised against RemoteArray."""
+
+
+class TestClipClient(_TestClip):
+    """numpy.ndarray TestClip exercised against RemoteArray."""
+
+
+class TestTakeClient(_TestTake):
+    """numpy.ndarray TestTake exercised against RemoteArray."""
+
+
+class TestStatsClient(_TestStats):
+    """numpy.ndarray TestStats exercised against RemoteArray."""
+
+
+class TestConversionClient(_TestConversion):
+    """numpy.ndarray TestConversion exercised against RemoteArray."""

--- a/tests/client_compat/methods/test_readonly_methods.py
+++ b/tests/client_compat/methods/test_readonly_methods.py
@@ -1,0 +1,50 @@
+"""Read-only ndarray methods bridge to server ops and behave like numpy."""
+
+from __future__ import annotations
+
+
+def test_argsort_matches_numpy():
+    import numpy as np  # constructors patched -> RemoteArray (methods mode)
+
+    a = np.array([3.0, 1.0, 2.0])
+    # argsort ascending: 1.0 at idx 1, 2.0 at idx 2, 3.0 at idx 0 -> [1, 2, 0]
+    assert a.argsort().tolist() == [1, 2, 0]
+
+
+def test_cumsum_matches_numpy():
+    import numpy as np
+
+    assert np.array([1.0, 2.0, 3.0]).cumsum().tolist() == [1.0, 3.0, 6.0]
+
+
+def test_clip_matches_numpy():
+    import numpy as np
+
+    assert np.array([-1.0, 0.5, 2.0]).clip(0.0, 1.0).tolist() == [0.0, 0.5, 1.0]
+
+
+def test_compress_matches_numpy():
+    import numpy as np
+
+    assert np.array([1.0, 2.0, 3.0]).compress([True, False, True]).tolist() == [
+        1.0,
+        3.0,
+    ]
+
+
+def test_trace_matches_numpy():
+    import numpy as np
+
+    assert float(np.array([[1.0, 2.0], [3.0, 4.0]]).trace()) == 5.0
+
+
+def test_prod_and_std_and_var():
+    import numpy as np
+
+    assert float(np.array([1.0, 2.0, 3.0, 4.0]).prod()) == 24.0
+
+
+def test_item_matches_numpy():
+    import numpy as np
+
+    assert np.array([42.0]).item() == 42.0

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -87,9 +87,10 @@ def test_dtype_string_alias_works():
     assert out.tolist() == [1.0, 2.0, 3.0]
 
 
-def test_dtype_type_object_gap():
-    with pytest.raises(TypeError, match="dtype"):
-        _ = fnp.array([1, 2, 3], dtype=float)
+def test_dtype_type_object_parity():
+    # rc3: dtype= now accepts Python type-objects (float/int) — parity with native.
+    assert fnp.array([1, 2, 3], dtype=float).tolist() == [1.0, 2.0, 3.0]
+    assert fnp.array([1, 2, 3], dtype=int).tolist() == [1, 2, 3]
 
 
 # --- flopscope.numpy is a module, not a package (audit P1, ~7 subs) ---

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -109,3 +109,38 @@ def test_raw_buffer_pointers_raise_clear_error():
     for attr in ("data", "ctypes", "__array_interface__", "__array_struct__"):
         with pytest.raises(AttributeError, match="remote"):
             getattr(a, attr)
+
+
+# --- in-place operators: immutable, parity with native (Codex review) ---
+# Native FlopscopeArray raises on `a += b`; without explicit __i* on the client,
+# Python would fall back to __add__ and silently rebind `a`, so `a += b` would
+# work on the eval client while raising locally. The client must raise too.
+
+
+def test_inplace_add_raises_on_client():
+    a, b = fnp.array([1.0, 2.0, 3.0]), fnp.array([1.0, 1.0, 1.0])
+    with pytest.raises(TypeError, match="immutable"):
+        a += b
+
+
+def test_inplace_mul_raises_on_client():
+    a = fnp.array([1.0, 2.0, 3.0])
+    with pytest.raises(TypeError, match="immutable"):
+        a *= fnp.array([2.0, 2.0, 2.0])
+
+
+# --- __complex__ preserves complex values (Codex review) ---
+# Must not route through float(self): float() raises for a genuinely complex
+# size-1 array, unlike NumPy's complex(arr).
+
+
+def test_complex_of_real_scalar_works():
+    assert complex(fnp.array([3.0])) == (3 + 0j)
+
+
+def test_complex_preserves_complex_value():
+    try:
+        a = fnp.array([1 + 2j])
+    except Exception:
+        pytest.skip("client/server does not support complex dtype")
+    assert complex(a) == (1 + 2j)

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -101,3 +101,10 @@ def test_float_of_reduced_scalar_works_now():
     # current client for this path; lock that in so a regression is caught.
     a = fnp.array([1.0, 2.0, 3.0])
     assert float(fnp.max(a)) == 3.0
+
+
+def test_raw_buffer_pointers_raise_clear_error():
+    a = fnp.array([1.0, 2.0, 3.0])
+    for attr in ("data", "ctypes", "__array_interface__", "__array_struct__"):
+        with pytest.raises(AttributeError, match="remote"):
+            getattr(a, attr)

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -85,12 +85,13 @@ def test_dtype_type_object_parity():
     assert fnp.array([1, 2, 3], dtype=int).tolist() == [1, 2, 3]
 
 
-# --- flopscope.numpy is a module, not a package (audit P1, ~7 subs) ---
+# --- flopscope.numpy is now a package (audit P1, ~7 subs) ---
 
 
-def test_flopscope_numpy_submodule_import_gap():
-    with pytest.raises(ModuleNotFoundError, match="not a package"):
-        __import__("flopscope.numpy.linalg")
+def test_flopscope_numpy_is_a_package():
+    import flopscope.numpy.linalg as fnl
+
+    assert hasattr(fnl, "svd")
 
 
 # --- scalar conversion: NO LONGER a gap on main (audit's __float__ bug) ---

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -26,40 +26,34 @@ import flopscope as fnp  # the CLIENT
 # is the dominant failure.
 
 
-def test_bitwise_and_gap():
+def test_bitwise_and_parity():
     a, b = fnp.array([1, 0, 1]), fnp.array([1, 1, 0])
-    with pytest.raises(TypeError, match="unsupported operand"):
-        _ = a & b
+    assert (a & b).tolist() == [1, 0, 0]
 
 
-def test_bitwise_or_gap():
+def test_bitwise_or_parity():
     a, b = fnp.array([1, 0, 1]), fnp.array([1, 1, 0])
-    with pytest.raises(TypeError, match="unsupported operand"):
-        _ = a | b
+    assert (a | b).tolist() == [1, 1, 1]
 
 
-def test_bitwise_xor_gap():
+def test_bitwise_xor_parity():
     a, b = fnp.array([1, 0, 1]), fnp.array([1, 1, 0])
-    with pytest.raises(TypeError, match="unsupported operand"):
-        _ = a ^ b
+    assert (a ^ b).tolist() == [0, 1, 1]
 
 
-def test_bitwise_invert_gap():
-    a = fnp.array([1, 0, 1])
-    with pytest.raises(TypeError, match="bad operand type for unary"):
-        _ = ~a
+def test_bitwise_invert_parity():
+    a = fnp.array([0, 1, 2])
+    assert (~a).tolist() == [-1, -2, -3]
 
 
-def test_left_shift_gap():
+def test_left_shift_parity():
     a, b = fnp.array([1, 2, 3]), fnp.array([1, 1, 1])
-    with pytest.raises(TypeError, match="unsupported operand"):
-        _ = a << b
+    assert (a << b).tolist() == [2, 4, 6]
 
 
-def test_right_shift_gap():
+def test_right_shift_parity():
     a, b = fnp.array([2, 4, 6]), fnp.array([1, 1, 1])
-    with pytest.raises(TypeError, match="unsupported operand"):
-        _ = a >> b
+    assert (a >> b).tolist() == [1, 2, 3]
 
 
 # --- ndarray methods missing on RemoteArray (audit P2) ---

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -65,16 +65,14 @@ def test_right_shift_gap():
 # --- ndarray methods missing on RemoteArray (audit P2) ---
 
 
-def test_argsort_method_gap():
+def test_argsort_method_parity():
     a = fnp.array([3.0, 1.0, 2.0])
-    with pytest.raises(AttributeError, match="argsort"):
-        _ = a.argsort()
+    assert a.argsort().tolist() == [1, 2, 0]
 
 
-def test_diagonal_method_gap():
+def test_diagonal_method_parity():
     a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
-    with pytest.raises(AttributeError, match="diagonal"):
-        _ = a.diagonal()
+    assert a.diagonal().tolist() == [1.0, 4.0]
 
 
 # --- dtype= constructor parity (audit P1) ---

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -1,0 +1,105 @@
+"""Lock in the client-vs-native gaps the 2026-06-23 prod audit found.
+
+These are OPERATOR / METHOD / NAMESPACE gaps on a real ``RemoteArray`` — the kind
+the numpy-suite harness does NOT surface (that harness operates on native
+ndarrays, so RemoteArray dunders/methods are never exercised). Each test builds a
+real client RemoteArray and asserts the gap reproduces on the CURRENT client, so
+the inventory is grounded in live behavior rather than the stale prod sample.
+
+These are deliberately written as "the gap currently reproduces" assertions:
+when Phase 2 closes a gap, the corresponding ``pytest.raises`` stops raising and
+the test FAILS — a loud signal to flip it into a positive parity assertion.
+
+All tests rely on the ambient ``BudgetContext`` (autouse fixture); they must NOT
+open their own.
+"""
+from __future__ import annotations
+
+import pytest
+
+import flopscope as fnp  # the CLIENT
+
+
+# --- Bitwise / shift operators on RemoteArray (audit's #1, ~112 subs) ---
+# Native FlopscopeArray defines __and__/__or__/__xor__/__invert__/__lshift__/
+# __rshift__; RemoteArray defines none. The boolean-mask idiom (a > 0) & (b < 1)
+# is the dominant failure.
+
+def test_bitwise_and_gap():
+    a, b = fnp.array([1, 0, 1]), fnp.array([1, 1, 0])
+    with pytest.raises(TypeError, match="unsupported operand"):
+        _ = a & b
+
+
+def test_bitwise_or_gap():
+    a, b = fnp.array([1, 0, 1]), fnp.array([1, 1, 0])
+    with pytest.raises(TypeError, match="unsupported operand"):
+        _ = a | b
+
+
+def test_bitwise_xor_gap():
+    a, b = fnp.array([1, 0, 1]), fnp.array([1, 1, 0])
+    with pytest.raises(TypeError, match="unsupported operand"):
+        _ = a ^ b
+
+
+def test_bitwise_invert_gap():
+    a = fnp.array([1, 0, 1])
+    with pytest.raises(TypeError, match="bad operand type for unary"):
+        _ = ~a
+
+
+def test_left_shift_gap():
+    a, b = fnp.array([1, 2, 3]), fnp.array([1, 1, 1])
+    with pytest.raises(TypeError, match="unsupported operand"):
+        _ = a << b
+
+
+def test_right_shift_gap():
+    a, b = fnp.array([2, 4, 6]), fnp.array([1, 1, 1])
+    with pytest.raises(TypeError, match="unsupported operand"):
+        _ = a >> b
+
+
+# --- ndarray methods missing on RemoteArray (audit P2) ---
+
+def test_argsort_method_gap():
+    a = fnp.array([3.0, 1.0, 2.0])
+    with pytest.raises(AttributeError, match="argsort"):
+        _ = a.argsort()
+
+
+def test_diagonal_method_gap():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    with pytest.raises(AttributeError, match="diagonal"):
+        _ = a.diagonal()
+
+
+# --- dtype= constructor parity (audit P1) ---
+# String aliases work; Python/numpy TYPE OBJECTS do not.
+
+def test_dtype_string_alias_works():
+    # Positive control: the string-alias path is already fine on the client.
+    out = fnp.array([1, 2, 3], dtype="float64")
+    assert out.tolist() == [1.0, 2.0, 3.0]
+
+
+def test_dtype_type_object_gap():
+    with pytest.raises(TypeError, match="dtype"):
+        _ = fnp.array([1, 2, 3], dtype=float)
+
+
+# --- flopscope.numpy is a module, not a package (audit P1, ~7 subs) ---
+
+def test_flopscope_numpy_submodule_import_gap():
+    with pytest.raises(ModuleNotFoundError, match="not a package"):
+        __import__("flopscope.numpy.linalg")
+
+
+# --- scalar conversion: NO LONGER a gap on main (audit's __float__ bug) ---
+
+def test_float_of_reduced_scalar_works_now():
+    # The audit's struct.unpack scalar-conversion bug does not reproduce on the
+    # current client for this path; lock that in so a regression is caught.
+    a = fnp.array([1.0, 2.0, 3.0])
+    assert float(fnp.max(a)) == 3.0

--- a/tests/client_compat/test_audit_gaps.py
+++ b/tests/client_compat/test_audit_gaps.py
@@ -13,17 +13,18 @@ the test FAILS — a loud signal to flip it into a positive parity assertion.
 All tests rely on the ambient ``BudgetContext`` (autouse fixture); they must NOT
 open their own.
 """
+
 from __future__ import annotations
 
 import pytest
 
 import flopscope as fnp  # the CLIENT
 
-
 # --- Bitwise / shift operators on RemoteArray (audit's #1, ~112 subs) ---
 # Native FlopscopeArray defines __and__/__or__/__xor__/__invert__/__lshift__/
 # __rshift__; RemoteArray defines none. The boolean-mask idiom (a > 0) & (b < 1)
 # is the dominant failure.
+
 
 def test_bitwise_and_gap():
     a, b = fnp.array([1, 0, 1]), fnp.array([1, 1, 0])
@@ -63,6 +64,7 @@ def test_right_shift_gap():
 
 # --- ndarray methods missing on RemoteArray (audit P2) ---
 
+
 def test_argsort_method_gap():
     a = fnp.array([3.0, 1.0, 2.0])
     with pytest.raises(AttributeError, match="argsort"):
@@ -78,6 +80,7 @@ def test_diagonal_method_gap():
 # --- dtype= constructor parity (audit P1) ---
 # String aliases work; Python/numpy TYPE OBJECTS do not.
 
+
 def test_dtype_string_alias_works():
     # Positive control: the string-alias path is already fine on the client.
     out = fnp.array([1, 2, 3], dtype="float64")
@@ -91,12 +94,14 @@ def test_dtype_type_object_gap():
 
 # --- flopscope.numpy is a module, not a package (audit P1, ~7 subs) ---
 
+
 def test_flopscope_numpy_submodule_import_gap():
     with pytest.raises(ModuleNotFoundError, match="not a package"):
         __import__("flopscope.numpy.linalg")
 
 
 # --- scalar conversion: NO LONGER a gap on main (audit's __float__ bug) ---
+
 
 def test_float_of_reduced_scalar_works_now():
     # The audit's struct.unpack scalar-conversion bug does not reproduce on the

--- a/tests/client_compat/test_harness_health.py
+++ b/tests/client_compat/test_harness_health.py
@@ -1,0 +1,18 @@
+"""Guards the client-parity harness actually stood up (server + client)."""
+from __future__ import annotations
+
+
+def test_client_is_the_proxy_not_native():
+    import flopscope
+    # The client package lives under flopscope-client/src; native under src/.
+    assert "flopscope-client" in flopscope.__file__, (
+        f"expected the CLIENT flopscope on sys.path, got {flopscope.__file__}"
+    )
+
+
+def test_server_round_trips_a_simple_op():
+    import flopscope as fnp
+    with fnp.BudgetContext(flop_budget=10**15):
+        a = fnp.array([1, 2, 3])
+        b = fnp.array([4, 5, 6])
+        assert fnp.add(a, b).tolist() == [5, 7, 9]

--- a/tests/client_compat/test_harness_health.py
+++ b/tests/client_compat/test_harness_health.py
@@ -20,3 +20,16 @@ def test_server_round_trips_a_simple_op():
     a = fnp.array([1, 2, 3])
     b = fnp.array([4, 5, 6])
     assert fnp.add(a, b).tolist() == [5, 7, 9]
+
+
+def test_numpy_sum_is_routed_to_client(_patch_active):
+    import numpy as np
+
+    # np.sum is a non-ufunc reduction in the client registry, so the patch
+    # targets it (ufuncs like np.add are intentionally skipped). np.array stays
+    # native (it is in _SKIP), so the input arrives as a real ndarray and the
+    # patch's input coercer must convert it (client rejects raw ndarrays).
+    # Relies on the ambient BudgetContext from the autouse fixture.
+    out = np.sum(np.array([1, 2, 3, 4]))
+    assert type(out).__name__ == "RemoteArray", f"got {type(out)!r}; swap inactive"
+    assert float(out) == 10.0

--- a/tests/client_compat/test_harness_health.py
+++ b/tests/client_compat/test_harness_health.py
@@ -1,9 +1,11 @@
 """Guards the client-parity harness actually stood up (server + client)."""
+
 from __future__ import annotations
 
 
 def test_client_is_the_proxy_not_native():
     import flopscope
+
     # The client package lives under flopscope-client/src; native under src/.
     assert "flopscope-client" in flopscope.__file__, (
         f"expected the CLIENT flopscope on sys.path, got {flopscope.__file__}"
@@ -17,6 +19,7 @@ def test_server_round_trips_a_simple_op():
     # nest-conflict, and NumPy's suite never opens one — so this mirrors how the
     # real suite runs.
     import flopscope as fnp
+
     a = fnp.array([1, 2, 3])
     b = fnp.array([4, 5, 6])
     assert fnp.add(a, b).tolist() == [5, 7, 9]

--- a/tests/client_compat/test_harness_health.py
+++ b/tests/client_compat/test_harness_health.py
@@ -11,8 +11,12 @@ def test_client_is_the_proxy_not_native():
 
 
 def test_server_round_trips_a_simple_op():
+    # Relies on the ambient BudgetContext opened by the autouse
+    # _fresh_connection_and_budget fixture (the client raises
+    # NoBudgetContextError without an active budget). Opening our own here would
+    # nest-conflict, and NumPy's suite never opens one — so this mirrors how the
+    # real suite runs.
     import flopscope as fnp
-    with fnp.BudgetContext(flop_budget=10**15):
-        a = fnp.array([1, 2, 3])
-        b = fnp.array([4, 5, 6])
-        assert fnp.add(a, b).tolist() == [5, 7, 9]
+    a = fnp.array([1, 2, 3])
+    b = fnp.array([4, 5, 6])
+    assert fnp.add(a, b).tolist() == [5, 7, 9]

--- a/tests/client_compat/test_harness_health.py
+++ b/tests/client_compat/test_harness_health.py
@@ -33,3 +33,15 @@ def test_numpy_sum_is_routed_to_client(_patch_active):
     out = np.sum(np.array([1, 2, 3, 4]))
     assert type(out).__name__ == "RemoteArray", f"got {type(out)!r}; swap inactive"
     assert float(out) == 10.0
+
+
+def test_numpy_testing_helpers_coerce_remote_array(_patch_active):
+    import numpy as np
+
+    # np.cumsum is a non-ufunc reduction -> patched -> returns a RemoteArray.
+    # numpy's own assert helper must accept that remote handle (it routes through
+    # asanyarray, which _coerce wraps to materialize via .tolist()).
+    # Relies on the ambient BudgetContext from the autouse fixture.
+    out = np.cumsum(np.array([1.0, 2.0, 3.0]))
+    assert type(out).__name__ == "RemoteArray", f"got {type(out)!r}; swap inactive"
+    np.testing.assert_allclose(out, [1.0, 3.0, 6.0])

--- a/tests/client_compat/test_native_feature_smoke.py
+++ b/tests/client_compat/test_native_feature_smoke.py
@@ -14,6 +14,7 @@ All tests rely on the ambient ``BudgetContext`` opened by the autouse
 ``_fresh_connection_and_budget`` fixture (the client rejects nested contexts);
 they must NOT open their own.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/client_compat/test_native_feature_smoke.py
+++ b/tests/client_compat/test_native_feature_smoke.py
@@ -61,3 +61,23 @@ def test_symmetric_tensor_is_intentionally_server_side():
     # error. Document that contract so it is not mistaken for a parity gap.
     with pytest.raises(AttributeError, match="server-side"):
         _ = fnp.SymmetricTensor
+
+
+def test_symmetrize_result_carries_symmetry_attribute():
+    # Positive control / partial parity: native symmetrize() returns a
+    # SymmetricTensor with a .symmetry attribute; the client returns a RemoteArray
+    # whose .symmetry DOES forward to the server. This part has parity.
+    out = fnp.symmetrize(fnp.array([[1.0, 2.0], [2.0, 1.0]]), symmetry=_sym2())
+    assert type(out.symmetry).__name__ == "SymmetryGroup"
+
+
+def test_symmetrize_result_is_symmetric_method_gap():
+    # PARTIAL-PARITY GAP: native SymmetricTensor has .is_symmetric (the type is a
+    # numpy.ndarray subclass with extra symmetric API); the client's RemoteArray
+    # proxy does NOT forward .is_symmetric. A participant who develops against
+    # native symmetrize().is_symmetric breaks on the client. No xfail — this
+    # failure IS the measurement; flip to a positive assert when Phase 2 closes it.
+    out = fnp.symmetrize(fnp.array([[1.0, 2.0], [2.0, 1.0]]), symmetry=_sym2())
+    assert hasattr(out, "is_symmetric"), (
+        "client symmetrize() result missing .is_symmetric (native SymmetricTensor has it)"
+    )

--- a/tests/client_compat/test_native_feature_smoke.py
+++ b/tests/client_compat/test_native_feature_smoke.py
@@ -1,0 +1,62 @@
+"""Native flopscope features must be reachable + behave through the client.
+
+One test per public native feature the 2026-06-23 prod audit saw participants
+use. These do NOT go through the numpy-suite harness (which only exercises the
+patched numpy *functions* against native ndarrays); they call the CLIENT's
+public flopscope API directly, so feature-level gaps — a native feature missing
+or broken on the client — surface here.
+
+No xfails on real gaps: a missing-but-native feature should FAIL loudly (that is
+the Phase-1 measurement signal). Only behaviour that is intentionally
+client-unavailable is asserted as such.
+
+All tests rely on the ambient ``BudgetContext`` opened by the autouse
+``_fresh_connection_and_budget`` fixture (the client rejects nested contexts);
+they must NOT open their own.
+"""
+from __future__ import annotations
+
+import pytest
+
+import flopscope as fnp  # the CLIENT (conftest puts flopscope-client/src first)
+
+
+def _sym2():
+    """A 2-axis symmetric group for 2-D test matrices."""
+    return fnp.SymmetryGroup.symmetric(axes=(0, 1))
+
+
+def test_symmetrize_through_client():
+    out = fnp.symmetrize(fnp.array([[1.0, 2.0], [0.0, 1.0]]), symmetry=_sym2())
+    # The client returns a RemoteArray proxy for the symmetrized tensor.
+    assert out.tolist() is not None
+
+
+def test_as_symmetric_through_client():
+    out = fnp.as_symmetric(fnp.array([[1.0, 2.0], [2.0, 1.0]]), symmetry=_sym2())
+    assert out.tolist() is not None
+
+
+def test_is_symmetric_through_client():
+    out = fnp.is_symmetric(fnp.array([[1.0, 2.0], [2.0, 1.0]]), symmetry=_sym2())
+    assert bool(out) is True
+
+
+def test_configure_through_client():
+    # configure(**kwargs) -> None; must be callable on the client.
+    assert fnp.configure() is None
+
+
+def test_accounting_namespace_reachable():
+    # REAL GAP (audit's CHILD_INTERNAL_ERROR class): flopscope.accounting exists
+    # natively but is missing on the client. No xfail — this failure IS the
+    # measurement. When Phase 2 adds it to the client, this goes green.
+    assert hasattr(fnp, "accounting"), "client missing flopscope.accounting"
+
+
+def test_symmetric_tensor_is_intentionally_server_side():
+    # NOT a gap: native exposes flopscope.SymmetricTensor, but the client
+    # deliberately withholds it (a server-side / analysis API) with a helpful
+    # error. Document that contract so it is not mistaken for a parity gap.
+    with pytest.raises(AttributeError, match="server-side"):
+        _ = fnp.SymmetricTensor

--- a/tests/client_compat/test_numpy_function_classes.py
+++ b/tests/client_compat/test_numpy_function_classes.py
@@ -1,0 +1,54 @@
+"""Wrap numpy's FUNCTION-surface test classes so they run inside this conftest's
+scope (budget context + numpy->client function patch active), exercising the
+CLIENT. The previous --pyargs approach was a no-op: --pyargs tests live in
+site-packages, outside this conftest's dir scope, so the autouse budget fixture
+never fired and ops fell through to native numpy.
+
+Import numpy's test modules at module level (before pytest_configure fires the
+patch). For each module we create thin subclasses of every Test* class; pytest
+collects them as local items here, so the _server + _fresh_connection_and_budget
+autouse fixtures apply and np.<fn> routes to the client during the test body.
+
+NOTE (coverage caveat): this captures numpy's CLASS-based tests only (the large
+majority — umath 53, numeric 35, linalg 27, etc. class-level).
+A small number of module-level `def test_*` functions are not wrapped.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from numpy._core.tests import test_numeric as _numeric
+from numpy._core.tests import test_umath as _umath
+from numpy.fft.tests import test_helper as _fft_helper
+from numpy.fft.tests import test_pocketfft as _pocketfft
+from numpy.linalg.tests import test_linalg as _linalg
+from numpy.polynomial.tests import test_polynomial as _poly
+from numpy.random.tests import test_random as _random
+
+_SOURCE_MODULES = (
+    _umath,
+    _numeric,
+    _linalg,
+    _pocketfft,
+    _fft_helper,
+    _poly,
+    _random,
+)
+
+
+def _make_subclasses() -> dict:
+    made: dict = {}
+    for mod in _SOURCE_MODULES:
+        prefix = mod.__name__.rsplit(".", 1)[-1]  # e.g. test_umath
+        for name, cls in inspect.getmembers(mod, inspect.isclass):
+            if not name.startswith("Test"):
+                continue
+            if cls.__module__ != mod.__name__:
+                continue  # skip imported-not-defined classes
+            new_name = f"{name}__{prefix}__Client"
+            made[new_name] = type(new_name, (cls,), {})
+    return made
+
+
+globals().update(_make_subclasses())

--- a/tests/client_compat/test_surface_parity.py
+++ b/tests/client_compat/test_surface_parity.py
@@ -85,14 +85,16 @@ _PROXY_IMPOSSIBLE = {
     "__setattr__",
     "__getattribute__",
 }
-# In-place mutation. NOTE: this is a DELIBERATE, DOCUMENTED policy divergence, not
-# a technical impossibility — native FlopscopeArray SUPPORTS all of these (verified:
-# a+=b, a.sort(), a[i]=x, a.fill(0)), but the client raises a documented
-# "flopscope arrays are immutable" error (competition docs: #immutable-arrays).
-# They ARE bridgeable to the server, but faithful parity needs the server to model
-# handle aliasing (b=a; a.sort() must mutate b; views must alias) — a half-bridge
-# would be silently wrong. Parked here as a policy decision (keep immutable, or
-# bridge, or make native immutable too so local==eval), NOT counted as fix-now.
+# In-place mutation. Immutable BY DESIGN on BOTH sides (competition rule
+# #immutable-arrays): native FlopscopeArray and the client RemoteArray both raise
+# a "flopscope arrays are immutable" error for item assignment, augmented
+# assignment, and the C-level mutators (fill/put/resize/sort/partition). Excluded
+# from the required surface because the client deliberately does not mirror the
+# mutating API; the behavioural parity (both raise identically) is locked by
+# dedicated tests (test_audit_gaps.py + tests/test_array_protocols.py), not by
+# this static surface diff. (Bridging to true in-place mutation was rejected: it
+# would need the server to model handle aliasing + views, and a half-bridge would
+# be silently wrong.)
 _BY_DESIGN_IMMUTABLE = {
     "fill",
     "partition",

--- a/tests/client_compat/test_surface_parity.py
+++ b/tests/client_compat/test_surface_parity.py
@@ -116,62 +116,16 @@ _BY_DESIGN_IMMUTABLE = {
     "__ixor__",
 }
 
-# Measured 2026-06-23 against flopscope-client 0.8.0rc2 / numpy 2.2. Every entry
-# is a real participant-usable ndarray method/operator the client is MISSING
-# (10/10 sampled raise AttributeError/TypeError live). This is the exhaustive
-# operator/method gap inventory — Phase 2 shrinks it; do not edit by hand except
-# to remove an entry a fix has genuinely closed.
+# Measured 2026-06-23 against flopscope-client 0.8.0rc3 / numpy 2.2.
+# rc3 closed 46 of the original 48 gaps (read-only methods, bitwise/shift
+# operators, conversion dunders, dtype type-objects, layout metadata, accounting,
+# is_symmetric, native immutability, flopscope.numpy package).
+# Only the two numpy dispatch-protocol hooks remain — DEFERRED, not participant-
+# relevant for the evaluation model (participant code never registers custom ufuncs
+# or __array_function__ overrides against the flopscope server).
 KNOWN_MISSING = {
-    # read-only methods (function forms like np.argsort may work; the METHOD does not)
-    "all",
-    "any",
-    "argmax",
-    "argmin",
-    "argpartition",
-    "argsort",
-    "choose",
-    "clip",
-    "compress",
-    "conj",
-    "conjugate",
-    "cumprod",
-    "cumsum",
-    "diagonal",
-    "item",
-    "nonzero",
-    "prod",
-    "repeat",
-    "round",
-    "searchsorted",
-    "squeeze",
-    "std",
-    "swapaxes",
-    "take",
-    "trace",
-    "var",
-    # operator / conversion dunders
-    "__and__",
-    "__or__",
-    "__xor__",
-    "__invert__",
-    "__lshift__",
-    "__rshift__",
-    "__rand__",
-    "__ror__",
-    "__rxor__",
-    "__rlshift__",
-    "__rrshift__",
-    "__divmod__",
-    "__rdivmod__",
-    "__pos__",
-    "__contains__",
-    "__index__",
-    "__complex__",
-    "__copy__",
-    "__deepcopy__",
-    "__array__",
-    "__array_ufunc__",
-    "__array_function__",
+    "__array_ufunc__",  # numpy dispatch protocol — deferred, not eval-model
+    "__array_function__",  # numpy dispatch protocol — deferred, not eval-model
 }
 
 
@@ -196,4 +150,5 @@ def test_remote_array_surface_matches_measured_baseline():
 
 def test_baseline_is_an_honest_count():
     # Guards the documented inventory number against silent drift.
-    assert len(KNOWN_MISSING) == 48
+    # rc3: down from 48 to 2 (only the numpy dispatch-protocol hooks remain, deferred).
+    assert len(KNOWN_MISSING) == 2

--- a/tests/client_compat/test_surface_parity.py
+++ b/tests/client_compat/test_surface_parity.py
@@ -1,0 +1,183 @@
+"""EXHAUSTIVE operator/method surface parity: RemoteArray vs numpy.ndarray.
+
+Why this exists: the numpy-suite harness patches numpy *functions* and runs them
+on native ndarrays, so it NEVER exercises ``RemoteArray``'s own attribute surface
+— a participant doing ``a.argsort()`` or ``a & b`` on a client array is invisible
+to it. Mining prod failures is also not exhaustive: it only finds gaps that some
+submission happened to hit.
+
+The participant's local reference is ``FlopscopeArray``, a ``numpy.ndarray``
+SUBCLASS, so locally they inherit the ENTIRE ndarray method/operator surface. The
+client ``RemoteArray`` is a hand-built proxy that implements only a subset. The
+COMPLETE set of operator/method parity gaps is therefore enumerable and bounded
+by the native API:
+
+    dir(numpy.ndarray)  −  dir(RemoteArray)
+
+filtered to the participant-relevant surface (excluding what a remote proxy
+genuinely cannot/should not mirror). This test pins that set to a measured
+baseline so that:
+  * a NEW gap (client regression, or a numpy version adding a method the client
+    doesn't mirror) fails the test, and
+  * a CLOSED gap (Phase-2 fix) also fails the test, forcing the baseline — and
+    thus the inventory — to be pruned and kept honest.
+
+No server needed: this is a static class-surface diff.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from flopscope._remote_array import RemoteArray
+
+# ndarray surface a remote proxy genuinely cannot/should not mirror: local memory
+# layout, numpy-subclass internals, device/IO buffers, object plumbing.
+_PROXY_IMPOSSIBLE = {
+    "data",
+    "strides",
+    "flags",
+    "base",
+    "ctypes",
+    "itemset",
+    "newbyteorder",
+    "dtype",
+    "getfield",
+    "setfield",
+    "byteswap",
+    "view",
+    "to_device",
+    "tobytes",
+    "tofile",
+    "tostring",
+    "dump",
+    "dumps",
+    "setflags",
+    "__buffer__",
+    "__array_interface__",
+    "__array_struct__",
+    "__array_priority__",
+    "__array_finalize__",
+    "__array_wrap__",
+    "__array_namespace__",
+    "__dlpack__",
+    "__dlpack_device__",
+    "__class_getitem__",
+    "__init_subclass__",
+    "__subclasshook__",
+    "__reduce__",
+    "__reduce_ex__",
+    "__dir__",
+    "__sizeof__",
+    "__init__",
+    "__new__",
+    "__getstate__",
+    "__setstate__",
+    "__delattr__",
+    "__setattr__",
+    "__getattribute__",
+}
+# In-place mutation: RemoteArray is immutable by design (server-held handle).
+_BY_DESIGN_IMMUTABLE = {
+    "fill",
+    "partition",
+    "put",
+    "resize",
+    "sort",
+    "__delitem__",
+    "__setitem__",
+    "__iadd__",
+    "__iand__",
+    "__ifloordiv__",
+    "__ilshift__",
+    "__imatmul__",
+    "__imod__",
+    "__imul__",
+    "__ior__",
+    "__ipow__",
+    "__irshift__",
+    "__isub__",
+    "__itruediv__",
+    "__ixor__",
+}
+
+# Measured 2026-06-23 against flopscope-client 0.8.0rc2 / numpy 2.2. Every entry
+# is a real participant-usable ndarray method/operator the client is MISSING
+# (10/10 sampled raise AttributeError/TypeError live). This is the exhaustive
+# operator/method gap inventory — Phase 2 shrinks it; do not edit by hand except
+# to remove an entry a fix has genuinely closed.
+KNOWN_MISSING = {
+    # read-only methods (function forms like np.argsort may work; the METHOD does not)
+    "all",
+    "any",
+    "argmax",
+    "argmin",
+    "argpartition",
+    "argsort",
+    "choose",
+    "clip",
+    "compress",
+    "conj",
+    "conjugate",
+    "cumprod",
+    "cumsum",
+    "diagonal",
+    "item",
+    "nonzero",
+    "prod",
+    "repeat",
+    "round",
+    "searchsorted",
+    "squeeze",
+    "std",
+    "swapaxes",
+    "take",
+    "trace",
+    "var",
+    # operator / conversion dunders
+    "__and__",
+    "__or__",
+    "__xor__",
+    "__invert__",
+    "__lshift__",
+    "__rshift__",
+    "__rand__",
+    "__ror__",
+    "__rxor__",
+    "__rlshift__",
+    "__rrshift__",
+    "__divmod__",
+    "__rdivmod__",
+    "__pos__",
+    "__contains__",
+    "__index__",
+    "__complex__",
+    "__copy__",
+    "__deepcopy__",
+    "__array__",
+    "__array_ufunc__",
+    "__array_function__",
+}
+
+
+def _participant_relevant_surface() -> set[str]:
+    surface = {n for n in dir(np.ndarray) if callable(getattr(np.ndarray, n, None))}
+    return surface - _PROXY_IMPOSSIBLE - _BY_DESIGN_IMMUTABLE
+
+
+def test_remote_array_surface_matches_measured_baseline():
+    missing = _participant_relevant_surface() - set(dir(RemoteArray))
+    new = sorted(missing - KNOWN_MISSING)
+    closed = sorted(KNOWN_MISSING - missing)
+    assert not new, (
+        "NEW RemoteArray surface gap(s) not in the baseline — a client regression "
+        f"or a numpy method the client does not mirror: {new}"
+    )
+    assert not closed, (
+        "Surface gap(s) now CLOSED — remove them from KNOWN_MISSING (and update "
+        f"INVENTORY.md): {closed}"
+    )
+
+
+def test_baseline_is_an_honest_count():
+    # Guards the documented inventory number against silent drift.
+    assert len(KNOWN_MISSING) == 48

--- a/tests/client_compat/test_surface_parity.py
+++ b/tests/client_compat/test_surface_parity.py
@@ -30,8 +30,17 @@ from __future__ import annotations
 import numpy as np
 from flopscope._remote_array import RemoteArray
 
-# ndarray surface a remote proxy genuinely cannot/should not mirror: local memory
-# layout, numpy-subclass internals, device/IO buffers, object plumbing.
+# Excluded from the fix-now 48 for two DIFFERENT reasons (do not conflate):
+#  - GENUINELY INCOMPATIBLE: raw-buffer / zero-copy interop whose contract is a
+#    pointer to THIS array's local memory (data, __array_interface__,
+#    __array_struct__, ctypes, __buffer__) and memory-reinterpret/view aliasing
+#    (view, getfield, setfield, byteswap). The buffer lives on the server; there
+#    is no local pointer, and a copy silently breaks the zero-copy/aliasing
+#    contract. These are the only truly un-bridgeable entries.
+#  - BRIDGEABLE METADATA we just haven't wired: strides, flags, itemsize are
+#    plain server-reportable values (the client already bridges shape/ndim/size/
+#    dtype/nbytes — the line is currently inconsistent). Worth bridging; parked
+#    here so they don't inflate the fix-now count.
 _PROXY_IMPOSSIBLE = {
     "data",
     "strides",
@@ -76,7 +85,14 @@ _PROXY_IMPOSSIBLE = {
     "__setattr__",
     "__getattribute__",
 }
-# In-place mutation: RemoteArray is immutable by design (server-held handle).
+# In-place mutation. NOTE: this is a DELIBERATE, DOCUMENTED policy divergence, not
+# a technical impossibility — native FlopscopeArray SUPPORTS all of these (verified:
+# a+=b, a.sort(), a[i]=x, a.fill(0)), but the client raises a documented
+# "flopscope arrays are immutable" error (competition docs: #immutable-arrays).
+# They ARE bridgeable to the server, but faithful parity needs the server to model
+# handle aliasing (b=a; a.sort() must mutate b; views must alias) — a half-bridge
+# would be silently wrong. Parked here as a policy decision (keep immutable, or
+# bridge, or make native immutable too so local==eval), NOT counted as fix-now.
 _BY_DESIGN_IMMUTABLE = {
     "fill",
     "partition",

--- a/tests/client_compat/xfails_client.py
+++ b/tests/client_compat/xfails_client.py
@@ -9,6 +9,7 @@ Patterns are matched against the pytest nodeid with fnmatch (glob) OR as a plain
 substring (mirrors tests/numpy_compat/conftest.py). xfail is non-strict, so an
 entry that unexpectedly passes is reported as xpass, not a failure.
 """
+
 # Seeded EMPTY after the first measurement. The structurally-"by-design"
 # patterns first guessed here (setitem/contiguous/strides) do NOT actually
 # manifest in this harness: NumPy's tests build their operands with the native

--- a/tests/client_compat/xfails_client.py
+++ b/tests/client_compat/xfails_client.py
@@ -9,11 +9,14 @@ Patterns are matched against the pytest nodeid with fnmatch (glob) OR as a plain
 substring (mirrors tests/numpy_compat/conftest.py). xfail is non-strict, so an
 entry that unexpectedly passes is reported as xpass, not a failure.
 """
-XFAIL_PATTERNS: dict[str, str] = {
-    # RemoteArray is immutable by design — item assignment cannot be supported.
-    "*test_*setitem*": "client RemoteArray is immutable by design",
-    # A remote proxy has no local memory buffer, so C/Fortran-contiguity,
-    # strides, and byte-layout assertions are meaningless against it.
-    "*test_*contiguous*": "remote proxy has no local memory layout",
-    "*test_*strides*": "remote proxy has no local memory layout",
-}
+# Seeded EMPTY after the first measurement. The structurally-"by-design"
+# patterns first guessed here (setitem/contiguous/strides) do NOT actually
+# manifest in this harness: NumPy's tests build their operands with the native
+# np.array (kept native — it is in _patch_client._SKIP), so item assignment and
+# memory-layout introspection run against real ndarrays and PASS. Seeding them
+# produced 147 spurious xpass. Operator/method gaps on a real RemoteArray (the
+# audit's bitwise &, argsort, etc.) are covered directly by
+# test_native_feature_smoke.py and the audit-gap tests, not by this numpy-suite
+# harness. Populate this ledger at the Phase-1 decision gate from the measured
+# inventory (each entry: documented by-design / proxy-internal reason).
+XFAIL_PATTERNS: dict[str, str] = {}

--- a/tests/client_compat/xfails_client.py
+++ b/tests/client_compat/xfails_client.py
@@ -1,0 +1,19 @@
+"""Known CLIENT-vs-native divergences that are proxy-inherent / by-design.
+
+Phase 1 seeds ONLY the structurally-unavoidable divergences — the ones that can
+never work through a remote proxy regardless of any fix. Everything else that
+fails is a CANDIDATE gap to triage at the Phase-1 decision gate; do NOT pre-xfail
+real gaps here (that would hide them from the inventory).
+
+Patterns are matched against the pytest nodeid with fnmatch (glob) OR as a plain
+substring (mirrors tests/numpy_compat/conftest.py). xfail is non-strict, so an
+entry that unexpectedly passes is reported as xpass, not a failure.
+"""
+XFAIL_PATTERNS: dict[str, str] = {
+    # RemoteArray is immutable by design — item assignment cannot be supported.
+    "*test_*setitem*": "client RemoteArray is immutable by design",
+    # A remote proxy has no local memory buffer, so C/Fortran-contiguity,
+    # strides, and byte-layout assertions are meaningless against it.
+    "*test_*contiguous*": "remote proxy has no local memory layout",
+    "*test_*strides*": "remote proxy has no local memory layout",
+}

--- a/tests/numpy_compat/conftest.py
+++ b/tests/numpy_compat/conftest.py
@@ -286,10 +286,14 @@ def reset_budget():
 
 
 def pytest_configure(config):
-    """Freeze numpy, rebind flopscope internals, then patch."""
+    """Freeze numpy, rebind flopscope internals, patch, register global plugins."""
     frozen = _freeze_numpy()
     _rebind_flopscope_np(frozen)
     _patch_numpy()
+    if not config.pluginmanager.has_plugin("flopscope-immutability-xfail"):
+        config.pluginmanager.register(
+            _ImmutabilityXfailPlugin(), "flopscope-immutability-xfail"
+        )
 
 
 def pytest_unconfigure(config):
@@ -306,3 +310,84 @@ def pytest_collection_modifyitems(config, items):
             if fnmatch.fnmatch(node_id, pattern) or pattern in node_id:
                 item.add_marker(pytest.mark.xfail(reason=reason, strict=False))
                 break
+
+
+# ---------------------------------------------------------------------------
+# Immutability divergence -> xfail (runtime, exception-matched)
+# ---------------------------------------------------------------------------
+# flopscope arrays are immutable by design (competition rule #immutable-arrays):
+# __setitem__, the in-place operators, and in-place sort/partition raise. Many
+# of NumPy's own tests mutate arrays in place — often via an ``out=`` scratch
+# buffer or ``arr[...] = `` setup — so when run against flopscope they fail with
+# our immutability TypeError/ValueError. That is a deliberate, documented
+# divergence, not a parity bug. Convert exactly those failures to xfail at
+# report time. Matching the raised exception (rather than enumerating test ids in
+# .xfails) keeps this robust across NumPy versions, which reshuffle which tests
+# happen to mutate. The dedicated surface-parity test pins the immutable method
+# *set*; this only suppresses NumPy tests that exercise that documented behaviour.
+
+# Contiguous phrase present in every immutability guard message
+# (src/flopscope/_ndarray.py). Specific enough not to match NumPy's own
+# read-only errors (e.g. "assignment destination is read-only").
+_IMMUTABLE_SENTINEL = "flopscope arrays are immutable"
+
+
+def _hit_immutability_guard(excinfo) -> bool:
+    """True if the raised exception chain is flopscope's immutability guard."""
+    exc = getattr(excinfo, "value", None)
+    seen: set[int] = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        if isinstance(exc, (TypeError, ValueError)) and _IMMUTABLE_SENTINEL in str(exc):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
+
+
+class _ImmutabilityXfailPlugin:
+    """Reclassify in-place-mutation failures as xfail (immutability is by design).
+
+    Registered as a global plugin in :func:`pytest_configure` rather than left as
+    a bare conftest hook so it also fires for the ``--pyargs`` NumPy tests: a
+    per-item runtest hook defined directly in a conftest only runs for items
+    inside that conftest's directory, and the borrowed NumPy tests live in
+    site-packages (the same ``--pyargs`` scoping that makes session hooks like
+    ``pytest_configure`` work but per-item ones silently no-op).
+    """
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(self, item, call):
+        outcome = yield
+        report = outcome.get_result()
+        # ``call`` covers in-test mutation; ``setup`` covers fixtures that mutate
+        # while preparing operands (reported as an ERROR, not a FAILURE).
+        if (
+            report.when in ("setup", "call")
+            and report.failed
+            and _hit_immutability_guard(call.excinfo)
+        ):
+            report.outcome = "skipped"
+            report.wasxfail = (
+                "flopscope arrays are immutable by design (#immutable-arrays); "
+                "NumPy's test mutates in place"
+            )
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_make_collect_report(self, collector):
+        # Some NumPy test modules mutate a (patched) flopscope array at *import*
+        # time — e.g. test_linalg builds strided test cases with ``xi[...] = x``.
+        # Under immutability that raises during collection, so the whole module
+        # is un-collectable and individual tests can never be reached to xfail.
+        # Convert that specific collection failure into a module-level skip
+        # (same by-design rationale as the runtime hook). The skip is loud in
+        # ``-rs`` output, so the coverage trade-off stays visible.
+        outcome = yield
+        report = outcome.get_result()
+        if report.outcome == "failed" and _IMMUTABLE_SENTINEL in str(report.longrepr):
+            report.outcome = "skipped"
+            report.longrepr = (
+                str(getattr(collector, "path", collector.nodeid)),
+                None,
+                "Skipped: flopscope arrays are immutable (#immutable-arrays); "
+                "this NumPy test module mutates an array at import time",
+            )

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -447,4 +447,14 @@ XFAIL_PATTERNS: dict[str, str] = {
     # numpy.polynomial.polyval — flopscope wrapper subclass / dispatch
     # diverges from numpy expectation. Surfaced by harness fix; out of scope.
     "TestEvaluation::test_polyval": NEEDS_TRIAGE,
+    # numpy.polynomial mutates its coefficient array in place internally
+    # (polypow / polymul scratch buffers). Under immutability that raises a
+    # TypeError, which numpy.polynomial swallows and re-raises as NotImplemented,
+    # so it surfaces as "unsupported operand type(s) for *: 'int' and
+    # 'Polynomial'" — the immutability sentinel is lost, so it cannot be matched
+    # at runtime and is pinned here. By-design divergence (#immutable-arrays).
+    "TestFraction::test_Fraction": (
+        "flopscope arrays are immutable (#immutable-arrays); numpy.polynomial "
+        "mutates its coefficient array in place internally"
+    ),
 }

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -253,47 +253,31 @@ def test_mixed_python_scalar_left_dispatches():
     assert bc.flops_used > 0
 
 
-# ----- In-place dunder identity preservation -----
+# ----- Immutability: in-place ops must raise -----
 
 
-def test_inplace_add_preserves_identity():
-    """a += b must mutate a, not rebind it. Currently broken on
-    post-PR-#51 main — fixed in Task 5."""
-    a = fnp.random.randn(8)
-    old_id = id(a)
-    with flops.BudgetContext(flop_budget=int(1e9)):
-        a += 1
-    assert id(a) == old_id
+def test_setitem_raises_immutable():
+    import flopscope.numpy as fnp
+
+    a = fnp.array([1.0, 2.0, 3.0])
+    with pytest.raises(TypeError, match="immutable"):
+        a[0] = 9.0
 
 
-def test_inplace_add_scalar_on_symmetric_tensor_preserves_identity():
-    """``A_sym += 1.0`` is symmetry-preserving (binary-with-scalar keeps
-    every group). It must mutate ``A_sym`` in place AND keep the
-    SymmetricTensor type — no spurious downgrade, no rebinding."""
-    A = flops.symmetrize(
-        fnp.random.randn(4, 4),
-        symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
-    )
-    old_id = id(A)
-    with flops.BudgetContext(flop_budget=int(1e9)) as bc:
-        A += 1.0
-    assert id(A) == old_id
-    assert isinstance(A, flops.SymmetricTensor)
-    assert bc.flops_used > 0
+def test_iadd_raises_immutable():
+    import flopscope.numpy as fnp
+
+    a = fnp.array([1.0, 2.0, 3.0])
+    with pytest.raises(TypeError, match="immutable"):
+        a += fnp.array([1.0, 1.0, 1.0])
 
 
-def test_inplace_add_refuses_when_symmetry_would_be_destroyed():
-    """``A_sym += B_unsymmetric`` would silently overwrite ``A_sym``'s
-    bytes with a non-symmetric result. The in-place dunder must refuse
-    rather than corrupt the symmetry metadata."""
-    A = flops.symmetrize(
-        fnp.random.randn(4, 4),
-        symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
-    )
-    B = fnp.random.randn(4, 4)  # plain FlopscopeArray, no symmetry
-    with flops.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises(ValueError, match="destroy or weaken symmetry"):
-            A += B
+def test_inplace_sort_raises_immutable():
+    import flopscope.numpy as fnp
+
+    a = fnp.array([3.0, 1.0, 2.0])
+    with pytest.raises(ValueError, match="immutable"):
+        a.sort()
 
 
 # ----- ufunc.outer / .reduceat / .at / generic .reduce / .accumulate -----
@@ -932,60 +916,6 @@ def test_perf_array_ufunc_dispatch_does_not_copy():
         f"100x np.add(flopscope, flopscope) took {elapsed:.3f}s; "
         f"are we re-introducing per-call copies or O(|G|) work in "
         f"__array_ufunc__ / _filter_to_np_signature?"
-    )
-
-
-def test_perf_warm_inplace_add_scalar_on_symmetric_is_fast():
-    """Warm ``A_sym += 1.0`` on a rank-4 SymmetricTensor must finish
-    well under 50 ms, AND must preserve the symmetry object identity.
-
-    This pins three PR #51 fast paths for the in-place dunder rewrite:
-    - class 4 (``_counted_binary`` scalar fast path) — ``A_sym + 1.0``
-      flows through the scalar branch that returns the operand's
-      symmetry unchanged (same object reference).
-    - class 5 (``SymmetryGroup.__eq__`` identity short-circuit) —
-      ``_inplace_from_result`` does ``self_sym != result_sym``; for
-      scalar ops these are the SAME instance, hitting the identity
-      short-circuit and skipping the O(|G|) ``_canonical_axis_action``
-      comparison.
-    - class 6 (per-instance ``_canonical_axis_action`` cache) — even
-      if identity short-circuit somehow misses, the cache still keeps
-      subsequent calls O(1).
-
-    If this test fails with elapsed > 50 ms or identity is lost, the
-    in-place dunder rewrite is constructing a fresh ``SymmetryGroup``
-    for comparison or wrapping the scalar into an array somewhere
-    along the dispatch chain.
-    """
-    import time
-
-    arr = fnp.random.randn(4, 4, 4, 4)
-    A_sym = flops.symmetrize(
-        arr, symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1, 2, 3))
-    )
-    original_symmetry_ref = A_sym._symmetry  # pyright: ignore[reportAttributeAccessIssue]
-    # Warm-up: prime caches and dispatch tables.
-    with flops.BudgetContext(flop_budget=int(1e12)):
-        A_sym += 1.0
-    # The above mutated A_sym; verify identity preserved through warm-up.
-    assert A_sym._symmetry is original_symmetry_ref, (  # pyright: ignore[reportAttributeAccessIssue]
-        "warm-up in-place add lost symmetry object identity; "
-        "_inplace_from_result is constructing a fresh group somewhere"
-    )
-    # Measure the warm path.
-    with flops.BudgetContext(flop_budget=int(1e12)):
-        t0 = time.perf_counter()
-        A_sym += 1.0
-        elapsed = time.perf_counter() - t0
-    assert elapsed < 0.05, (
-        f"warm A_sym += 1.0 took {elapsed * 1000:.1f}ms; "
-        f"PR #51 made this the scalar fast path. Are we missing the "
-        f"identity short-circuit in _inplace_from_result, or wrapping "
-        f"the scalar in an array in __iadd__ before dispatch?"
-    )
-    assert A_sym._symmetry is original_symmetry_ref, (  # pyright: ignore[reportAttributeAccessIssue]
-        "warm in-place add lost symmetry object identity; "
-        "_inplace_from_result is constructing a fresh group somewhere"
     )
 
 

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -280,6 +280,34 @@ def test_inplace_sort_raises_immutable():
         a.sort()
 
 
+def test_fill_raises_immutable():
+    # fill is a C-level mutator that bypasses __setitem__; it must be overridden
+    # explicitly or native arrays stay mutable (and diverge from the client).
+    import flopscope.numpy as fnp
+
+    a = fnp.array([1.0, 2.0, 3.0])
+    with pytest.raises(ValueError, match="immutable"):
+        a.fill(0.0)
+    assert a.tolist() == [1.0, 2.0, 3.0]  # unchanged
+
+
+def test_put_raises_immutable():
+    import flopscope.numpy as fnp
+
+    a = fnp.array([1.0, 2.0, 3.0])
+    with pytest.raises(ValueError, match="immutable"):
+        a.put([0], [9.0])
+    assert a.tolist() == [1.0, 2.0, 3.0]
+
+
+def test_resize_raises_immutable():
+    import flopscope.numpy as fnp
+
+    a = fnp.array([1.0, 2.0, 3.0])
+    with pytest.raises(ValueError, match="immutable"):
+        a.resize((1, 3))
+
+
 # ----- ufunc.outer / .reduceat / .at / generic .reduce / .accumulate -----
 
 

--- a/tests/test_method_tracking.py
+++ b/tests/test_method_tracking.py
@@ -100,53 +100,46 @@ def test_searchsorted_method_tracks():
     assert bc.flops_used > 0
 
 
-# ----- In-place sort / partition -----
+# ----- In-place sort / partition: immutable, must raise -----
 
 
-def test_inplace_sort_method_tracks_and_mutates():
-    """``a.sort()`` mutates ``a`` in place and returns ``None``. The
-    method override must charge FLOPs through ``me.sort``."""
+def test_inplace_sort_raises_immutable():
+    """``a.sort()`` must raise; flopscope arrays are immutable.
+    Use fnp.sort(arr) for a sorted copy."""
     a = fnp.random.randn(8)
-    old_id = id(a)
-    with flops.BudgetContext(flop_budget=int(1e9)) as bc:
-        ret = a.sort()
-    assert ret is None
-    assert id(a) == old_id
-    assert bc.flops_used > 0
-    # ``a`` is now sorted ascending
-    assert np.all(np.diff(np.asarray(a)) >= 0)
+    with flops.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises(ValueError, match="immutable"):
+            a.sort()
 
 
-def test_inplace_partition_method_tracks_and_mutates():
+def test_inplace_partition_raises_immutable():
+    """``a.partition(k)`` must raise; flopscope arrays are immutable.
+    Use fnp.partition(arr, k) for a copy."""
     a = fnp.random.randn(8)
-    old_id = id(a)
-    with flops.BudgetContext(flop_budget=int(1e9)) as bc:
-        ret = a.partition(3)
-    assert ret is None
-    assert id(a) == old_id
-    assert bc.flops_used > 0
+    with flops.BudgetContext(flop_budget=int(1e9)):
+        with pytest.raises(ValueError, match="immutable"):
+            a.partition(3)
 
 
-def test_inplace_sort_on_symmetric_refuses():
-    """``A_sym.sort()`` would scramble axis order and break the symmetry
-    metadata. The method override must raise rather than silently
-    corrupt the metadata."""
+def test_inplace_sort_on_symmetric_raises_immutable():
+    """``A_sym.sort()`` must raise (immutable, not a symmetry-specific error)."""
     A = flops.symmetrize(
         fnp.random.randn(4, 4),
         symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
     )
     with flops.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises(ValueError, match="symmetry"):
+        with pytest.raises(ValueError, match="immutable"):
             A.sort()
 
 
-def test_inplace_partition_on_symmetric_refuses():
+def test_inplace_partition_on_symmetric_raises_immutable():
+    """``A_sym.partition(k)`` must raise (immutable)."""
     A = flops.symmetrize(
         fnp.random.randn(4, 4),
         symmetry=flops.SymmetryGroup.symmetric(axes=(0, 1)),
     )
     with flops.BudgetContext(flop_budget=int(1e9)):
-        with pytest.raises(ValueError, match="symmetry"):
+        with pytest.raises(ValueError, match="immutable"):
             A.partition(2)
 
 

--- a/tests/test_operator_tracking.py
+++ b/tests/test_operator_tracking.py
@@ -262,45 +262,6 @@ def test_unary_bitwise_flops_match_function(name, op, func_name):
     assert b1.flops_used == b2.flops_used
 
 
-# ----- In-place operator tests -----
-
-
-def test_inplace_mul_tracked():
-    a = fnp.array([1.0, 2.0, 3.0, 4.0])
-    b = fnp.array([0.5, 1.5, 2.5, 3.5])
-    with flops.BudgetContext(flop_budget=int(1e9)) as budget:
-        a *= b
-    assert budget.flops_used > 0
-    assert isinstance(a, fnp.ndarray)
-
-
-def test_inplace_add_tracked():
-    a = fnp.array([1.0, 2.0, 3.0, 4.0])
-    b = fnp.array([0.5, 1.5, 2.5, 3.5])
-    with flops.BudgetContext(flop_budget=int(1e9)) as budget:
-        a += b
-    assert budget.flops_used > 0
-    assert isinstance(a, fnp.ndarray)
-
-
-def test_inplace_sub_tracked():
-    a = fnp.array([1.0, 2.0, 3.0, 4.0])
-    b = fnp.array([0.5, 1.5, 2.5, 3.5])
-    with flops.BudgetContext(flop_budget=int(1e9)) as budget:
-        a -= b
-    assert budget.flops_used > 0
-    assert isinstance(a, fnp.ndarray)
-
-
-def test_inplace_truediv_tracked():
-    a = fnp.array([1.0, 2.0, 3.0, 4.0])
-    b = fnp.array([0.5, 1.5, 2.5, 3.5])
-    with flops.BudgetContext(flop_budget=int(1e9)) as budget:
-        a /= b
-    assert budget.flops_used > 0
-    assert isinstance(a, fnp.ndarray)
-
-
 # ----- Integration test -----
 
 

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -466,71 +466,71 @@ class TestFlopscopeArrayReverseOps:
 
 
 class TestFlopscopeArrayInPlaceOps:
-    """Cover lines for __iadd__, __isub__, __imul__, etc."""
+    """In-place ops must raise; flopscope arrays are immutable."""
 
-    def test_iadd(self):
+    def test_iadd_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([1.0, 2.0, 3.0])
-            arr += 1.0
-            numpy.testing.assert_array_equal(arr, [2.0, 3.0, 4.0])
+            with pytest.raises(TypeError, match="immutable"):
+                arr += 1.0
 
-    def test_isub(self):
+    def test_isub_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([10.0, 20.0, 30.0])
-            arr -= 5.0
-            numpy.testing.assert_array_equal(arr, [5.0, 15.0, 25.0])
+            with pytest.raises(TypeError, match="immutable"):
+                arr -= 5.0
 
-    def test_imul(self):
+    def test_imul_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([1.0, 2.0, 3.0])
-            arr *= 3.0
-            numpy.testing.assert_array_equal(arr, [3.0, 6.0, 9.0])
+            with pytest.raises(TypeError, match="immutable"):
+                arr *= 3.0
 
-    def test_itruediv(self):
+    def test_itruediv_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([10.0, 20.0, 30.0])
-            arr /= 10.0
-            numpy.testing.assert_array_equal(arr, [1.0, 2.0, 3.0])
+            with pytest.raises(TypeError, match="immutable"):
+                arr /= 10.0
 
-    def test_ifloordiv(self):
+    def test_ifloordiv_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([10.0, 21.0, 35.0])
-            arr //= 10.0
-            numpy.testing.assert_array_equal(arr, [1.0, 2.0, 3.0])
+            with pytest.raises(TypeError, match="immutable"):
+                arr //= 10.0
 
-    def test_imod(self):
+    def test_imod_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([10.0, 21.0, 35.0])
-            arr %= 10.0
-            numpy.testing.assert_array_equal(arr, [0.0, 1.0, 5.0])
+            with pytest.raises(TypeError, match="immutable"):
+                arr %= 10.0
 
-    def test_ipow(self):
+    def test_ipow_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([2.0, 3.0, 4.0])
-            arr **= 2.0
-            numpy.testing.assert_array_equal(arr, [4.0, 9.0, 16.0])
+            with pytest.raises(TypeError, match="immutable"):
+                arr **= 2.0
 
-    def test_imatmul(self):
+    def test_imatmul_raises(self):
         import flopscope.numpy as fnp
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([[1.0, 0.0], [0.0, 1.0]])
-            arr @= numpy.array([[2.0, 3.0], [4.0, 5.0]])
-            numpy.testing.assert_array_equal(arr, [[2.0, 3.0], [4.0, 5.0]])
+            with pytest.raises(TypeError, match="immutable"):
+                arr @= numpy.array([[2.0, 3.0], [4.0, 5.0]])
 
 
 class TestFlopscopeArrayBitwiseOps:
@@ -549,8 +549,8 @@ class TestFlopscopeArrayBitwiseOps:
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([0b1010, 0b1100], dtype=numpy.int32)
-            arr &= numpy.int32(0b1010)
-            numpy.testing.assert_array_equal(arr, [0b1010, 0b1000])
+            with pytest.raises(TypeError, match="immutable"):
+                arr &= numpy.int32(0b1010)
 
     def test_ror(self):
         import flopscope.numpy as fnp
@@ -565,8 +565,8 @@ class TestFlopscopeArrayBitwiseOps:
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([0b1010, 0b0001], dtype=numpy.int32)
-            arr |= numpy.int32(0b0100)
-            numpy.testing.assert_array_equal(arr, [0b1110, 0b0101])
+            with pytest.raises(TypeError, match="immutable"):
+                arr |= numpy.int32(0b0100)
 
     def test_rxor(self):
         import flopscope.numpy as fnp
@@ -581,8 +581,8 @@ class TestFlopscopeArrayBitwiseOps:
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([0b1010, 0b1100], dtype=numpy.int32)
-            arr ^= numpy.int32(0b1111)
-            numpy.testing.assert_array_equal(arr, [0b0101, 0b0011])
+            with pytest.raises(TypeError, match="immutable"):
+                arr ^= numpy.int32(0b1111)
 
     def test_rlshift(self):
         import flopscope.numpy as fnp
@@ -601,8 +601,8 @@ class TestFlopscopeArrayBitwiseOps:
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([1, 2], dtype=numpy.int32)
-            arr <<= numpy.int32(2)
-            numpy.testing.assert_array_equal(arr, [4, 8])
+            with pytest.raises(TypeError, match="immutable"):
+                arr <<= numpy.int32(2)
 
     def test_rrshift(self):
         import flopscope.numpy as fnp
@@ -617,8 +617,8 @@ class TestFlopscopeArrayBitwiseOps:
 
         with BudgetContext(flop_budget=10**9):
             arr = fnp.array([4, 8], dtype=numpy.int32)
-            arr >>= numpy.int32(1)
-            numpy.testing.assert_array_equal(arr, [2, 4])
+            with pytest.raises(TypeError, match="immutable"):
+                arr >>= numpy.int32(1)
 
 
 class TestArrayWrapReturnScalar:

--- a/website/public/ops.json
+++ b/website/public/ops.json
@@ -8376,7 +8376,7 @@
       "numpy_ref": "np.random.default_rng",
       "slug": "random-default_rng",
       "status": "supported",
-      "summary": "Construct a new Generator with the default BitGenerator (PCG64).",
+      "summary": "default_rng(seed=None) Construct a new Generator with the default BitGenerator (PCG64).",
       "weight": 0.0
     },
     {


### PR DESCRIPTION
## Summary

Closes the drift between **native flopscope** (`src/`, the `numpy.ndarray`-subclass reference participants develop against) and the **flopscope client** (`flopscope-client/`, the ZMQ proxy they run at grading). Participant code that worked locally was failing only at eval; this PR makes the client mirror native's participant-facing surface. It is the **content** for the `0.8.0rc3` release — the version bump + tag are cut separately via `cz bump` on `main` after merge (see *Release handling*).

Two parts:
1. **A behavioral parity harness** (`tests/client_compat/`) that runs NumPy's own test suite (and native-feature probes) **against the client**, plus an exhaustive `dir(numpy.ndarray) − dir(RemoteArray)` surface diff, so gaps surface as failing tests instead of prod incidents.
2. **The parity fixes** that close the gaps the harness found.

## What changed

**Client `RemoteArray` surface — 46 of 48 gaps closed:**
- Read-only ndarray methods: `argsort, all, any, argmax, argmin, argpartition, choose, clip, compress, conj, conjugate, cumprod, cumsum, diagonal, item, nonzero, prod, repeat, round, searchsorted, squeeze, std, swapaxes, take, trace, var`
- Bitwise/shift operators `& | ^ ~ << >>` (+reverse) — the audit's #1 prod failure (the `(a>0)&(b<1)` mask idiom)
- Conversion dunders: `__contains__`, `__pos__`, `__complex__`, `__index__`, `__divmod__`, `__copy__`/`__deepcopy__`, `__array__`
- Read-only layout metadata: `itemsize`, `strides`, `flags`

**dtype:** `dtype=` now accepts Python type-objects (`float`/`int`/`bool`/`complex`), numpy scalar types (`np.float64`), and numpy 2.x DType objects — via a numpy-free duck-typed resolver, in both the `dtype=` path and arg serialization.

**Namespace / features:** `flopscope.numpy` is now a package (`import flopscope.numpy.linalg` works); `flopscope.accounting` added; `.is_symmetric` forwarded on `symmetrize()` results; raw-buffer pointers (`data`/`ctypes`/`__array_interface__`/`__array_struct__`) raise a clear "no local buffer on a remote proxy" error.

**Immutability everywhere (parity-closing):** `FlopscopeArray` **and** `RemoteArray` are now immutable, identically — `a[i]=x`, `a += b`, `a.sort()`, `a.fill(0)`, `a.put(...)`, `a.resize(...)` all raise on both backends. This closes the place where local was *more permissive* than eval. Enforced via method-override, **not** `setflags` (that would break internal `np.copyto` compute).

## Key correction found mid-flight

The original harness used `pytest --pyargs numpy...`, but those tests live in `site-packages/`, outside the conftest's dir scope, so the autouse budget fixture never fired and ops fell through to **native numpy** — a no-op. The earlier "0 function-level gaps" was native-vs-native, not the client. Reworked to **wrapper-subclass numpy's test classes as local files** so the client is genuinely exercised. The re-measure showed the function-surface residual is dominated by **proxy-inherent / numpy-internal** behaviour (e.g. `isinstance(result, ndarray)`, NEP-50 `can_cast`, exotic dtypes) — not fixable gaps.

## Review feedback (Codex)

All four Codex review comments addressed:
- **`__complex__`** fetches the scalar and calls `complex()` directly (was routing through `float()`, which raises for complex arrays). — `fix(client)`
- **Client in-place operators** (`__iadd__`…`__irshift__`) now raise instead of silently rebinding via `__add__`, matching native. — `fix(client)`
- **Native `fill`/`put`/`resize`** overridden to raise (C-level mutators that bypassed `__setitem__`). — `fix(native)`
- **Inventory script** runs the local wrapper tests instead of the `--pyargs` no-op. — `fix(client-parity)`

## numpy-compat under immutability

Native immutability makes NumPy's *borrowed* test suites mutate arrays they build for scratch/setup, which now raises. The `numpy-compat` harness reclassifies those as **by-design divergences** (a global plugin xfails the immutability `TypeError` at call/setup phase; modules that mutate at *import* — `test_linalg`, `test_random` — are module-skipped; `test_Fraction` is pinned in the xfail ledger). The redundant full-suite step (already covered by the `test` job) was dropped from the job.

## Release handling

This PR is **feature-only at `0.8.0rc2`** — it does **not** bump the version, matching the repo convention where every release tag points at a clean `cz bump` commit made **directly on `main`** (`bump:` commits are exempt from the PR gitlint gate). After merge, `cz bump --prerelease rc` on `main` produces the `bump: version 0.8.0rc2 → 0.8.0rc3` commit + `v0.8.0rc3` tag.

## Testing

- **Green gate:** `make test-client-parity` (targeted participant-parity tests). CI's `client-parity` job now **gates** on this (promoted from `continue-on-error`).
- **Measurement (non-blocking):** `make test-client-parity-measure` runs NumPy's full suite against the client as a regression monitor.
- Surface diff `dir(numpy.ndarray) − dir(RemoteArray)`: **48 → 2** (only `__array_ufunc__`/`__array_function__`, deferred), pinned by `tests/client_compat/test_surface_parity.py`.
- Verified locally: lint (ruff + gitlint), pyright (0 errors), `check-sync` / version-sync (8 sites consistent at `0.8.0rc2`), `check-lock` (×3), native `make test`, all 8 `numpy-compat` suites exit 0, client-server-sync, client unit tests (1341 passing).

## Deferred / out of scope (documented)

- `view`/`byteswap`/`getfield` (no server op; rare), `__array_ufunc__`/`__array_function__` (not the eval model), the `SymmetricTensor` *type* (intentionally server-side-only), exotic dtypes (`longdouble`/`rational`/object), raw-memory pointers.
- **Not in this PR (gated ops):** the `cz bump` release, deploying `0.8.0rc3` to the worker (uniform `Dockerfile.worker` pin bump + rebuild/deploy both scorer & worker, **incl. reconciling the `Dockerfile.worker` numpy shim for the new `flopscope.numpy` package layout**), and re-grading affected submissions.

## Reviewer notes

- Large PR (harness + client fixes + immutability). Suggested reading order: the harness (`tests/client_compat/` conftests + `test_surface_parity.py`) → `flopscope-client/src/flopscope/_remote_array.py` (surface + dtype resolver + immutable in-place ops) → `flopscope-client/src/flopscope/_dtypes.py` → `src/flopscope/_ndarray.py` (native immutability).
