### PR TITLE
Add optional GPU execution via CuPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@
 
 **flopscope** is a drop-in replacement for a subset of NumPy that counts floating-point operations as you compute. Algorithms submitted to the ARC Whitebox Estimation Challenge are scored by their analytical FLOP cost, not wall-clock time, so researchers can focus on **algorithmic innovation** rather than hardware tuning. Every arithmetic call deducts from a fixed budget; exceed it and execution stops immediately.
 
+## Optional GPU execution
+
+flopscope can optionally execute selected backend calls with CuPy while
+preserving the public CPU `flopscope.numpy.ndarray` contract and analytical
+FLOP accounting. Install the optional extra and enable GPU execution locally:
+
+```sh
+pip install "flopscope[gpu]"
+FLOPSCOPE_GPU=1 python your_script.py
+```
+
+or:
+
+```python
+import flopscope as flops
+
+flops.configure_gpu(True)
+print(flops.gpu_status())
+```
+
+Results are copied back to CPU after each offloaded operation. The default gate
+keeps tiny or transfer-heavy calls on CPU with
+`FLOPSCOPE_GPU_MIN_FLOPS=5000000`,
+`FLOPSCOPE_GPU_MIN_FLOPS_PER_BYTE=0.05`, and no transfer-byte floor.
+
 ## Why flopscope?
 
 <table>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 
 [project.optional-dependencies]
 server = ["flopscope-server==0.8.0rc4"]
