### PR TITLE
fix(client,server): decode wire with raw=False; drop bytes-vs-str heuristic

### DIFF
--- a/flopscope-client/src/flopscope/_getattr.py
+++ b/flopscope-client/src/flopscope/_getattr.py
@@ -30,6 +30,13 @@ _ABSTRACT_SCALAR_TYPES = frozenset(
     }
 )
 
+# numpy helpers that wrap an arbitrary Python callable and apply it per element.
+# They can't work in the remote client: the wrapped callable runs in the client
+# process on materialized values, so its work is neither FLOP-counted nor
+# dispatched to the compute server (an accounting hole). Give a clear,
+# actionable error instead of a bare "no attribute".
+_PYFUNC_WRAPPERS = frozenset({"vectorize", "frompyfunc"})
+
 
 def make_module_getattr(module_prefix: str, module_label: str):
     """Return a ``__getattr__`` suitable for assignment at module scope.
@@ -49,6 +56,17 @@ def make_module_getattr(module_prefix: str, module_label: str):
         # Skip dunder/private names to avoid interfering with import machinery
         if name.startswith("_"):
             raise AttributeError(f"module '{module_label}' has no attribute '{name}'")
+
+        if name in _PYFUNC_WRAPPERS:
+            raise AttributeError(
+                f"'{module_label}.{name}' is not supported in the flopscope "
+                f"client: it wraps an arbitrary Python callable applied per "
+                f"element, which cannot be FLOP-counted or dispatched to the "
+                f"remote compute server (the callable would run uncounted in the "
+                f"client process). Use native vectorized ops / ufuncs instead, or "
+                f"flopscope.stats for special functions (e.g. erf via "
+                f"flopscope.stats.norm.cdf)."
+            )
 
         qualified = f"{module_prefix}{name}" if module_prefix else name
         category = get_category(qualified)

--- a/flopscope-client/src/flopscope/_protocol.py
+++ b/flopscope-client/src/flopscope/_protocol.py
@@ -4,34 +4,6 @@ from __future__ import annotations
 
 import msgpack
 
-# Maximum byte length that we consider "short enough" to attempt ASCII decode.
-# Handle IDs and status strings are short ASCII; binary array data may contain
-# high bytes even when valid UTF-8.
-_SHORT_THRESHOLD = 32
-
-
-def _normalize(value: object) -> object:
-    """Recursively normalize bytes keys/values to strings where appropriate.
-
-    Binary data fields (raw array bytes) stay as bytes.  Only decode bytes
-    that are short AND contain only ASCII printable characters (no bytes > 127).
-    This catches handle IDs and dtype strings but never touches binary data.
-    """
-    if isinstance(value, bytes):
-        if (
-            len(value) > 0
-            and len(value) <= _SHORT_THRESHOLD
-            and all(32 <= b < 128 for b in value)
-        ):
-            return value.decode("ascii")
-        return value
-    if isinstance(value, dict):
-        return {_normalize(k): _normalize(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        normalized = [_normalize(item) for item in value]
-        return type(value)(normalized)
-    return value
-
 
 def encode_request(op: str, args=None, kwargs=None) -> bytes:
     """Msgpack-encode ``{"op": op, "args": args, "kwargs": kwargs}``."""
@@ -77,9 +49,15 @@ def encode_free(handles: list[str]) -> bytes:
 
 
 def decode_response(raw: bytes) -> dict:
-    """Decode a msgpack response, normalizing bytes keys/values to strings.
+    """Decode a msgpack response using msgpack's native bin/str distinction.
 
-    Binary data fields (raw array bytes) stay as bytes.
+    The server packs every field with ``use_bin_type=True`` -- string fields
+    (status, dtype, handle IDs, error messages) as msgpack ``str`` and raw array
+    buffers as msgpack ``bin``.  Decoding with ``raw=False`` therefore yields
+    ``str`` for strings and ``bytes`` for binary natively.  We must NOT guess
+    types from content: a short, all-printable-ASCII array buffer (e.g.
+    ``struct.pack('<d', x) == b'12345678'``) is indistinguishable from a string
+    by content, and the old heuristic mis-decoded it to ``str`` -- breaking
+    ``__float__``/``__int__``/``tolist`` (see test_fetch_bytes_decode).
     """
