### PR TITLE
fix(cost): charge zero for empty contractions and reductions

### DIFF
--- a/src/flopscope/_accumulation/_cost.py
+++ b/src/flopscope/_accumulation/_cost.py
@@ -124,6 +124,15 @@ def compute_step_cost_from_joint_group(
     combined_sizes = tuple(sizes[lbl] for lbl in canonical_labels)
     M = size_aware_burnside(all_elems, combined_sizes)
 
+    if M == 0:
+        # Empty arithmetic domain: no multiply or accumulation events occur,
+        # and there is no first term to receive the free initial-copy
+        # correction. Without this guard ``M - num_v_orbits`` goes negative and,
+        # because this candidate competes in the min() selection, a zero-sized
+        # contraction would win with a negative charge. Mirror the zero-domain
+        # guard in ``aggregate_einsum``.
+        return 0
+
     v_elems = [_Perm(list(elem.array_form[:n_v])) for elem in all_elems]
     v_sizes = combined_sizes[:n_v]
     num_v_orbits = size_aware_burnside(v_elems, v_sizes)

--- a/src/flopscope/_accumulation/_cost.py
+++ b/src/flopscope/_accumulation/_cost.py
@@ -323,7 +323,13 @@ def aggregate_einsum(
             alpha_product *= c.alpha
             output_orbit_product *= c.num_output_orbits
         mu = (num_terms - 1) * m_total
-        total = mu + alpha_product - output_orbit_product
+        if alpha_product == 0:
+            # Empty arithmetic domain: no multiply or accumulation events
+            # occur, and there is no first term to receive the free initial
+            # copy, so the off-by-one correction must not apply.
+            total = 0
+        else:
+            total = mu + alpha_product - output_orbit_product
         return AccumulationCost(
             total=total,
             mu=mu,
@@ -1409,10 +1415,14 @@ def aggregate_reduction(
         assert c.alpha is not None  # for type narrowing
         alpha_product *= c.alpha
 
-    # Invariant: output_dense (num_output_orbits) <= alpha_product. The
-    # orchestrator computes both consistently. If you ever see a negative
-    # total here, the orchestrator passed an inconsistent output_dense.
-    total = op_factor * (alpha_product - output_dense) + extra_ops
+    # Invariant: output_dense (num_output_orbits) <= alpha_product for
+    # non-empty inputs. For a zero-sized arithmetic domain no term exists to
+    # receive the free initial copy, so only explicit output-side extra_ops
+    # are charged.
+    if alpha_product == 0:
+        total = extra_ops
+    else:
+        total = op_factor * (alpha_product - output_dense) + extra_ops
     return AccumulationCost(
         total=total,
         mu=0,  # k=1 single-operand reduction

--- a/tests/accumulation/test_empty_domain_cost.py
+++ b/tests/accumulation/test_empty_domain_cost.py
@@ -35,3 +35,26 @@ def test_empty_matmul_does_not_refund_budget():
 def test_empty_reduction_preserves_extra_ops():
     cost = flops.reduction_accumulation_cost(np.empty((0,)), extra_ops=3)
     assert cost.total == 3
+
+
+def test_empty_symmetric_contraction_costs_zero():
+    # The k>=3 contraction path selects the cheapest of several cost
+    # candidates; the joint-burnside candidate applies the same free
+    # initial-copy correction and must also charge zero for an empty
+    # contracted dimension with a symmetric output pair.
+    left = flops.as_symmetric(fnp.zeros((4, 4, 0)), symmetry=(0, 1))
+    cost = flops.einsum_accumulation_cost(
+        "ijk,kl,lm->ijm", left, fnp.zeros((0, 5)), fnp.zeros((5, 2))
+    )
+    assert cost.total == 0
+
+
+def test_empty_symmetric_contraction_does_not_refund_budget():
+    left = flops.as_symmetric(fnp.zeros((4, 4, 0)), symmetry=(0, 1))
+    with flops.BudgetContext(flop_budget=10, quiet=True) as budget:
+        result = fnp.einsum(
+            "ijk,kl,lm->ijm", left, fnp.zeros((0, 5)), fnp.zeros((5, 2))
+        )
+    assert result.shape == (4, 4, 2)
+    assert budget.flops_used == 0
+    assert budget.flops_remaining == 10

--- a/tests/accumulation/test_empty_domain_cost.py
+++ b/tests/accumulation/test_empty_domain_cost.py
@@ -1,0 +1,37 @@
+"""Regression tests for issue #145: zero-sized contractions must not
+produce negative FLOP charges."""
+
+import numpy as np
+
+import flopscope as flops
+import flopscope.numpy as fnp
+
+
+def test_empty_inner_matmul_costs_zero():
+    cost = flops.einsum_accumulation_cost(
+        "ij,jk->ik", np.empty((2, 0)), np.empty((0, 3))
+    )
+    assert cost.total == 0
+
+
+def test_empty_scalar_dot_costs_zero():
+    cost = flops.einsum_accumulation_cost("i,i->", np.empty((0,)), np.empty((0,)))
+    assert cost.total == 0
+
+
+def test_empty_reduction_costs_zero():
+    assert flops.reduction_accumulation_cost(np.empty((0,))).total == 0
+    assert flops.reduction_accumulation_cost(np.empty((0, 5)), axis=0).total == 0
+
+
+def test_empty_matmul_does_not_refund_budget():
+    with flops.BudgetContext(flop_budget=10, quiet=True) as budget:
+        result = fnp.matmul(np.empty((2, 0)), np.empty((0, 3)))
+    assert result.shape == (2, 3)
+    assert budget.flops_used == 0
+    assert budget.flops_remaining == 10
+
+
+def test_empty_reduction_preserves_extra_ops():
+    cost = flops.reduction_accumulation_cost(np.empty((0,)), extra_ops=3)
+    assert cost.total == 3


### PR DESCRIPTION
Closes #145

## Summary

Prevent zero-sized contractions and reductions from producing negative FLOP
charges that increase the remaining budget.

## Root cause

The aggregation formulas subtract a free initial copy for every output orbit.
That correction is valid only when the arithmetic domain contains at least one
term. For an empty domain no first term exists, so the subtraction makes the
total negative.

## Changes

- Return zero for a zero-sized einsum arithmetic domain.
- Preserve only explicit output-side `extra_ops` for zero-sized reductions.
- Add regression coverage for empty-inner-dimension matmul, empty scalar dot
  products, empty reductions, budget non-refund, and `extra_ops`
  preservation.

The non-empty accounting paths are unchanged.

## Validation

- 5 new regression tests pass; the full `tests/accumulation/` suite
  (279 tests) and related budget/einsum/reduction/accounting suites pass.
- Ruff check and format check pass on the changed files.
- Pyright reports 0 errors on the changed files.
- The branch merges cleanly with PR #144 head.