+gpu = ["cupy-cuda12x>=13.0.0"]
 dev = [
     "commitizen>=4.0",
     "gitlint>=0.19",

--- a/src/flopscope/__init__.py
+++ b/src/flopscope/__init__.py
@@ -32,7 +32,7 @@ import numpy as _np
 
 from flopscope._registry import REGISTRY_META as _REGISTRY_META
 
-__version__ = f"0.8.0rc4+np{_np.__version__}"
+__version__ = f"0.8.0rc4+gpu.np{_np.__version__}"
 __numpy_version__ = _np.__version__
 __numpy_pinned__ = _REGISTRY_META["numpy_version"]
 __numpy_supported__ = _REGISTRY_META.get("numpy_supported", ">=2.0.0,<2.5.0")
@@ -61,6 +61,12 @@ from flopscope._budget import (  # noqa: F401,E402
 )
 from flopscope._config import configure  # noqa: F401,E402
 from flopscope._display import budget_live, budget_summary  # noqa: F401,E402
+from flopscope._gpu import (  # noqa: F401,E402
+    configure_gpu,
+    gpu_available,
+    gpu_enabled,
+    gpu_status,
+)
 
 # --- Module base class ---
 from flopscope._module import Module  # noqa: F401,E402
@@ -266,9 +272,13 @@ __all__ = [
     "budget_summary_dict",
     "clear_cache",
     "configure",
+    "configure_gpu",
     "einsum_accumulation_cost",
     "einsum_cache_info",
     "einsum_clear_caches",
+    "gpu_available",
+    "gpu_enabled",
+    "gpu_status",
     "is_symmetric",
     "namespace",
     "numpy",

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -214,6 +214,21 @@ def _call_numpy(fn: Any, *args: Any, **kwargs: Any) -> Any:
     """
     t0 = time.perf_counter()
     try:
+        from flopscope._gpu import maybe_call_gpu
+
+        flop_cost = None
+        budget = get_active_budget()
+        timer = budget._current_op_timer if budget is not None else None
+        op_index = getattr(timer, "_op_index", None)
+        if op_index is not None:
+            try:
+                flop_cost = budget._op_log[op_index].flop_cost  # type: ignore[union-attr]
+            except (IndexError, TypeError):
+                flop_cost = None
+
+        used_gpu, result = maybe_call_gpu(fn, *args, flop_cost=flop_cost, **kwargs)
+        if used_gpu:
+            return result
         return fn(*args, **kwargs)
     finally:
         d = time.perf_counter() - t0

--- a/src/flopscope/_gpu.py
+++ b/src/flopscope/_gpu.py
@@ -1,0 +1,389 @@
+"""Optional GPU execution helpers for flopscope.
+
+This module deliberately keeps GPU support behind an opt-in execution boundary.
+``FlopscopeArray`` is a ``numpy.ndarray`` subclass, so public values still need
+to be CPU ndarrays. The GPU backend accelerates selected backend calls, then
+copies results back before normal flopscope wrapping and accounting continue.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as _np
+
+_enabled = os.environ.get("FLOPSCOPE_GPU", "").lower() in {"1", "true", "yes", "on"}
+_strict = os.environ.get("FLOPSCOPE_GPU_STRICT", "").lower() in {"1", "true", "yes", "on"}
+_use_predictor = os.environ.get("FLOPSCOPE_GPU_USE_PREDICTOR", "0").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+_min_free_bytes = int(os.environ.get("FLOPSCOPE_GPU_MIN_FREE_BYTES", str(512 * 1024 * 1024)))
+_min_flops = int(os.environ.get("FLOPSCOPE_GPU_MIN_FLOPS", "5000000"))
+_min_transfer_bytes = int(os.environ.get("FLOPSCOPE_GPU_MIN_TRANSFER_BYTES", "0"))
+_min_flops_per_byte = float(os.environ.get("FLOPSCOPE_GPU_MIN_FLOPS_PER_BYTE", "0.05"))
+_min_predicted_speedup = float(os.environ.get("FLOPSCOPE_GPU_MIN_PREDICTED_SPEEDUP", "1.05"))
+_max_transfer_fraction = float(os.environ.get("FLOPSCOPE_GPU_MAX_TRANSFER_FRACTION", "0.25"))
+_cupy: Any | None = None
+_cupy_error: Exception | None = None
+_runtime_error: Exception | None = None
+_runtime_checked = False
+_last_skip_reason: str | None = None
+_gpu_call_count = 0
+_fallback_count = 0
+
+_GPU_FUNCTIONS = {
+    "absolute",
+    "add",
+    "clip",
+    "divide",
+    "dot",
+    "einsum",
+    "exp",
+    "log",
+    "matmul",
+    "maximum",
+    "mean",
+    "minimum",
+    "multiply",
+    "negative",
+    "power",
+    "sqrt",
+    "subtract",
+    "sum",
+    "tensordot",
+    "true_divide",
+    "where",
+}
+
+
+def configure_gpu(enabled: bool = True) -> None:
+    """Enable or disable optional GPU-backed execution."""
+
+    global _enabled, _runtime_error, _runtime_checked, _last_skip_reason
+    _enabled = bool(enabled)
+    if _enabled:
+        _runtime_error = None
+        _runtime_checked = False
+        _last_skip_reason = None
+
+
+def gpu_enabled() -> bool:
+    """Return whether GPU execution has been requested."""
+
+    return _enabled
+
+
+def gpu_available() -> bool:
+    """Return whether CuPy can import and the CUDA runtime is usable."""
+
+    return _runtime_available()
+
+
+def gpu_status() -> dict[str, Any]:
+    """Return a small diagnostic snapshot for the optional GPU backend."""
+
+    cp = _load_cupy()
+    runtime_available = _runtime_available() if cp is not None else False
+    free_bytes, total_bytes = _memory_info(cp) if runtime_available else (None, None)
+    return {
+        "enabled": _enabled,
+        "available": runtime_available,
+        "backend": "cupy" if runtime_available else None,
+        "error": repr(_cupy_error) if _cupy_error is not None else None,
+        "runtime_error": repr(_runtime_error) if _runtime_error is not None else None,
+        "free_bytes": free_bytes,
+        "total_bytes": total_bytes,
+        "min_flops": _min_flops,
+        "min_transfer_bytes": _min_transfer_bytes,
+        "min_flops_per_byte": _min_flops_per_byte,
+        "use_predictor": _use_predictor,
+        "min_predicted_speedup": _min_predicted_speedup,
+        "last_skip_reason": _last_skip_reason,
+        "gpu_call_count": _gpu_call_count,
+        "fallback_count": _fallback_count,
+        "supported_functions": tuple(sorted(_GPU_FUNCTIONS)),
+    }
+
+
+def maybe_call_gpu(
+    fn: Any, *args: Any, flop_cost: int | None = None, **kwargs: Any
+) -> tuple[bool, Any]:
+    """Try to execute ``fn`` through CuPy.
+
+    Returns ``(True, result)`` when the operation ran on GPU and was copied back
+    to CPU, otherwise ``(False, None)`` so the caller can use the normal NumPy
+    path. Exceptions from supported GPU calls are allowed to propagate; silent
+    fallback after partial GPU execution would hide real numerical failures.
+    """
+
+    if not _enabled:
+        return False, None
+    name = getattr(fn, "__name__", "")
+    if name not in _GPU_FUNCTIONS:
+        return False, None
+    cp = _load_cupy()
+    if cp is None or not _runtime_available():
+        _record_fallback("runtime_unavailable")
+        return False, None
+    gpu_fn = getattr(cp, name, None)
+    if gpu_fn is None:
+        _record_fallback("unsupported_function")
+        return False, None
+    if not _has_memory_headroom(cp, name, args, kwargs, flop_cost=flop_cost):
+        _record_fallback(_last_skip_reason or "insufficient_memory")
+        return False, None
+
+    try:
+        gpu_args = _to_gpu_tree(cp, args)
+        gpu_kwargs = {key: _to_gpu_tree(cp, value) for key, value in kwargs.items()}
+        result = gpu_fn(*gpu_args, **gpu_kwargs)
+        cp.cuda.Stream.null.synchronize()
+        _record_gpu_call()
+        return True, _to_cpu_tree(cp, result)
+    except Exception as exc:  # pragma: no cover - depends on CUDA runtime state
+        _record_runtime_failure(exc)
+        if _strict:
+            raise
+        _record_fallback(type(exc).__name__)
+        return False, None
+
+
+def _load_cupy() -> Any | None:
+    global _cupy, _cupy_error
+    if _cupy is not None:
+        return _cupy
+    if _cupy_error is not None:
+        return None
+    try:
+        import cupy as cp
+    except Exception as exc:  # pragma: no cover - depends on optional package
+        _cupy_error = exc
+        return None
+    _cupy = cp
+    return cp
+
+
+def _runtime_available() -> bool:
+    """Return True only when CuPy can talk to CUDA and allocate a tiny array."""
+
+    global _runtime_checked
+    cp = _load_cupy()
+    if cp is None:
+        return False
+    if _runtime_error is not None:
+        return False
+    if _runtime_checked:
+        return True
+    try:
+        if cp.cuda.runtime.getDeviceCount() < 1:
+            raise RuntimeError("CuPy found no CUDA devices")
+        probe = cp.empty((1,), dtype=cp.float32)
+        probe.fill(0)
+        cp.cuda.Stream.null.synchronize()
+        cp.get_default_memory_pool().free_all_blocks()
+    except Exception as exc:  # pragma: no cover - depends on CUDA runtime state
+        _record_runtime_failure(exc)
+        return False
+    _runtime_checked = True
+    return True
+
+
+def _record_runtime_failure(exc: Exception) -> None:
+    global _runtime_error, _runtime_checked
+    _runtime_error = exc
+    _runtime_checked = False
+    cp = _cupy
+    if cp is not None:
+        try:
+            cp.get_default_memory_pool().free_all_blocks()
+            cp.get_default_pinned_memory_pool().free_all_blocks()
+        except Exception:
+            pass
+
+
+def _record_gpu_call() -> None:
+    global _gpu_call_count
+    _gpu_call_count += 1
+
+
+def _record_fallback(reason: str) -> None:
+    global _fallback_count, _last_skip_reason
+    _fallback_count += 1
+    _last_skip_reason = reason
+
+
+def _memory_info(cp: Any) -> tuple[int | None, int | None]:
+    try:
+        free_bytes, total_bytes = cp.cuda.runtime.memGetInfo()
+    except Exception as exc:  # pragma: no cover - depends on CUDA runtime state
+        _record_runtime_failure(exc)
+        return None, None
+    return int(free_bytes), int(total_bytes)
+
+
+def _has_memory_headroom(
+    cp: Any, op_name: str, args: Any, kwargs: Any, *, flop_cost: int | None
+) -> bool:
+    """Cheap preflight so low-memory CUDA states fall back to CPU per op."""
+
+    global _last_skip_reason
+    free_bytes, _total_bytes = _memory_info(cp)
+    if free_bytes is None:
+        _last_skip_reason = "cuda_meminfo_failed"
+        return False
+    transfer_bytes = _tree_nbytes(args) + _tree_nbytes(kwargs)
+    if _min_transfer_bytes > 0 and transfer_bytes < _min_transfer_bytes:
+        _last_skip_reason = (
+            f"below_min_transfer_bytes(transfer={transfer_bytes}, "
+            f"minimum={_min_transfer_bytes})"
+        )
+        return False
+    if not _use_predictor and flop_cost is not None and flop_cost < _min_flops:
+        _last_skip_reason = (
+            f"below_min_flops(flops={flop_cost}, minimum={_min_flops}, "
+            f"transfer={transfer_bytes})"
+        )
+        return False
+    if (
+        not _use_predictor
+        and _min_flops_per_byte > 0
+        and flop_cost is not None
+        and transfer_bytes > 0
+    ):
+        flops_per_byte = flop_cost / transfer_bytes
+        if flops_per_byte < _min_flops_per_byte:
+            _last_skip_reason = (
+                f"below_min_flops_per_byte(value={flops_per_byte:.6g}, "
+                f"minimum={_min_flops_per_byte:.6g}, flops={flop_cost}, "
+                f"transfer={transfer_bytes})"
+            )
+            return False
+    if _use_predictor and flop_cost is not None and transfer_bytes > 0:
+        predicted = _predict_speedup(op_name, flop_cost, transfer_bytes)
+        if predicted is not None and predicted < _min_predicted_speedup:
+            _last_skip_reason = (
+                f"below_predicted_speedup(value={predicted:.6g}, "
+                f"minimum={_min_predicted_speedup:.6g}, op={op_name}, "
+                f"flops={flop_cost}, transfer={transfer_bytes})"
+            )
+            return False
+    # Account for host->device inputs, at least one output-sized scratch, and
+    # backend temporaries. This is intentionally conservative because the public
+    # API copies results back to CPU after every op.
+    required = max(_min_free_bytes, int(transfer_bytes * 3))
+    if transfer_bytes > 0:
+        required = max(required, int(transfer_bytes / max(_max_transfer_fraction, 1e-9)))
+    if free_bytes < required:
+        _last_skip_reason = (
+            f"insufficient_free_memory(free={free_bytes}, required={required}, "
+            f"transfer={transfer_bytes})"
+        )
+        return False
+    _last_skip_reason = None
+    return True
+
+
+def _tree_nbytes(value: Any) -> int:
+    if isinstance(value, _np.ndarray):
+        return int(value.nbytes)
+    if isinstance(value, (tuple, list)):
+        return sum(_tree_nbytes(item) for item in value)
+    if isinstance(value, Mapping):
+        return sum(_tree_nbytes(item) for item in value.values())
+    return 0
+
+
+def _op_family(op_name: str) -> str:
+    if op_name in {"matmul", "dot", "tensordot"}:
+        return "matmul"
+    if op_name == "einsum":
+        return "einsum_mm"
+    if op_name in {"sum", "mean"}:
+        return "sum"
+    if op_name in {
+        "add",
+        "clip",
+        "divide",
+        "maximum",
+        "minimum",
+        "multiply",
+        "subtract",
+        "true_divide",
+        "where",
+    }:
+        return "add"
+    if op_name in {"absolute", "exp", "log", "negative", "power", "sqrt"}:
+        return "sqrt"
+    return "other"
+
+
+def _predict_speedup(op_name: str, flop_cost: int, transfer_bytes: int) -> float | None:
+    """Predict CPU/GPU speedup from the local per-family linear calibration."""
+
+    family = _op_family(op_name)
+    cpu_s = _predict_seconds("cpu", family, flop_cost, transfer_bytes)
+    gpu_s = _predict_seconds("gpu", family, flop_cost, transfer_bytes)
+    if cpu_s is None or gpu_s is None or gpu_s <= 0:
+        return None
+    return cpu_s / gpu_s
+
+
+_CPU_LINEAR = {
+    # family: (bias + family_intercept, input_gb_slope, flops_g_slope)
+    "add": (-8.46838e-06, 0.055149452, 0.0034468408),
+    "einsum_mm": (0.00065389923, -0.29327636, 0.22666659),
+    "matmul": (0.00020809060, -0.31185279, 0.016144399),
+    "sqrt": (-0.00010633678, 0.30440510, 0.076101275),
+    "sum": (0.00003329585, 0.16882305, 0.021102882),
+}
+
+_GPU_LINEAR = {
+    # family: (bias + family_intercept, input_gb_slope, flops_g_slope)
+    "add": (0.000005522236, 0.061959127, 0.0038724454),
+    "einsum_mm": (0.00039135901, 0.12503778, 0.0065383439),
+    "matmul": (0.00010991234, 0.24604765, 0.0051278073),
+    "sqrt": (-0.00018535899, 0.42722801, 0.10680700),
+    "sum": (0.00010195763, 0.12028859, 0.015036074),
+}
+
+
+def _predict_seconds(
+    target: str, family: str, flop_cost: int, transfer_bytes: int
+) -> float | None:
+    table = _CPU_LINEAR if target == "cpu" else _GPU_LINEAR
+    coeffs = table.get(family)
+    if coeffs is None:
+        return None
+    intercept, input_gb_slope, flops_g_slope = coeffs
+    input_gb = transfer_bytes / 1e9
+    flops_g = flop_cost / 1e9
+    return max(intercept + input_gb_slope * input_gb + flops_g_slope * flops_g, 0.0)
+
+
+def _to_gpu_tree(cp: Any, value: Any) -> Any:
+    if isinstance(value, _np.ndarray):
+        return cp.asarray(value)
+    if isinstance(value, tuple):
+        return tuple(_to_gpu_tree(cp, item) for item in value)
+    if isinstance(value, list):
+        return [_to_gpu_tree(cp, item) for item in value]
+    if isinstance(value, Mapping):
+        return {key: _to_gpu_tree(cp, item) for key, item in value.items()}
+    return value
+
+
+def _to_cpu_tree(cp: Any, value: Any) -> Any:
+    if isinstance(value, cp.ndarray):
+        return cp.asnumpy(value)
+    if isinstance(value, tuple):
+        return tuple(_to_cpu_tree(cp, item) for item in value)
+    if isinstance(value, list):
+        return [_to_cpu_tree(cp, item) for item in value]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return type(value)(_to_cpu_tree(cp, item) for item in value)
+    return value

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,154 @@
+import numpy as np
+
+import flopscope as flops
+import flopscope.numpy as fnp
+import flopscope._gpu as flops_gpu
+
+
+def test_gpu_controls_are_exposed():
+    assert "+gpu.np" in flops.__version__
+    status = flops.gpu_status()
+    assert status["min_flops"] == 5_000_000
+    assert status["min_transfer_bytes"] == 0
+    assert status["min_flops_per_byte"] == 0.05
+    assert "matmul" in status["supported_functions"]
+
+
+def test_gpu_opt_in_preserves_cpu_array_contract():
+    previous = flops.gpu_enabled()
+    flops.configure_gpu(True)
+    try:
+        with flops.BudgetContext(flop_budget=10_000) as budget:
+            a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+            b = fnp.array([[5.0], [6.0]])
+            out = fnp.matmul(a, b)
+
+        assert isinstance(out, fnp.ndarray)
+        np.testing.assert_allclose(np.asarray(out), np.array([[17.0], [39.0]]))
+        assert budget.flops_used > 0
+    finally:
+        flops.configure_gpu(previous)
+
+
+def test_gpu_success_path_preserves_cpu_array_contract_with_fake_cupy(monkeypatch):
+    class FakeStreamNull:
+        @staticmethod
+        def synchronize():
+            pass
+
+    class FakeRuntime:
+        @staticmethod
+        def getDeviceCount():
+            return 1
+
+        @staticmethod
+        def memGetInfo():
+            return 2 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024
+
+    class FakeStream:
+        null = FakeStreamNull()
+
+    class FakeCuda:
+        runtime = FakeRuntime()
+        Stream = FakeStream()
+
+    class FakePool:
+        def free_all_blocks(self):
+            pass
+
+    class FakeCupy:
+        cuda = FakeCuda()
+        float32 = np.float32
+        ndarray = np.ndarray
+
+        @staticmethod
+        def empty(*args, **kwargs):
+            return np.empty(*args, **kwargs)
+
+        @staticmethod
+        def asarray(value):
+            return np.asarray(value)
+
+        @staticmethod
+        def asnumpy(value):
+            return np.asarray(value)
+
+        @staticmethod
+        def matmul(a, b, **kwargs):
+            return np.matmul(a, b, **kwargs)
+
+        @staticmethod
+        def get_default_memory_pool():
+            return FakePool()
+
+        @staticmethod
+        def get_default_pinned_memory_pool():
+            return FakePool()
+
+    monkeypatch.setattr(flops_gpu, "_cupy", FakeCupy)
+    monkeypatch.setattr(flops_gpu, "_cupy_error", None)
+    monkeypatch.setattr(flops_gpu, "_runtime_error", None)
+    monkeypatch.setattr(flops_gpu, "_runtime_checked", False)
+
+    previous = flops.gpu_enabled()
+    flops.configure_gpu(True)
+    try:
+        used_gpu, result = flops_gpu.maybe_call_gpu(
+            np.matmul, np.eye(2), np.eye(2), flop_cost=5_000_000
+        )
+        assert used_gpu is True
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_allclose(result, np.eye(2))
+    finally:
+        flops.configure_gpu(previous)
+
+
+def test_gpu_runtime_failure_falls_back_to_cpu(monkeypatch):
+    class FakeRuntime:
+        @staticmethod
+        def getDeviceCount():
+            return 1
+
+    class FakeStream:
+        null = object()
+
+    class FakeCuda:
+        runtime = FakeRuntime()
+        Stream = FakeStream()
+
+    class FakePool:
+        def free_all_blocks(self):
+            pass
+
+    class FakeCupy:
+        cuda = FakeCuda()
+        float32 = np.float32
+
+        @staticmethod
+        def empty(*args, **kwargs):
+            raise RuntimeError("synthetic cuda allocation failure")
+
+        @staticmethod
+        def get_default_memory_pool():
+            return FakePool()
+
+        @staticmethod
+        def get_default_pinned_memory_pool():
+            return FakePool()
+
+    monkeypatch.setattr(flops_gpu, "_cupy", FakeCupy)
+    monkeypatch.setattr(flops_gpu, "_cupy_error", None)
+    monkeypatch.setattr(flops_gpu, "_runtime_error", None)
+    monkeypatch.setattr(flops_gpu, "_runtime_checked", False)
+
+    previous = flops.gpu_enabled()
+    flops.configure_gpu(True)
+    try:
+        used_gpu, result = flops_gpu.maybe_call_gpu(np.matmul, np.eye(2), np.eye(2))
+        assert used_gpu is False
+        assert result is None
+        status = flops.gpu_status()
+        assert status["available"] is False
+        assert "synthetic cuda allocation failure" in status["runtime_error"]
+    finally:
+        flops.configure_gpu(previous)

--- a/uv.lock
+++ b/uv.lock
@@ -406,6 +406,42 @@ toml = [
 ]
 
 [[package]]
+name = "cuda-pathfinder"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl", hash = "sha256:0228c023f95d1480f143ef5c8922d27a2ab052087a942e81dc289c9eb8f91689", size = 51671, upload-time = "2026-05-27T01:21:25.413Z" },
+]
+
+[[package]]
+name = "cupy-cuda12x"
+version = "14.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/18/8ec57a901a11d6955f90e1fbf3e04c8f26721066c99dfa25276e3e3b1f1d/cupy_cuda12x-14.1.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:909c4b8ac05eee43edfbe791522ee5d593e3504be7bd5c20e2de12b050db2a26", size = 143787561, upload-time = "2026-06-01T04:51:46.125Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/79/6a4e1562b3b6b18e93365955adfd4f66a84b60bdacf559becc0e3e0f1012/cupy_cuda12x-14.1.1-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:71b8de628a4a9ab24b6cc2af2162db2898e65a44a50a6d79cbc131c4f36405de", size = 132662808, upload-time = "2026-06-01T04:51:54.719Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/df/39530cffd84a00dfe98484a9ece77eed4acdc14717e1f77fa2a3e82a40dc/cupy_cuda12x-14.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:519e50b7dec2400e3fddbe9e6c4066937fd622a16774f375ab5be9d1cb1ea05e", size = 95338688, upload-time = "2026-06-01T04:51:59.685Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/65/13c173fec4923b9c4e1573344fc4a5585bf0e4efe5d9a5632e9bb18b2a31/cupy_cuda12x-14.1.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:5d4c1c74f9f7fc9de0aa5781cf3ec54f9f05143f5761e21a8798772c8eedd0be", size = 145089362, upload-time = "2026-06-01T04:52:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/ccd2fea320ece269dd7237649da384cad71fbb1ba30937a1eb3311c31b77/cupy_cuda12x-14.1.1-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:8889cb83dbb7dbea593e60c85fcc91e21b0ccd10cd5380dfdfaac70b6bd9390a", size = 134012855, upload-time = "2026-06-01T04:52:11.526Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/93970d536e8401cf31d8f5602141f1c2edfc304e6d6b8702041688509509/cupy_cuda12x-14.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:e39a081fc4fe2166f95ef8be38fe2a95b2c4decb3ec991b4f26bfc9673d16b17", size = 95336905, upload-time = "2026-06-01T04:52:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6e/290ee2d7cc4ad63d66e67acfd7ff3026f2b648dd04449a1bf88ffaa36b1e/cupy_cuda12x-14.1.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7aae7d3bed37985e2aa39f0914b88ad90dbd3a6141d3e8198d73fce65859013c", size = 144383812, upload-time = "2026-06-01T04:52:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/dc03c1ddc940f33b3d32803898e2fdae5c9538a2127a25f499494c84b183/cupy_cuda12x-14.1.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a1138f20080489a46209291498cd12f792226d0a57d50c64a586c162a875a069", size = 133516927, upload-time = "2026-06-01T04:52:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/d4a8045b533af634bc791572e8c87981065e4a27b5d3e09d0d4d285742fd/cupy_cuda12x-14.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:85bebce86ffc25ecf31727b25da7b3793daf07b6fd9952704546af574d250988", size = 95238722, upload-time = "2026-06-01T04:52:46.296Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/00fe874c47207b26c9b6ac950d0cecc533b4a145491641932df17e573f3c/cupy_cuda12x-14.1.1-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:afbb3d1fa9484b0ae20d76372c5939a8c5da327e3fc8711b77b2354566cac355", size = 143920086, upload-time = "2026-06-01T04:52:51.726Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a4/c46ff91dba0dbe2a0a557974faf4c090a3159d6e7296431ca6846038d047/cupy_cuda12x-14.1.1-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:76ea35469e2aa0a8332b88f72505ea2f7871a0bc8f9b0c87184f57e47c9aa3bf", size = 133071615, upload-time = "2026-06-01T04:52:57.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a0/46778424035ad3fc920d49471f079687a054f74d179142e9520014c2514e/cupy_cuda12x-14.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:64072f4139b44df38215f0519a6badc14138fa0e4bb5b2db44fe94d05f8b9c8b", size = 95219598, upload-time = "2026-06-01T04:53:02.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/99/d72336481264c3483b162ea128d58f80abb50009f1df82ca82905e0b8fd7/cupy_cuda12x-14.1.1-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:22d0ff2755a7f29cb225d1d5fb979a73428c5534ea0bca91b0c02698e9948f84", size = 143788629, upload-time = "2026-06-01T04:53:09.404Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/77/c43a67e6809e03780d88caf690fa44a8b3152db2d8f848714bec327c9881/cupy_cuda12x-14.1.1-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:1059581507343e7cf6231facce30932a195c7aad4fa7771d00e4a252683915a1", size = 132406367, upload-time = "2026-06-01T04:53:16.232Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/dc/96cd37de6da41239e02fc7f17e3364d60f99bd6816673d622916a06113ec/cupy_cuda12x-14.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:e707e0eceee174d323be21652e87bb97be982e6966b5dc241756307df42842aa", size = 95793971, upload-time = "2026-06-01T04:53:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c6/0ddec1be851de546e883ae3da5f03c1ea69738628b38234dce4362b5e38b/cupy_cuda12x-14.1.1-cp314-cp314t-manylinux2014_aarch64.whl", hash = "sha256:e09897636b7468a90efa1152109f0b19ba49ebc9a423d5dbd4682ed589e57843", size = 144093057, upload-time = "2026-06-01T04:53:28.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/80/5e05de89ba61df072aab6f8a6ee3ffeec57db68a0a456825b3b4ce608426/cupy_cuda12x-14.1.1-cp314-cp314t-manylinux2014_x86_64.whl", hash = "sha256:238080487174268d0f09770fe518de7c5b206527bef5c6792aef7ba0626a1c48", size = 132635338, upload-time = "2026-06-01T04:53:35.229Z" },
+]
+
+[[package]]
 name = "decli"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -498,6 +534,9 @@ dev = [
 docs = [
     { name = "numpydoc" },
 ]
+gpu = [
+    { name = "cupy-cuda12x" },
+]
 server = [
     { name = "flopscope-server" },
 ]
@@ -514,6 +553,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "cupy-cuda12x", marker = "extra == 'gpu'", specifier = ">=13.0.0" },
     { name = "flopscope-server", marker = "extra == 'server'", editable = "flopscope-server" },
     { name = "gitlint", marker = "extra == 'dev'", specifier = ">=0.19" },
     { name = "numpy", specifier = ">=2.0.0,<2.5.0" },
@@ -529,7 +569,7 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "sympy", marker = "extra == 'sympy'", specifier = ">=1.11" },
 ]
-provides-extras = ["server", "dev", "docs", "sympy"]
+provides-extras = ["server", "gpu", "dev", "docs", "sympy"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- add opt-in CuPy execution for selected backend NumPy calls while preserving CPU ndarray outputs and FLOP accounting
- expose `configure_gpu`, `gpu_status`, `gpu_enabled`, and `gpu_available` at the top level
- add a `gpu` optional dependency extra and README documentation for local GPU execution
- add focused tests for public controls, CPU array contract preservation, fake-CuPy offload, and CUDA runtime fallback

## Testing

- `UV_CACHE_DIR=/tmp/flopscope-uv-cache uv run --python 3.10 pytest -q tests/test_gpu.py`