-    decoded = msgpack.unpackb(raw, raw=True, strict_map_key=False)
-    return _normalize(decoded)
+    return msgpack.unpackb(raw, raw=False, strict_map_key=False)

--- a/flopscope-client/tests/test_connection.py
+++ b/flopscope-client/tests/test_connection.py
@@ -180,23 +180,37 @@ class TestProtocol:
             result["result"]["budget_breakdown"]["by_namespace"]["phase"]["calls"] == 1
         )
 
-    def test_normalize_preserves_small_binary_data(self):
-        """FIX 2 (client): small binary array data must NOT be decoded."""
-        import struct
+    def test_decode_response_preserves_binary_data(self):
+        """decode_response (raw=False) keeps binary array buffers as bytes -- even
+        short, all-printable ones the old content heuristic wrongly decoded to str
+        (the __float__/__int__/tolist regression; see test_fetch_bytes_decode)."""
+        import msgpack
+        from flopscope._protocol import decode_response
 
-        from flopscope._protocol import _normalize
+        # The server packs ``data`` as a msgpack bin field (use_bin_type=True).
+        raw = msgpack.packb(
+            {
+                "status": "ok",
+                "result": {"data": b"12345678", "shape": [1], "dtype": "float64"},
+            },
+            use_bin_type=True,
+        )
+        resp = decode_response(raw)
+        assert isinstance(resp["result"]["data"], bytes)
+        assert resp["result"]["data"] == b"12345678"
 
-        data = struct.pack("<d", 3.14)  # 8 bytes float64
-        result = _normalize(data)
-        assert isinstance(result, bytes), "binary float64 data was decoded to str"
+    def test_decode_response_yields_str_for_string_fields(self):
+        """String fields decode to str via msgpack's native bin/str distinction."""
+        import msgpack
+        from flopscope._protocol import decode_response
 
-    def test_normalize_decodes_ascii_handle(self):
-        """FIX 2 (client): short ASCII handle IDs are decoded to str."""
-        from flopscope._protocol import _normalize
-
-        result = _normalize(b"a0")
-        assert result == "a0"
-        assert isinstance(result, str)
+        raw = msgpack.packb(
+            {"status": "ok", "result": {"dtype": "float64"}}, use_bin_type=True
+        )
+        resp = decode_response(raw)
+        assert resp["status"] == "ok" and isinstance(resp["status"], str)
+        assert resp["result"]["dtype"] == "float64"
+        assert isinstance(resp["result"]["dtype"], str)
 
 
 # ---------------------------------------------------------------------------

--- a/flopscope-client/tests/test_numpy_namespace_errors.py
+++ b/flopscope-client/tests/test_numpy_namespace_errors.py
@@ -15,6 +15,18 @@ def test_fnp_server_only_gives_clear_error():
         _ = fnp.SymmetricTensor
 
 
+@pytest.mark.parametrize("name", ["vectorize", "frompyfunc"])
+def test_fnp_pyfunc_wrapper_gives_actionable_error(name):
+    """np.vectorize/frompyfunc wrap an arbitrary Python callable applied per
+    element -- it can't be FLOP-counted or dispatched (it would run uncounted in
+    the client). Participants must get an actionable error, not a bare
+    'no attribute' (prod sub 310855 hit the cryptic AttributeError)."""
+    import flopscope.numpy as fnp
+
+    with pytest.raises(AttributeError, match="not supported in the flopscope client"):
+        _ = getattr(fnp, name)
+
+
 def test_fnp_real_op_still_resolves():
     import flopscope.numpy as fnp
 

--- a/flopscope-client/uv.lock
+++ b/flopscope-client/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "flopscope-client"
-version = "0.8.0rc3"
+version = "0.8.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "msgpack" },

