### PR TITLE
fix(client): client-parity rc4 — recover prod submission failures

### DIFF
--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -339,10 +339,20 @@ def array(object, dtype=None, **kwargs):  # noqa: F811
     # raw bytes directly (C-speed) rather than materializing a Python list, so
     # the timed array() dispatch is not inflated.
     _BUFFER_FORMAT_TO_WIRE = {
-        "f": "float32", "d": "float64", "e": "float16",
-        "b": "int8", "B": "uint8", "h": "int16", "H": "uint16",
-        "i": "int32", "I": "uint32", "l": "int64", "L": "uint64",
-        "q": "int64", "Q": "uint64", "?": "bool",
+        "f": "float32",
+        "d": "float64",
+        "e": "float16",
+        "b": "int8",
+        "B": "uint8",
+        "h": "int16",
+        "H": "uint16",
+        "i": "int32",
+        "I": "uint32",
+        "l": "int64",
+        "L": "uint64",
+        "q": "int64",
+        "Q": "uint64",
+        "?": "bool",
     }
     try:
         mv = memoryview(object)

--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -354,6 +354,15 @@ def array(object, dtype=None, **kwargs):  # noqa: F811
         "Q": "uint64",
         "?": "bool",
     }
+    # bytes/bytearray/str expose a buffer but numpy treats them as string/bytes
+    # dtypes (e.g. np.array(b"abc") -> |S3 scalar), which flopscope has no dtype
+    # for. Reject cleanly rather than mis-reading them as a uint8 buffer.
+    if isinstance(object, (bytes, bytearray, str)):
+        raise TypeError(
+            f"Cannot create array from {type(object).__name__}. "
+            f"Expected list, tuple, int, float, RemoteArray, or a numeric buffer "
+            f"(array.array / memoryview of a numeric type)."
+        )
     try:
         mv = memoryview(object)
     except TypeError:
@@ -374,8 +383,8 @@ def array(object, dtype=None, **kwargs):  # noqa: F811
 
     raise TypeError(
         f"Cannot create array from {type(object).__name__}. "
-        f"Expected list, tuple, int, float, RemoteArray, or a buffer "
-        f"(array.array / memoryview / bytes-like)."
+        f"Expected list, tuple, int, float, RemoteArray, or a numeric buffer "
+        f"(array.array / memoryview of a numeric type)."
     )
 
 

--- a/flopscope-client/src/flopscope/__init__.py
+++ b/flopscope-client/src/flopscope/__init__.py
@@ -334,9 +334,38 @@ def array(object, dtype=None, **kwargs):  # noqa: F811
         resp = conn.send_recv(encode_create_from_data(data, [], dtype_str))
         return _result_from_response(resp)
 
+    # Buffer-protocol inputs (stdlib array.array, memoryview, bytes-backed
+    # buffers). Native numpy-backed flopscope accepts these; mirror it. Send the
+    # raw bytes directly (C-speed) rather than materializing a Python list, so
+    # the timed array() dispatch is not inflated.
+    _BUFFER_FORMAT_TO_WIRE = {
+        "f": "float32", "d": "float64", "e": "float16",
+        "b": "int8", "B": "uint8", "h": "int16", "H": "uint16",
+        "i": "int32", "I": "uint32", "l": "int64", "L": "uint64",
+        "q": "int64", "Q": "uint64", "?": "bool",
+    }
+    try:
+        mv = memoryview(object)
+    except TypeError:
+        mv = None
+    if mv is not None and mv.ndim <= 1:
+        native_wire = _BUFFER_FORMAT_TO_WIRE.get(mv.format)
+        if native_wire is not None:
+            data = mv.tobytes()
+            n = mv.nbytes // mv.itemsize
+            conn = get_connection()
+            resp = conn.send_recv(encode_create_from_data(data, [n], native_wire))
+            arr = _result_from_response(resp)
+            if dtype is not None:
+                want = _normalize_dtype(dtype)
+                if want != native_wire:
+                    return array(arr, dtype=want)  # server-side cast (astype)
+            return arr
+
     raise TypeError(
         f"Cannot create array from {type(object).__name__}. "
-        f"Expected list, tuple, int, float, or RemoteArray."
+        f"Expected list, tuple, int, float, RemoteArray, or a buffer "
+        f"(array.array / memoryview / bytes-like)."
     )
 
 

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -267,8 +267,10 @@ class RemoteScalar:
         return int(self._value)
 
     def __index__(self) -> int:
-        # Only integer/bool scalars can index (numpy parity: np.float64 has no
-        # __index__, even for whole values like 2.0).
+        # Only integer/bool scalars can index (numpy parity: float/complex
+        # scalars have no __index__, even for whole values like 2.0). The "int"
+        # substring matches BOTH signed and unsigned widths -- "int64" and
+        # "uint64" both contain "int" -- so unsigned scalars index fine too.
         if "int" not in self._dtype and self._dtype != "bool":
             raise TypeError(
                 f"only integer scalars can be used as indices; this RemoteScalar "

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -432,6 +432,8 @@ def _encode_index_key(key):
         return [_encode_index_key(k) for k in key]
     if isinstance(key, list):
         return [_encode_index_key(k) for k in key]
+    if key is Ellipsis:
+        return {"__ellipsis__": True}
     return key
 
 

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -750,9 +750,25 @@ class RemoteArray(metaclass=_RemoteArrayMeta):
 
         encoded_args = [_encode_arg(a) for a in args]
         encoded_kwargs = {k: _encode_arg(v) for k, v in kwargs.items()}
-        resp = get_connection().send_recv(
-            encode_request(op_name, args=encoded_args, kwargs=encoded_kwargs)
-        )
+        try:
+            request = encode_request(op_name, args=encoded_args, kwargs=encoded_kwargs)
+        except (TypeError, ValueError) as exc:
+            # Mirror the function-dispatch proxy (_make_proxy in __init__): an
+            # unserializable arg leaks an opaque "can not serialize 'X' object"
+            # from msgpack (this is how the RemoteScalar bug surfaced). Surface
+            # a clear error naming the offending type instead. Imported lazily
+            # (error path only) to avoid a circular import: __init__ imports us.
+            from flopscope import _describe_unserializable
+            from flopscope.errors import RemoteSerializationError
+
+            bad = _describe_unserializable(encoded_args, encoded_kwargs)
+            detail = f" {bad}" if bad else ""
+            raise RemoteSerializationError(
+                f"{op_name}() received an argument{detail} that cannot be sent "
+                f"to the remote (client/server) backend. Pass a materialized "
+                f"array or built-in (list / number / str) instead."
+            ) from exc
+        resp = get_connection().send_recv(request)
         return _result_from_response(resp)
 
     # Arithmetic

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -266,6 +266,19 @@ class RemoteScalar:
     def __int__(self) -> int:
         return int(self._value)
 
+    def __index__(self) -> int:
+        # Allow a 0-D integral scalar to index Python sequences / range()
+        # (numpy parity). A non-integral value must raise (matching numpy's
+        # __index__), so reject it rather than silently truncating.
+        v = self._value
+        iv = int(v)
+        if iv != v:
+            raise TypeError(
+                f"only integer scalars can be used as indices; "
+                f"this RemoteScalar holds {v!r}"
+            )
+        return iv
+
     def __bool__(self) -> bool:
         return bool(self._value)
 

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -267,17 +267,14 @@ class RemoteScalar:
         return int(self._value)
 
     def __index__(self) -> int:
-        # Allow a 0-D integral scalar to index Python sequences / range()
-        # (numpy parity). A non-integral value must raise (matching numpy's
-        # __index__), so reject it rather than silently truncating.
-        v = self._value
-        iv = int(v)
-        if iv != v:
+        # Only integer/bool scalars can index (numpy parity: np.float64 has no
+        # __index__, even for whole values like 2.0).
+        if "int" not in self._dtype and self._dtype != "bool":
             raise TypeError(
-                f"only integer scalars can be used as indices; "
-                f"this RemoteScalar holds {v!r}"
+                f"only integer scalars can be used as indices; this RemoteScalar "
+                f"has dtype {self._dtype!r}"
             )
-        return iv
+        return int(self._value)
 
     def __bool__(self) -> bool:
         return bool(self._value)

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -308,61 +308,90 @@ class RemoteScalar:
         return hash(self._value)
 
     # -- arithmetic ---------------------------------------------------------
+    #
+    # A scalar combined with an *array* broadcasts to an array, exactly like
+    # numpy (``np.float64(2) * np.array([1, 2])`` -> ``array([2, 4])``). When
+    # ``other`` is a RemoteArray the ``self._value <op> other`` expression is
+    # dispatched through ``RemoteArray.__r<op>__`` and already yields a
+    # RemoteArray; we must return that array UNWRAPPED. Wrapping it back in a
+    # ``RemoteScalar`` would create a malformed "scalar" whose ``_value`` is a
+    # RemoteArray, which later serializes as a raw RemoteArray and crashes the
+    # wire encoder with ``can not serialize 'RemoteArray' object``. The
+    # ``_scalar_result`` helper mirrors numpy: scalar results stay scalars,
+    # array results pass through.
 
     def __add__(self, other):
         other_val = other._value if isinstance(other, RemoteScalar) else other
-        return RemoteScalar(self._value + other_val, self._dtype)
+        return _scalar_result(self._value + other_val, self._dtype)
 
     def __radd__(self, other):
-        return RemoteScalar(other + self._value, self._dtype)
+        return _scalar_result(other + self._value, self._dtype)
 
     def __sub__(self, other):
         other_val = other._value if isinstance(other, RemoteScalar) else other
-        return RemoteScalar(self._value - other_val, self._dtype)
+        return _scalar_result(self._value - other_val, self._dtype)
 
     def __rsub__(self, other):
-        return RemoteScalar(other - self._value, self._dtype)
+        return _scalar_result(other - self._value, self._dtype)
 
     def __mul__(self, other):
         other_val = other._value if isinstance(other, RemoteScalar) else other
-        return RemoteScalar(self._value * other_val, self._dtype)
+        return _scalar_result(self._value * other_val, self._dtype)
 
     def __rmul__(self, other):
-        return RemoteScalar(other * self._value, self._dtype)
+        return _scalar_result(other * self._value, self._dtype)
 
     def __truediv__(self, other):
         other_val = other._value if isinstance(other, RemoteScalar) else other
-        return RemoteScalar(self._value / other_val, self._dtype)
+        return _scalar_result(self._value / other_val, self._dtype)
 
     def __rtruediv__(self, other):
-        return RemoteScalar(other / self._value, self._dtype)
+        return _scalar_result(other / self._value, self._dtype)
 
     def __floordiv__(self, other):
         other_val = other._value if isinstance(other, RemoteScalar) else other
-        return RemoteScalar(self._value // other_val, self._dtype)
+        return _scalar_result(self._value // other_val, self._dtype)
 
     def __rfloordiv__(self, other):
-        return RemoteScalar(other // self._value, self._dtype)
+        return _scalar_result(other // self._value, self._dtype)
 
     def __mod__(self, other):
         other_val = other._value if isinstance(other, RemoteScalar) else other
-        return RemoteScalar(self._value % other_val, self._dtype)
+        return _scalar_result(self._value % other_val, self._dtype)
 
     def __rmod__(self, other):
-        return RemoteScalar(other % self._value, self._dtype)
+        return _scalar_result(other % self._value, self._dtype)
 
     def __pow__(self, other):
         other_val = other._value if isinstance(other, RemoteScalar) else other
-        return RemoteScalar(self._value**other_val, self._dtype)
+        return _scalar_result(self._value**other_val, self._dtype)
 
     def __rpow__(self, other):
-        return RemoteScalar(other**self._value, self._dtype)
+        return _scalar_result(other**self._value, self._dtype)
 
     def __neg__(self):
-        return RemoteScalar(-self._value, self._dtype)
+        return _scalar_result(-self._value, self._dtype)
 
     def __abs__(self):
-        return RemoteScalar(abs(self._value), self._dtype)
+        return _scalar_result(abs(self._value), self._dtype)
+
+
+def _scalar_result(value, dtype):
+    """Wrap a scalar arithmetic result, passing array/proxy results through.
+
+    ``RemoteScalar`` arithmetic with a plain number yields a number, which we
+    re-wrap as a ``RemoteScalar`` (numpy-scalar analog). But ``RemoteScalar``
+    combined with a ``RemoteArray`` broadcasts to a ``RemoteArray`` (the op runs
+    server-side via the array's reflected dunder). That array result must be
+    returned as-is: re-wrapping it would yield a ``RemoteScalar`` holding an
+    array, which the wire encoder later unwraps to a raw ``RemoteArray`` and
+    fails on (``can not serialize 'RemoteArray' object``). ``RemoteScalar``
+    itself passes ``isinstance(_, RemoteArray)`` via the metaclass, so an
+    already-proxy result is also returned unchanged.
+    """
+    if isinstance(value, RemoteArray):
+        return value
+    return RemoteScalar(value, dtype)
 
 
 # ---------------------------------------------------------------------------

--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -1107,6 +1107,12 @@ class RemoteGenerator:
     def permutation(self, *args, **kwargs):
         return self._call("permutation", *args, **kwargs)
 
+    def permuted(self, *args, **kwargs):
+        return self._call("permuted", *args, **kwargs)
+
+    def chisquare(self, *args, **kwargs):
+        return self._call("chisquare", *args, **kwargs)
+
 
 # ---------------------------------------------------------------------------
 # RemoteRandomState

--- a/flopscope-server/src/flopscope_server/_protocol.py
+++ b/flopscope-server/src/flopscope_server/_protocol.py
@@ -33,6 +33,12 @@ _PROTOCOL_OPS: frozenset[str] = frozenset(
         "create_from_data",
         "__getitem__",
         "astype",
+        # Analytical FLOP cost estimators (flopscope.accounting). Pure functions
+        # of shapes — the client proxies these here; the server computes the
+        # WEIGHTED cost via native flopscope.accounting (authoritative weights +
+        # the single-source einsum cost engine).
+        "flops.einsum_cost",
+        "flops.svd_cost",
     }
 )
 

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -469,6 +469,8 @@ class RequestHandler:
                 if isinstance(handle, bytes):
                     handle = handle.decode()
                 return self._session.get_array(handle)
+            if raw_key.get("__ellipsis__") or raw_key.get(b"__ellipsis__"):
+                return Ellipsis
             if "__slice__" in raw_key:
                 parts = raw_key["__slice__"]
                 return slice(*[None if p is None else int(p) for p in parts])
@@ -628,8 +630,13 @@ def _decode_index_key(raw_key):
     - list of the above -> tuple (for multi-dimensional indexing)
     """
     if isinstance(raw_key, dict):
+        if raw_key.get("__ellipsis__") or raw_key.get(b"__ellipsis__"):
+            return Ellipsis
         if "__slice__" in raw_key:
             parts = raw_key["__slice__"]
+            return slice(*[None if p is None else int(p) for p in parts])
+        if b"__slice__" in raw_key:
+            parts = raw_key[b"__slice__"]
             return slice(*[None if p is None else int(p) for p in parts])
     if isinstance(raw_key, list):
         decoded = [_decode_index_key(item) for item in raw_key]

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -289,6 +289,37 @@ class RequestHandler:
         return self._pack_result(result)
 
     # ------------------------------------------------------------------
+    # Analytical cost estimators (flopscope.accounting)
+    # ------------------------------------------------------------------
+
+    def _handle_flops_cost(self, op: str, kwargs: dict) -> dict:
+        """Compute a WEIGHTED analytical FLOP cost estimate.
+
+        The client proxies ``flopscope.accounting.einsum_cost`` / ``svd_cost``
+        here. We delegate to native ``flopscope.accounting`` so the returned
+        value uses this session's authoritative weights AND the single-source
+        einsum cost engine — identical to the in-process reference, with no
+        formula duplicated on the client. Pure shape math: no array data, no
+        FLOP budget charged.
+        """
+        kw = {
+            (k.decode("utf-8") if isinstance(k, bytes) else k): v
+            for k, v in kwargs.items()
+        }
+        if op == "flops.einsum_cost":
+            subscripts = kw["subscripts"]
+            if isinstance(subscripts, bytes):
+                subscripts = subscripts.decode("utf-8")
+            shapes = [tuple(s) for s in kw["shapes"]]
+            value = int(flops.accounting.einsum_cost(subscripts, shapes))
+        else:  # flops.svd_cost
+            m, n = int(kw["m"]), int(kw["n"])
+            k = int(kw.get("k") or 0)
+            # Client surface uses k=0 to mean "full SVD"; native uses k=None.
+            value = int(flops.accounting.svd_cost(m, n, None if k == 0 else k))
+        return self._pack_result(value)
+
+    # ------------------------------------------------------------------
     # Flopscope function dispatch
     # ------------------------------------------------------------------
 
@@ -305,6 +336,14 @@ class RequestHandler:
                 dtype = dtype.decode("utf-8")
             result = self._run_kernel(arr.astype, dtype)
             return self._pack_result(result)
+
+        # Analytical cost estimators (flopscope.accounting). The client proxies
+        # these as flops.* ops; compute the WEIGHTED cost via native flopscope's
+        # accounting helpers, which use this session's authoritative weights and
+        # the single-source einsum cost engine (no formula duplicated on the
+        # client). Pure shape math — no array data, no budget charge.
+        if op in ("flops.einsum_cost", "flops.svd_cost"):
+            return self._handle_flops_cost(op, kwargs)
 
         # Generator method calls: op is "Generator.<method>" with the remote
         # generator handle as the first arg. Resolve it and call the method

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -481,7 +481,13 @@ class RequestHandler:
                 return slice(*[None if p is None else int(p) for p in parts])
         if isinstance(raw_key, list):
             decoded = [self._decode_index_key(item) for item in raw_key]
-            if any(isinstance(d, slice) for d in decoded) or len(decoded) > 1:
+            # A one-element key like ``arr[..., ]`` arrives as ``(Ellipsis,)`` ->
+            # ``[Ellipsis]``; numpy needs the tuple form, so treat Ellipsis (like
+            # a slice) as a marker that this list is a multi-axis index tuple.
+            if (
+                any(isinstance(d, slice) or d is Ellipsis for d in decoded)
+                or len(decoded) > 1
+            ):
                 return tuple(decoded)
             return decoded
         if isinstance(raw_key, (int, float)):
@@ -642,8 +648,12 @@ def _decode_index_key(raw_key):
             return slice(*[None if p is None else int(p) for p in parts])
     if isinstance(raw_key, list):
         decoded = [_decode_index_key(item) for item in raw_key]
-        # A list of slices/ints -> tuple for multi-dim indexing
-        if any(isinstance(d, slice) for d in decoded) or len(decoded) > 1:
+        # A list of slices/ints (or a one-element Ellipsis like ``arr[..., ]``)
+        # -> tuple for multi-dim indexing; numpy needs the tuple form.
+        if (
+            any(isinstance(d, slice) or d is Ellipsis for d in decoded)
+            or len(decoded) > 1
+        ):
             return tuple(decoded)
         # Single-element list: could be the key itself being a list
         # (e.g., fancy indexing) -- keep as list

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -33,6 +33,8 @@ _ALLOWED_GEN_METHODS = frozenset(
         "gamma",
         "choice",
         "permutation",
+        "permuted",
+        "chisquare",
     }
 )
 

--- a/flopscope-server/tests/test_request_handler.py
+++ b/flopscope-server/tests/test_request_handler.py
@@ -420,3 +420,15 @@ def test_result_array_size_limit(handler, session, monkeypatch):
     assert resp["status"] == "error"
     assert resp["error_type"] == "ValueError"
     assert "too large" in resp["message"]
+
+
+# ---------------------------------------------------------------------------
+# Ellipsis (...) indexing: client encodes {"__ellipsis__": True}
+# (prod regression sub 310351: "can not serialize 'ellipsis' object")
+# ---------------------------------------------------------------------------
+
+
+def test_decode_index_key_ellipsis(handler):
+    """The {"__ellipsis__": True} wire form decodes to Ellipsis (str + bytes keys)."""
+    assert handler._decode_index_key({"__ellipsis__": True}) is Ellipsis
+    assert handler._decode_index_key({b"__ellipsis__": True}) is Ellipsis

--- a/flopscope-server/tests/test_request_handler.py
+++ b/flopscope-server/tests/test_request_handler.py
@@ -130,6 +130,48 @@ def test_handle_einsum(handler, session):
 
 
 # ---------------------------------------------------------------------------
+# Analytical cost estimators (flopscope.accounting) — the client proxies these
+# as flops.* ops. Regression guard for "unknown op: flops.einsum_cost".
+# ---------------------------------------------------------------------------
+
+
+def test_flops_cost_ops_are_whitelisted():
+    from flopscope_server._protocol import WHITELIST
+
+    assert "flops.einsum_cost" in WHITELIST
+    assert "flops.svd_cost" in WHITELIST
+
+
+def test_handle_einsum_cost(handler, session):
+    import flopscope as flops
+
+    resp = handler.handle(
+        {
+            "op": "flops.einsum_cost",
+            "kwargs": {"subscripts": "ij,jk->ik", "shapes": [[4, 5], [5, 6]]},
+        }
+    )
+    assert resp["status"] == "ok"
+    # session BudgetContext is active -> native accounting uses the same weights.
+    assert resp["result"]["value"] == flops.accounting.einsum_cost(
+        "ij,jk->ik", [(4, 5), (5, 6)]
+    )
+    assert resp["result"]["value"] > 0
+
+
+def test_handle_svd_cost(handler, session):
+    import flopscope as flops
+
+    full = handler.handle({"op": "flops.svd_cost", "kwargs": {"m": 128, "n": 64, "k": 0}})
+    topk = handler.handle({"op": "flops.svd_cost", "kwargs": {"m": 128, "n": 64, "k": 8}})
+    assert full["status"] == "ok" and topk["status"] == "ok"
+    # client surface uses k=0 to mean FULL svd (native k=None), NOT "top-0".
+    assert full["result"]["value"] == flops.accounting.svd_cost(128, 64)
+    assert topk["result"]["value"] == flops.accounting.svd_cost(128, 64, k=8)
+    assert full["result"]["value"] > topk["result"]["value"] > 0
+
+
+# ---------------------------------------------------------------------------
 # create_from_data
 # ---------------------------------------------------------------------------
 

--- a/flopscope-server/tests/test_request_handler.py
+++ b/flopscope-server/tests/test_request_handler.py
@@ -162,8 +162,12 @@ def test_handle_einsum_cost(handler, session):
 def test_handle_svd_cost(handler, session):
     import flopscope as flops
 
-    full = handler.handle({"op": "flops.svd_cost", "kwargs": {"m": 128, "n": 64, "k": 0}})
-    topk = handler.handle({"op": "flops.svd_cost", "kwargs": {"m": 128, "n": 64, "k": 8}})
+    full = handler.handle(
+        {"op": "flops.svd_cost", "kwargs": {"m": 128, "n": 64, "k": 0}}
+    )
+    topk = handler.handle(
+        {"op": "flops.svd_cost", "kwargs": {"m": 128, "n": 64, "k": 8}}
+    )
     assert full["status"] == "ok" and topk["status"] == "ok"
     # client surface uses k=0 to mean FULL svd (native k=None), NOT "top-0".
     assert full["result"]["value"] == flops.accounting.svd_cost(128, 64)

--- a/tests/client_compat/test_array_buffer_input.py
+++ b/tests/client_compat/test_array_buffer_input.py
@@ -1,0 +1,40 @@
+"""fnp.array() must accept array.array / buffer-protocol inputs (numpy parity).
+
+Prod regression (subs 310414, 311239, 311356): participants build a stdlib
+array.array('f', ...) C buffer for speed and pass it to fnp.array(); native
+numpy-backed flopscope accepts the buffer protocol, the client rejected it with
+"Cannot create array from array".
+"""
+from __future__ import annotations
+
+import array as _array
+
+import flopscope as fnp
+
+
+def test_array_from_array_array_float32_with_dtype():
+    buf = _array.array("f", [1.0, 2.0, 3.0, 4.0])
+    out = fnp.array(buf, dtype="float32")
+    assert type(out).__name__ == "RemoteArray"
+    assert out.shape == (4,)
+    assert out.tolist() == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_array_from_array_array_infers_dtype_from_typecode():
+    buf = _array.array("d", [1.5, 2.5, 3.5])  # 'd' -> float64
+    out = fnp.array(buf)
+    assert out.tolist() == [1.5, 2.5, 3.5]
+    assert out.dtype == "float64"
+
+
+def test_array_from_array_array_casts_when_dtype_differs():
+    buf = _array.array("d", [1.0, 2.0, 3.0])  # double buffer
+    out = fnp.array(buf, dtype="float32")     # cast to float32 (numpy parity)
+    assert out.dtype == "float32"
+    assert out.tolist() == [1.0, 2.0, 3.0]
+
+
+def test_array_from_memoryview():
+    buf = _array.array("i", [10, 20, 30])
+    out = fnp.array(memoryview(buf))
+    assert out.tolist() == [10, 20, 30]

--- a/tests/client_compat/test_array_buffer_input.py
+++ b/tests/client_compat/test_array_buffer_input.py
@@ -5,6 +5,7 @@ array.array('f', ...) C buffer for speed and pass it to fnp.array(); native
 numpy-backed flopscope accepts the buffer protocol, the client rejected it with
 "Cannot create array from array".
 """
+
 from __future__ import annotations
 
 import array as _array
@@ -29,7 +30,7 @@ def test_array_from_array_array_infers_dtype_from_typecode():
 
 def test_array_from_array_array_casts_when_dtype_differs():
     buf = _array.array("d", [1.0, 2.0, 3.0])  # double buffer
-    out = fnp.array(buf, dtype="float32")     # cast to float32 (numpy parity)
+    out = fnp.array(buf, dtype="float32")  # cast to float32 (numpy parity)
     assert out.dtype == "float32"
     assert out.tolist() == [1.0, 2.0, 3.0]
 

--- a/tests/client_compat/test_array_buffer_input.py
+++ b/tests/client_compat/test_array_buffer_input.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import array as _array
 
+import pytest
+
 import flopscope as fnp
 
 
@@ -39,3 +41,11 @@ def test_array_from_memoryview():
     buf = _array.array("i", [10, 20, 30])
     out = fnp.array(memoryview(buf))
     assert out.tolist() == [10, 20, 30]
+
+
+def test_array_rejects_raw_bytes_cleanly():
+    # numpy makes a |S3 string scalar; flopscope has no string dtype, so reject
+    # cleanly (not a cryptic downstream error, not a wrong uint8 array).
+    for bad in (b"abc", bytearray(b"abc")):
+        with pytest.raises(TypeError, match="Cannot create array from"):
+            fnp.array(bad)

--- a/tests/client_compat/test_ellipsis_index.py
+++ b/tests/client_compat/test_ellipsis_index.py
@@ -22,3 +22,11 @@ def test_leading_ellipsis():
 def test_bare_ellipsis_returns_full():
     a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
     assert a[...].tolist() == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_one_element_ellipsis_tuple():
+    # ``arr[..., ]`` passes the key as ``(Ellipsis,)`` -> a one-element list on
+    # the wire; the server must decode it back to a tuple ``(Ellipsis,)``, not a
+    # bare ``[Ellipsis]`` (which numpy rejects). Equivalent to ``arr[...]``.
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[...,].tolist() == [[1.0, 2.0], [3.0, 4.0]]

--- a/tests/client_compat/test_ellipsis_index.py
+++ b/tests/client_compat/test_ellipsis_index.py
@@ -1,0 +1,23 @@
+"""Ellipsis (...) in indexing must work (numpy parity).
+
+Prod regression (sub 310351): "can not serialize 'ellipsis' object" — the client
+index encoder had no branch for Ellipsis.
+"""
+from __future__ import annotations
+
+import flopscope as fnp
+
+
+def test_trailing_ellipsis():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[0, ...].tolist() == [1.0, 2.0]
+
+
+def test_leading_ellipsis():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[..., 1].tolist() == [2.0, 4.0]
+
+
+def test_bare_ellipsis_returns_full():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[...].tolist() == [[1.0, 2.0], [3.0, 4.0]]

--- a/tests/client_compat/test_ellipsis_index.py
+++ b/tests/client_compat/test_ellipsis_index.py
@@ -3,6 +3,7 @@
 Prod regression (sub 310351): "can not serialize 'ellipsis' object" — the client
 index encoder had no branch for Ellipsis.
 """
+
 from __future__ import annotations
 
 import flopscope as fnp

--- a/tests/client_compat/test_generator_methods.py
+++ b/tests/client_compat/test_generator_methods.py
@@ -3,6 +3,7 @@
 Prod regression (subs 310786, 311261, 311929): "'RemoteGenerator' object has no
 attribute 'permuted' / 'chisquare'".
 """
+
 from __future__ import annotations
 
 import flopscope as fnp

--- a/tests/client_compat/test_generator_methods.py
+++ b/tests/client_compat/test_generator_methods.py
@@ -1,0 +1,24 @@
+"""RemoteGenerator must proxy permuted + chisquare (numpy Generator parity).
+
+Prod regression (subs 310786, 311261, 311929): "'RemoteGenerator' object has no
+attribute 'permuted' / 'chisquare'".
+"""
+from __future__ import annotations
+
+import flopscope as fnp
+
+
+def test_generator_chisquare():
+    g = fnp.random.default_rng(0)
+    out = g.chisquare(3.0, size=5)
+    assert type(out).__name__ == "RemoteArray"
+    assert out.shape == (5,)
+    assert all(v >= 0 for v in out.tolist())  # chi-square is non-negative
+
+
+def test_generator_permuted():
+    g = fnp.random.default_rng(0)
+    a = fnp.array([1.0, 2.0, 3.0, 4.0])
+    out = g.permuted(a)
+    assert type(out).__name__ == "RemoteArray"
+    assert sorted(out.tolist()) == [1.0, 2.0, 3.0, 4.0]

--- a/tests/client_compat/test_native_feature_smoke.py
+++ b/tests/client_compat/test_native_feature_smoke.py
@@ -55,6 +55,27 @@ def test_accounting_namespace_reachable():
     assert hasattr(fnp, "accounting"), "client missing flopscope.accounting"
 
 
+def test_accounting_cost_helpers_work_end_to_end():
+    # rc3 regression caught by the prod re-grade: flopscope.accounting cost
+    # helpers IMPORTED but failed at CALL time with
+    # "FlopscopeServerError: unknown op: 'flops.einsum_cost'" — the client
+    # proxied einsum_cost/svd_cost to a server op that didn't exist. Exercise
+    # the real client->server path so a call-time regression can't slip through
+    # (the import-only check above could not catch it).
+    ec = fnp.accounting.einsum_cost("ij,jk->ik", [(4, 5), (5, 6)])
+    assert isinstance(ec, int) and ec > 0
+
+    svd_full = fnp.accounting.svd_cost(128, 64)  # k=0 -> FULL svd (not "top-0")
+    svd_topk = fnp.accounting.svd_cost(128, 64, k=8)
+    assert isinstance(svd_full, int) and svd_full > 0
+    assert isinstance(svd_topk, int) and svd_topk > 0
+    assert svd_full > svd_topk  # full decomposition costs more than rank-8
+
+    # pointwise/reduction were already local; confirm they still work too.
+    assert fnp.accounting.pointwise_cost("add", shape=(16, 16)) > 0
+    assert fnp.accounting.reduction_cost("sum", input_shape=(16, 16)) > 0
+
+
 def test_symmetric_tensor_is_intentionally_server_side():
     # NOT a gap: native exposes flopscope.SymmetricTensor, but the client
     # deliberately withholds it (a server-side / analysis API) with a helpful

--- a/tests/client_compat/test_scalar_array_arithmetic.py
+++ b/tests/client_compat/test_scalar_array_arithmetic.py
@@ -1,0 +1,101 @@
+"""RemoteScalar combined with a RemoteArray must broadcast to a RemoteArray.
+
+REAL prod regression (2026-06-24 re-grade): participants wrote
+``acc = acc + coef * tensor`` where ``coef`` is a 0-D ``RemoteScalar`` (from
+indexing/reduction) and ``tensor`` is a ``RemoteArray``. ``RemoteScalar``'s
+arithmetic dunders wrapped the result of ``self._value * other`` back in a
+``RemoteScalar`` unconditionally; when ``other`` was a ``RemoteArray`` the
+product is itself a ``RemoteArray``, producing a malformed "scalar" whose
+``_value`` is an array. The next op that took that object as an argument tried
+to wire-encode it and crashed with::
+
+    TypeError: can not serialize 'RemoteArray' object
+
+(and, when it sat inside a ``stack`` list, the proxy's
+``RemoteSerializationError: stack() received an argument of type 'RemoteArray'``).
+
+numpy's contract is ``scalar (op) array -> array`` (``np.float64(2) *
+np.array([1, 2]) == array([2, 4])``). These tests exercise the real
+client->server path so the malformed-scalar regression can't return.
+
+All tests rely on the ambient ``BudgetContext`` from the autouse
+``_fresh_connection_and_budget`` fixture; they must NOT open their own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import flopscope as fnp  # the CLIENT (conftest puts flopscope-client/src first)
+
+# Forward op, reverse op, and the expected element value for scalar=2.0,
+# array element=4.0 (so we cover commutative + non-commutative ops both ways).
+_OPS = [
+    ("mul", lambda s, a: s * a, lambda a, s: a * s, 8.0, 8.0),
+    ("add", lambda s, a: s + a, lambda a, s: a + s, 6.0, 6.0),
+    ("sub", lambda s, a: s - a, lambda a, s: a - s, -2.0, 2.0),
+    ("truediv", lambda s, a: s / a, lambda a, s: a / s, 0.5, 2.0),
+]
+
+
+def _scalar_two():
+    """A genuine RemoteScalar (0-D) with value 2.0, via indexing."""
+    s = fnp.array([2.0, 99.0])[0]
+    assert type(s).__name__ == "RemoteScalar", f"expected RemoteScalar, got {type(s)}"
+    return s
+
+
+@pytest.mark.parametrize("name,fwd,rev,fwd_val,rev_val", _OPS)
+def test_scalar_op_array_returns_array(name, fwd, rev, fwd_val, rev_val):
+    s = _scalar_two()
+    arr = fnp.array([4.0, 4.0, 4.0])
+
+    fwd_res = fwd(s, arr)  # scalar OP array
+    rev_res = rev(arr, s)  # array OP scalar
+
+    # Must broadcast to an ARRAY, not a (malformed) RemoteScalar.
+    assert type(fwd_res).__name__ == "RemoteArray", (
+        f"scalar {name} array returned {type(fwd_res).__name__}, expected RemoteArray"
+    )
+    assert type(rev_res).__name__ == "RemoteArray", (
+        f"array {name} scalar returned {type(rev_res).__name__}, expected RemoteArray"
+    )
+    assert fwd_res.tolist() == [fwd_val] * 3
+    assert rev_res.tolist() == [rev_val] * 3
+
+
+def test_scalar_array_product_is_wire_serializable():
+    """The exact crash: the malformed scalar only blew up when used as an op ARG."""
+    s = _scalar_two()
+    arr = fnp.array([4.0, 4.0, 4.0])
+    product = s * arr  # was a RemoteScalar wrapping a RemoteArray -> raw on the wire
+    # Using `product` as an argument forces it through encode_request/msgpack.
+    out = arr + product
+    assert out.tolist() == [12.0, 12.0, 12.0]
+
+
+def test_accumulation_pattern_from_prod():
+    """``acc = acc + coef * tensor`` with coef a RemoteScalar (sub 309722 shape)."""
+    acc = fnp.array([0.0, 0.0, 0.0])
+    tensor = fnp.array([1.0, 2.0, 3.0])
+    for coef_src in (fnp.array([0.5, 0.0])[0], fnp.array([2.0, 0.0])[0]):
+        acc = acc + coef_src * tensor  # crashed here pre-fix
+    assert acc.tolist() == [2.5, 5.0, 7.5]
+
+
+def test_scalar_array_product_in_stack_list():
+    """A malformed scalar inside a stack() list (sub 310080 shape)."""
+    s = _scalar_two()
+    a = fnp.array([1.0, 1.0])
+    b = fnp.array([3.0, 3.0])
+    stacked = fnp.stack([s * a, s + b])  # each element was a malformed scalar pre-fix
+    assert stacked.tolist() == [[2.0, 2.0], [5.0, 5.0]]
+
+
+def test_scalar_scalar_arithmetic_still_scalar():
+    """Regression guard: scalar (op) scalar/number must stay a RemoteScalar."""
+    s = _scalar_two()
+    assert type(s * 3).__name__ == "RemoteScalar"
+    assert type(s + s).__name__ == "RemoteScalar"
+    assert float(s * 3) == 6.0
+    assert float(s + s) == 4.0

--- a/tests/client_compat/test_scalar_index.py
+++ b/tests/client_compat/test_scalar_index.py
@@ -30,6 +30,9 @@ def test_scalar_indexes_list_and_range():
 
 
 def test_noninteger_scalar_rejects_index():
-    s = fnp.array([1.5, 2.5])[0]  # float scalar
+    s_frac = fnp.array([1.5, 2.5])[0]  # fractional float scalar
     with pytest.raises((TypeError, ValueError)):
-        ("a", "b")[s]
+        ("a", "b")[s_frac]
+    s_whole = fnp.array([2.0, 3.0])[0]  # WHOLE-valued float scalar: numpy still rejects
+    with pytest.raises((TypeError, ValueError)):
+        ("a", "b", "c")[s_whole]

--- a/tests/client_compat/test_scalar_index.py
+++ b/tests/client_compat/test_scalar_index.py
@@ -1,0 +1,34 @@
+"""A 0-D RemoteScalar must be usable as a Python index (numpy parity).
+
+Prod regression (subs 310044, 310045, 310059, 310067): "tuple indices must be
+integers or slices, not RemoteScalar" — a scalar from indexing/reduction used to
+index a Python tuple/list. v22 added __index__ to RemoteArray, not RemoteScalar.
+"""
+from __future__ import annotations
+
+import pytest
+
+import flopscope as fnp
+
+
+def _int_scalar(v):
+    s = fnp.array([v, v + 1])[0]
+    assert type(s).__name__ == "RemoteScalar"
+    return s
+
+
+def test_scalar_indexes_tuple():
+    s = _int_scalar(2)
+    assert ("a", "b", "c", "d")[s] == "c"
+
+
+def test_scalar_indexes_list_and_range():
+    s = _int_scalar(1)
+    assert [10, 20, 30][s] == 20
+    assert list(range(s, s + 2)) == [1, 2]
+
+
+def test_noninteger_scalar_rejects_index():
+    s = fnp.array([1.5, 2.5])[0]  # float scalar
+    with pytest.raises((TypeError, ValueError)):
+        ("a", "b")[s]

--- a/tests/client_compat/test_scalar_index.py
+++ b/tests/client_compat/test_scalar_index.py
@@ -29,6 +29,16 @@ def test_scalar_indexes_list_and_range():
     assert list(range(s, s + 2)) == [1, 2]
 
 
+def test_unsigned_int_scalar_indexes():
+    # Unsigned integer scalars are valid Python indices (numpy parity). The
+    # dtype gate's "int" substring matches "uintN" too, so these must work.
+    for dt in ("uint8", "uint16", "uint32", "uint64"):
+        s = fnp.array([0, 1], dtype=dt)[1]
+        assert type(s).__name__ == "RemoteScalar" and s.dtype == dt
+        assert ("a", "b")[s] == "b"
+        assert s.__index__() == 1
+
+
 def test_noninteger_scalar_rejects_index():
     s_frac = fnp.array([1.5, 2.5])[0]  # fractional float scalar
     with pytest.raises((TypeError, ValueError)):

--- a/tests/client_compat/test_scalar_index.py
+++ b/tests/client_compat/test_scalar_index.py
@@ -4,6 +4,7 @@ Prod regression (subs 310044, 310045, 310059, 310067): "tuple indices must be
 integers or slices, not RemoteScalar" — a scalar from indexing/reduction used to
 index a Python tuple/list. v22 added __index__ to RemoteArray, not RemoteScalar.
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/client_compat/test_serialization_errors.py
+++ b/tests/client_compat/test_serialization_errors.py
@@ -4,6 +4,7 @@ offending type, not a raw msgpack 'can not serialize' TypeError.
 The function-dispatch proxy already does this; the operator path (_dispatch_op)
 leaked the raw error (this is how the RemoteScalar bug surfaced cryptically).
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/client_compat/test_serialization_errors.py
+++ b/tests/client_compat/test_serialization_errors.py
@@ -1,0 +1,19 @@
+"""Operator/op dispatch must raise a clear RemoteSerializationError naming the
+offending type, not a raw msgpack 'can not serialize' TypeError.
+
+The function-dispatch proxy already does this; the operator path (_dispatch_op)
+leaked the raw error (this is how the RemoteScalar bug surfaced cryptically).
+"""
+from __future__ import annotations
+
+import pytest
+
+import flopscope as fnp
+from flopscope.errors import RemoteSerializationError
+
+
+def test_operator_dispatch_unserializable_arg_is_clear():
+    a = fnp.array([1.0, 2.0, 3.0])
+    with pytest.raises(RemoteSerializationError) as ei:
+        a + (lambda x: x)  # a function is not serializable
+    assert "function" in str(ei.value)


### PR DESCRIPTION
## Summary

Client/server/native parity fixes recovering production submission failures found by scanning all 578 prod failure reports. Feature-only PR; the `0.8.0rc4` version bump happens via `cz bump` on `main` after merge (same convention as rc3 #140), and deploy + re-grade are separate gated steps.

### Fixes (each with a failing-first client→server e2e test under `tests/client_compat/`)
- **RemoteScalar ⊗ RemoteArray broadcasts to an array** (`_remote_array.py` `_scalar_result`). Root cause of the `can not serialize 'RemoteArray' object` failures: the scalar dunders wrapped an array-valued result back into a `RemoteScalar`, whose `._value` (an array) then hit msgpack raw.
- **`flopscope.accounting.einsum_cost`/`svd_cost`** server ops (server `_request_handler.py` + native weighted cost). Intercepted before the budget path → charges 0 FLOPs.
- **`fnp.array()` accepts `array.array`/buffer-protocol** inputs, buffer-direct bytes (mirrors native `np.frombuffer`; keeps the `@timed_dispatch` cost honest). Raw `bytes`/`bytearray`/`str` are rejected cleanly (numpy makes a `|S` scalar, which flopscope has no dtype for).
- **`RemoteScalar.__index__`** (integer/bool dtype only — numpy parity) so a 0-D scalar can index tuples/lists/`range`.
- **Ellipsis (`...`) in indexing** (client `_encode_index_key` + server `_decode_index_key`).
- **`RemoteGenerator.permuted` / `chisquare`** (client proxies + server `_ALLOWED_GEN_METHODS`).
- **Operator-path serialization errors** now raise a clear `RemoteSerializationError` naming the offending type, instead of a raw msgpack `TypeError` (defense-in-depth; this is how the RemoteScalar bug surfaced cryptically).

### Dropped after investigation
A planned "list `axis` in reductions" fix was **dropped**: numpy itself raises `'list' object cannot be interpreted as an integer` for `a.sum(axis=[0,1])` (only int/tuple/None), so flopscope is already at parity — that's a participant bug, not a gap. Normalizing would diverge from numpy.

## Test Plan
- [x] `make test-client-parity` — core **54 passed**, methods **17 passed**
- [x] client unit suite **1380 passed** (1 pre-existing native-src path-leak failure, identical on `main`)
- [x] server unit suite **244 passed**
- [x] `scripts/sync_client.py --check` — in sync
- [x] `ruff check` + `ruff format --check` — clean (151 files)
- [x] CI typecheck (`pyright src/flopscope tests`) — identical to `main` (zero new)
- [x] Real-submission worker-exec replay for the RemoteScalar fix (sub 309722) passes

Companion docs PR (participant-facing failure modes) in `whest-starterkit`.