--- a/flopscope-server/src/flopscope_server/_protocol.py
+++ b/flopscope-server/src/flopscope_server/_protocol.py
@@ -89,8 +89,13 @@ def decode_request(raw: bytes) -> dict:
         raise InvalidRequestError("malformed request: empty bytes")
 
     try:
-        # Use raw=True so that we get bytes keys and can selectively decode.
-        msg_raw = msgpack.unpackb(raw, raw=True)
+        # raw=False uses msgpack's native bin/str distinction: the client packs
+        # string fields (op, dtype, handle IDs) as ``str`` and raw array buffers
+        # as ``bin`` (use_bin_type=True), so strings decode to str and binary to
+        # bytes natively. We must NOT guess types from content -- a short,
+        # all-printable-ASCII array buffer is indistinguishable from a string
+        # (see flopscope-client test_fetch_bytes_decode).
+        msg_raw = msgpack.unpackb(raw, raw=False, strict_map_key=False)
     except Exception as exc:
         raise InvalidRequestError(f"malformed request: {exc}") from exc
 

--- a/flopscope-server/src/flopscope_server/_server.py
+++ b/flopscope-server/src/flopscope_server/_server.py
@@ -366,13 +366,13 @@ def _normalize_arg(a: object) -> object:
     are always short ASCII).
     """
     if isinstance(a, bytes):
-        # Only decode bytes that are short AND contain only ASCII printable
-        # characters (no bytes > 127).  This catches handle IDs and dtype
-        # strings but never touches binary array data (which often contains
-        # high bytes even if it happens to be valid UTF-8).
-        if len(a) > 0 and len(a) <= 32 and all(32 <= b < 128 for b in a):
-            return a.decode("ascii")
-        return a  # keep as raw bytes (likely binary payload)
+        # Binary payloads (array buffers) MUST stay bytes. Under raw=False
+        # decoding, genuine string fields already arrive as ``str``, so any
+        # ``bytes`` here is binary data -- never guess from content. A short,
+        # all-printable-ASCII buffer is indistinguishable from a string by
+        # content, and decoding it broke create_from_data (see
+        # flopscope-client test_fetch_bytes_decode).
+        return a
     if isinstance(a, dict):
         return {_decode_if_bytes(k): _normalize_arg(v) for k, v in a.items()}
     if isinstance(a, list):

--- a/flopscope-server/tests/test_bugfixes_round2.py
+++ b/flopscope-server/tests/test_bugfixes_round2.py
@@ -137,19 +137,23 @@ class TestFix8ScalarDtype:
 
 
 class TestFix9NormalizeArgRecursive:
-    def test_dict_with_nested_list(self):
-        result = _normalize_arg({b"key": [b"hello"]})
-        assert result == {"key": ["hello"]}
+    def test_dict_with_nested_list_preserves_binary(self):
+        # Binary values stay bytes through recursion (keys decode for legacy bytes
+        # keys; under raw=False keys already arrive as str).
+        result = _normalize_arg({b"key": [b"12345678"]})
+        assert result == {"key": [b"12345678"]}
 
-    def test_dict_with_nested_dict(self):
-        result = _normalize_arg({b"outer": {b"inner": b"val"}})
-        assert result == {"outer": {"inner": "val"}}
+    def test_dict_with_nested_dict_preserves_binary(self):
+        result = _normalize_arg({b"outer": {b"inner": b"\x00\x01\x02"}})
+        assert result == {"outer": {"inner": b"\x00\x01\x02"}}
 
     def test_dict_with_bytes_value_long(self):
         binary = bytes(range(256)) * 2
         result = _normalize_arg({b"data": binary})
         assert result["data"] is binary
 
-    def test_dict_with_short_bytes_value(self):
-        result = _normalize_arg({b"dtype": b"float64"})
-        assert result == {"dtype": "float64"}
+    def test_dict_with_short_printable_bytes_value_preserved(self):
+        # The old content heuristic decoded short all-printable byte VALUES to str;
+        # they are now preserved as binary (the create_from_data fix).
+        result = _normalize_arg({b"dtype": b"12345678"})
+        assert result == {"dtype": b"12345678"}

--- a/flopscope-server/tests/test_server.py
+++ b/flopscope-server/tests/test_server.py
@@ -274,18 +274,16 @@ def test_normalize_arg_preserves_binary_float64():
     assert result == data
 
 
-def test_normalize_arg_decodes_handle_id():
-    """FIX 2: short ASCII handle IDs like b'a0' must still be decoded."""
-    result = _normalize_arg(b"a0")
-    assert result == "a0"
-    assert isinstance(result, str)
-
-
-def test_normalize_arg_decodes_dtype():
-    """FIX 2: short ASCII dtype strings must still be decoded."""
-    result = _normalize_arg(b"float64")
-    assert result == "float64"
-    assert isinstance(result, str)
+def test_normalize_arg_keeps_all_bytes_as_binary():
+    """Under raw=False decoding, genuine string fields (handle IDs, dtype) arrive
+    as ``str`` at the msgpack layer, so any ``bytes`` reaching _normalize_arg is
+    binary array data and MUST be preserved -- including short, all-printable
+    buffers the old content heuristic wrongly decoded to str (the create_from_data
+    regression; see flopscope-client test_fetch_bytes_decode)."""
+    for buf in (b"a0", b"float64", b"12345678"):
+        result = _normalize_arg(buf)
+        assert result == buf
+        assert isinstance(result, bytes)
 
 
 def test_normalize_arg_preserves_high_bytes():
@@ -300,21 +298,20 @@ def test_normalize_arg_preserves_high_bytes():
 # ---------------------------------------------------------------------------
 
 
-def test_normalize_msg_kwargs_handle_dict():
-    """FIX 8: kwargs values containing handle dicts are normalized recursively."""
+def test_normalize_msg_preserves_binary_in_args_and_kwargs():
+    """_normalize_msg recurses args/kwargs preserving binary buffers. Under raw=False
+    string keys/handles already arrive as str; binary array data stays bytes (a short
+    all-printable buffer must NOT be decoded -- the create_from_data regression)."""
     msg = {
-        "op": "some_op",
-        "args": [],
-        "kwargs": {
-            b"out": {b"__handle__": b"a5"},
-        },
+        "op": "create_from_data",
+        "args": [b"12345678", [1], "float64"],
+        "kwargs": {"data": b"12345678"},
     }
     _normalize_msg(msg)
-    # The dict inside kwargs should have its keys/values normalized
-    out_val = msg["kwargs"]["out"]
-    assert isinstance(out_val, dict)
-    assert "__handle__" in out_val
-    assert out_val["__handle__"] == "a5"
+    assert msg["args"][0] == b"12345678"
+    assert isinstance(msg["args"][0], bytes)
+    assert msg["kwargs"]["data"] == b"12345678"
+    assert isinstance(msg["kwargs"]["data"], bytes)
 
 
 # ---------------------------------------------------------------------------

--- a/flopscope-server/uv.lock
+++ b/flopscope-server/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "flopscope"
-version = "0.8.0rc3"
+version = "0.8.0rc4"
 source = { editable = "../" }
 dependencies = [
     { name = "numpy" },
@@ -143,7 +143,7 @@ dev = [
 
 [[package]]
 name = "flopscope-server"
-version = "0.8.0rc3"
+version = "0.8.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "flopscope" },

--- a/tests/client_compat/test_fetch_bytes_decode.py
+++ b/tests/client_compat/test_fetch_bytes_decode.py
@@ -1,0 +1,51 @@
+"""A fetched array whose raw buffer happens to be short + all printable-ASCII
+must still decode correctly through float()/int()/tolist().
+
+Prod regression (rc4, 11 subs; e.g. ``estimator.py predict`` ->
+``RemoteArray.__float__``): ``TypeError: a bytes-like object is required, not
+'str'``. The client response decoder (``_protocol.decode_response``) unpacks
+with ``raw=True`` and then a heuristic (``_normalize``) re-decodes any short
+(<=32 byte), all-printable-ASCII ``bytes`` value to ``str``. That heuristic
+cannot distinguish a string field from a raw array buffer: a size-1 array (the
+float()/int() path) serializes to 4-8 bytes, so whenever the value's IEEE-754
+bytes all land in ``[32, 128)`` the ``data`` buffer is turned into a ``str`` and
+``_bytes_to_list``'s ``struct.unpack`` blows up.
+
+The server packs ``data`` as a msgpack ``bin`` field (``use_bin_type=True``), so
+the bin/str distinction is already on the wire -- the client just discards it.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import flopscope as fnp
+
+# A float64 whose little-endian IEEE-754 bytes are exactly b"12345678" -- all
+# printable ASCII, length 8 (<= the 32-byte heuristic threshold).
+_TRIGGER_F64 = struct.unpack("<d", b"12345678")[0]
+
+
+def test_float_on_allprintable_buffer():
+    """float() on a size-1 array with an all-printable buffer (the prod path)."""
+    arr = fnp.array([_TRIGGER_F64])
+    assert float(arr) == _TRIGGER_F64
+
+
+def test_int_on_allprintable_buffer():
+    """int() on a size-1 int array whose buffer is printable ASCII."""
+    one = fnp.array([49], dtype="int8")  # buffer == b"1"
+    assert int(one) == 49
+
+
+def test_tolist_on_allprintable_buffer():
+    """tolist() (the general fetch path) on a multi-element printable buffer."""
+    arr = fnp.array([49, 50, 51, 52], dtype="int8")  # buffer == b"1234"
+    assert arr.tolist() == [49, 50, 51, 52]
+
+
+def test_normal_value_unaffected():
+    """A value whose buffer has high/zero bytes already works -- proves the bug
+    is the heuristic, not the fetch path as a whole."""
+    arr = fnp.array([1.0])  # struct.pack('<d', 1.0) has 0x00 and 0xf0 bytes
+    assert float(arr) == 1.0


### PR DESCRIPTION
## Summary

The client `decode_response` and server `decode_request` both unpacked msgpack with `raw=True` and then **guessed** which `bytes` were strings via a content heuristic (`len<=32 and all bytes in [32,128)`). That heuristic cannot distinguish a short, all-printable-ASCII **array buffer** (e.g. `struct.pack('<d', x) == b'12345678'`) from a string, so it mis-decoded raw array data to `str`:

- **fetch path (client):** `RemoteArray.__float__`/`__int__`/`tolist` → `_bytes_to_list` got a `str` → `TypeError: a bytes-like object is required, not 'str'`. This hit **11 production submissions** (largest non-recovery cluster).
- **create path (server):** `create_from_data` → `np.frombuffer` got a `str` for an all-printable input buffer.

Both encoders already pack with `use_bin_type=True`, so the wire carries the msgpack `bin`/`str` distinction — the decoders threw it away. **Fix:** decode with `raw=False` and use the native distinction (strings → `str`, binary → `bytes`); the `_normalize`/`_normalize_arg` helpers no longer guess (binary is always preserved).

Also: `flopscope.numpy.vectorize`/`frompyfunc` now raise an **actionable** error (they wrap an arbitrary Python callable that can't be FLOP-counted or dispatched) instead of a bare `AttributeError`.

## Test plan

- `ruff check` + `ruff format --check` ✅
- `pyright src/flopscope tests` ✅ (0 errors)
- `gitlint` ✅
- `sync_client.py --check`, `check_version_sync.py`, client-surface snapshot ✅
- parity: `test_client_server_parity` / `test_serialization_parity` / `test_public_api_client_reachability` ✅
- `make test-client-parity` (client_compat, both modes — includes new `test_fetch_bytes_decode`) ✅
- server suite (243 passed) + client suite (1341 passed) ✅
- New: `test_fetch_bytes_decode` (4/4); obsolete bytes→str heuristic tests rewritten to the `raw=False` contract; `vectorize`/`frompyfunc` error tests.

No version bump in this PR — the rc5 release (version bump + publish) is a separate follow-up.
