### PR TITLE
fix(client,server): tag list index keys on the wire to disambiguate from tuples

### DIFF
--- a/flopscope-client/src/flopscope/_remote_array.py
+++ b/flopscope-client/src/flopscope/_remote_array.py
@@ -416,6 +416,9 @@ def _encode_index_key(key):
 
     Slices become ``{"__slice__": [start, stop, step]}``.
     Tuples become lists of encoded items.
+    Lists become ``{"__list__": [...]}`` -- tagged so the server can tell
+    fancy indexing ``x[[0, 1]]`` apart from element access ``x[0, 1]``
+    (a tuple key, which shares the bare-list wire encoding).
     RemoteArray -> ``{"__handle__": handle_id}`` (fancy indexing).
     RemoteScalar -> its raw value.
     Integers pass through as-is.
@@ -430,7 +433,7 @@ def _encode_index_key(key):
     if isinstance(key, tuple):
         return [_encode_index_key(k) for k in key]
     if isinstance(key, list):
-        return [_encode_index_key(k) for k in key]
+        return {"__list__": [_encode_index_key(k) for k in key]}
     if key is Ellipsis:
         return {"__ellipsis__": True}
     return key

--- a/flopscope-client/tests/test_bugfixes_round3.py
+++ b/flopscope-client/tests/test_bugfixes_round3.py
@@ -119,9 +119,10 @@ class TestFix2FancyIndexEncoding:
         from flopscope._remote_array import RemoteArray, _encode_index_key
 
         idx = RemoteArray(handle_id="a3", shape=(5,), dtype="int64")
-        # list fancy index containing a RemoteArray
+        # list fancy index containing a RemoteArray; list keys are tagged so
+        # the server can tell them apart from tuple keys (bare lists on wire)
         result = _encode_index_key([idx])
-        assert result == [{"__handle__": "a3"}]
+        assert result == {"__list__": [{"__handle__": "a3"}]}
 
 
 # =========================================================================

--- a/flopscope-client/tests/test_list_index_key.py
+++ b/flopscope-client/tests/test_list_index_key.py
@@ -1,0 +1,38 @@
+"""List index keys must be distinguishable from tuple keys on the wire.
+
+``x[[0, 1]]`` (fancy row selection) and ``x[0, 1]`` (element access) are
+different numpy operations, but both used to encode as a bare msgpack list.
+Genuine list keys now encode as ``{"__list__": [...]}``; tuples keep the
+bare-list encoding for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from flopscope._remote_array import _encode_index_key
+
+
+class TestEncodeListKey:
+    def test_list_key_is_tagged(self):
+        assert _encode_index_key([0, 1]) == {"__list__": [0, 1]}
+
+    def test_single_element_list_is_tagged(self):
+        assert _encode_index_key([1]) == {"__list__": [1]}
+
+    def test_nested_list_key(self):
+        assert _encode_index_key([[0, 1], [1, 0]]) == {
+            "__list__": [{"__list__": [0, 1]}, {"__list__": [1, 0]}]
+        }
+
+    def test_tuple_key_stays_bare_list(self):
+        assert _encode_index_key((0, 1)) == [0, 1]
+
+    def test_tuple_containing_list(self):
+        # x[(slice(None), [0, 1])] — per-axis fancy index inside a tuple
+        encoded = _encode_index_key((slice(None), [0, 1]))
+        assert encoded == [
+            {"__slice__": [None, None, None]},
+            {"__list__": [0, 1]},
+        ]
+
+    def test_int_passthrough(self):
+        assert _encode_index_key(3) == 3

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -496,6 +496,10 @@ class RequestHandler:
             ):
                 return tuple(decoded)
             return decoded
+        # bool before int: bool subclasses int, and coercing a boolean-mask
+        # element True -> 1 would turn mask indexing into integer indexing.
+        if isinstance(raw_key, bool):
+            return raw_key
         if isinstance(raw_key, (int, float)):
             return int(raw_key)
         return raw_key
@@ -669,6 +673,10 @@ def _decode_index_key(raw_key):
         # Single-element list: could be the key itself being a list
         # (e.g., fancy indexing) -- keep as list
         return decoded
+    # bool before int: bool subclasses int, and coercing a boolean-mask
+    # element True -> 1 would turn mask indexing into integer indexing.
+    if isinstance(raw_key, bool):
+        return raw_key
     if isinstance(raw_key, (int, float)):
         return int(raw_key)
     return raw_key

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -479,6 +479,12 @@ class RequestHandler:
             if b"__slice__" in raw_key:
                 parts = raw_key[b"__slice__"]
                 return slice(*[None if p is None else int(p) for p in parts])
+            # Tagged list: a genuine Python list key (fancy indexing, e.g.
+            # x[[0, 1]]) -- decode to a list, never a tuple.
+            if "__list__" in raw_key:
+                return [self._decode_index_key(item) for item in raw_key["__list__"]]
+            if b"__list__" in raw_key:
+                return [self._decode_index_key(item) for item in raw_key[b"__list__"]]
         if isinstance(raw_key, list):
             decoded = [self._decode_index_key(item) for item in raw_key]
             # A one-element key like ``arr[..., ]`` arrives as ``(Ellipsis,)`` ->
@@ -635,6 +641,7 @@ def _decode_index_key(raw_key):
     Supports:
     - int / float -> int
     - ``{"__slice__": [start, stop, step]}`` -> slice
+    - ``{"__list__": [...]}`` -> list (fancy indexing, e.g. ``x[[0, 1]]``)
     - list of the above -> tuple (for multi-dimensional indexing)
     """
     if isinstance(raw_key, dict):
@@ -646,6 +653,10 @@ def _decode_index_key(raw_key):
         if b"__slice__" in raw_key:
             parts = raw_key[b"__slice__"]
             return slice(*[None if p is None else int(p) for p in parts])
+        if "__list__" in raw_key:
+            return [_decode_index_key(item) for item in raw_key["__list__"]]
+        if b"__list__" in raw_key:
+            return [_decode_index_key(item) for item in raw_key[b"__list__"]]
     if isinstance(raw_key, list):
         decoded = [_decode_index_key(item) for item in raw_key]
         # A list of slices/ints (or a one-element Ellipsis like ``arr[..., ]``)

--- a/flopscope-server/tests/test_list_index_key.py
+++ b/flopscope-server/tests/test_list_index_key.py
@@ -47,6 +47,39 @@ class TestDecodeListKeyModuleLevel:
         assert _decode_index_key(raw) == (slice(None), [0, 1])
 
 
+class TestDecodeBooleanMask:
+    # bool is a subclass of int; the int() coercion in the scalar branch must
+    # not turn a boolean mask [True, False] into the integer indices [1, 0].
+    def test_module_level_preserves_bools(self):
+        decoded = _decode_index_key({"__list__": [True, False]})
+        assert decoded == [True, False]
+        assert all(type(d) is bool for d in decoded)
+
+    def test_instance_method_preserves_bools(self, handler):
+        decoded = handler._decode_index_key({"__list__": [True, False]})
+        assert decoded == [True, False]
+        assert all(type(d) is bool for d in decoded)
+
+    def test_bare_bool_key_preserved(self):
+        assert _decode_index_key(True) is True
+
+    def test_getitem_with_bool_mask_selects_rows(self, handler, session):
+        handle = session.store_array(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        resp = handler.handle(
+            {
+                "op": "__getitem__",
+                "args": [{"__handle__": handle}, {"__list__": [True, False]}],
+                "kwargs": {},
+            }
+        )
+        assert resp["status"] == "ok"
+        # Mask selects only row 0 -> shape (1, 2). Int coercion would instead
+        # reorder rows as x[[1, 0]] -> shape (2, 2).
+        assert resp["result"]["shape"] == [1, 2]
+        result = session.get_array(resp["result"]["id"])
+        assert result.tolist() == [[1.0, 2.0]]
+
+
 class TestDecodeListKeyInstanceMethod:
     def test_tagged_list_decodes_to_list(self, handler):
         assert handler._decode_index_key({"__list__": [0, 1]}) == [0, 1]

--- a/flopscope-server/tests/test_list_index_key.py
+++ b/flopscope-server/tests/test_list_index_key.py
@@ -1,0 +1,71 @@
+"""Server-side decoding of tagged list index keys.
+
+The client encodes genuine Python list keys as ``{"__list__": [...]}`` so the
+server can distinguish ``x[[0, 1]]`` (row selection) from ``x[0, 1]``
+(element access, sent as a bare msgpack list). Both str and bytes dict keys
+must decode, matching the existing ``__slice__``/``__ellipsis__`` handling.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from flopscope_server._request_handler import RequestHandler, _decode_index_key
+from flopscope_server._session import Session
+
+
+@pytest.fixture()
+def session():
+    s = Session(flop_budget=1_000_000)
+    yield s
+    if s.is_open:
+        s.close()
+
+
+@pytest.fixture()
+def handler(session):
+    return RequestHandler(session)
+
+
+class TestDecodeListKeyModuleLevel:
+    def test_tagged_list_decodes_to_list(self):
+        assert _decode_index_key({"__list__": [0, 1]}) == [0, 1]
+
+    def test_tagged_list_bytes_key(self):
+        assert _decode_index_key({b"__list__": [0, 1]}) == [0, 1]
+
+    def test_nested_tagged_list(self):
+        raw = {"__list__": [{"__list__": [0, 1]}, {"__list__": [1, 0]}]}
+        assert _decode_index_key(raw) == [[0, 1], [1, 0]]
+
+    def test_bare_list_still_decodes_to_tuple(self):
+        # Tuple keys stay bare lists on the wire (backward compatibility).
+        assert _decode_index_key([0, 1]) == (0, 1)
+
+    def test_tuple_containing_tagged_list(self):
+        raw = [{"__slice__": [None, None, None]}, {"__list__": [0, 1]}]
+        assert _decode_index_key(raw) == (slice(None), [0, 1])
+
+
+class TestDecodeListKeyInstanceMethod:
+    def test_tagged_list_decodes_to_list(self, handler):
+        assert handler._decode_index_key({"__list__": [0, 1]}) == [0, 1]
+
+    def test_tagged_list_bytes_key(self, handler):
+        assert handler._decode_index_key({b"__list__": [0, 1]}) == [0, 1]
+
+    def test_getitem_with_tagged_list_selects_rows(self, handler, session):
+        handle = session.store_array(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        resp = handler.handle(
+            {
+                "op": "__getitem__",
+                "args": [{"__handle__": handle}, {"__list__": [0, 1]}],
+                "kwargs": {},
+            }
+        )
+        assert resp["status"] == "ok"
+        # x[[0, 1]] on a 2x2 array selects both rows -> shape (2, 2).
+        # The buggy heuristic decoded it as x[0, 1] -> scalar 2.0.
+        assert resp["result"]["shape"] == [2, 2]
+        result = session.get_array(resp["result"]["id"])
+        assert result.tolist() == [[1.0, 2.0], [3.0, 4.0]]

--- a/tests/client_compat/test_list_index.py
+++ b/tests/client_compat/test_list_index.py
@@ -41,6 +41,18 @@ def test_nested_list_key():
     ]
 
 
+def test_bool_mask_list_2d():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    # Boolean mask selects row 0 only; int coercion of the bools would
+    # instead reorder rows as a[[1, 0]].
+    assert a[[True, False]].tolist() == [[1.0, 2.0]]
+
+
+def test_bool_mask_list_1d():
+    a = fnp.array([10.0, 20.0, 30.0])
+    assert a[[False, True, True]].tolist() == [20.0, 30.0]
+
+
 def test_tuple_key_still_element_access():
     a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
     assert float(a[0, 1]) == 2.0

--- a/tests/client_compat/test_list_index.py
+++ b/tests/client_compat/test_list_index.py
@@ -1,0 +1,61 @@
+"""Fancy indexing with plain Python list keys (numpy parity).
+
+``x[[0, 1]]`` selects rows; it must not be conflated with ``x[0, 1]``
+(element access). The wire protocol used to encode both as a msgpack list
+and the server heuristically decoded len>1 lists as tuples, so ``x[[0, 1]]``
+on a 2-D array silently returned the scalar ``x[0, 1]`` and raised
+IndexError on 1-D arrays.
+"""
+
+from __future__ import annotations
+
+import flopscope as fnp
+
+
+def test_list_key_2d_selects_rows():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[[0, 1]].tolist() == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_list_key_2d_reorders_rows():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[[1, 0]].tolist() == [[3.0, 4.0], [1.0, 2.0]]
+
+
+def test_list_key_1d():
+    a = fnp.array([10.0, 20.0, 30.0])
+    assert a[[0, 1]].tolist() == [10.0, 20.0]
+
+
+def test_single_element_list_key_keeps_dimension():
+    a = fnp.array([10.0, 20.0, 30.0])
+    assert a[[1]].tolist() == [20.0]
+
+
+def test_nested_list_key():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    # 2-D index array selects rows -> shape (2, 2, 2)
+    assert a[[[0, 1], [1, 0]]].tolist() == [
+        [[1.0, 2.0], [3.0, 4.0]],
+        [[3.0, 4.0], [1.0, 2.0]],
+    ]
+
+
+def test_tuple_key_still_element_access():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert float(a[0, 1]) == 2.0
+
+
+def test_tuple_with_list_component():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[:, [1]].tolist() == [[2.0], [4.0]]
+
+
+def test_slice_key_roundtrip():
+    a = fnp.array([10.0, 20.0, 30.0, 40.0])
+    assert a[1:3].tolist() == [20.0, 30.0]
+
+
+def test_ellipsis_key_roundtrip():
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a[..., 0].tolist() == [1.0, 3.0]


### PR DESCRIPTION
## Summary

The `__getitem__` wire protocol conflated Python **list** keys with **tuple** keys: the client encoded both as bare msgpack lists, and the server used a heuristic (`len > 1` or any slice/Ellipsis → tuple) to decode them.

Consequence: client-side fancy indexing with a plain list, e.g. `x[[0, 1]]`, was decoded as the tuple `(0, 1)` and executed as `x[0, 1]` — **silent wrong result** (element access instead of row selection) on 2-D arrays, and `IndexError` on 1-D arrays.

## Fix

- **Client** (`flopscope-client/src/flopscope/_remote_array.py`): genuine list keys now encode as a tagged dict `{"__list__": [...]}`. Tuple keys keep the bare-list encoding, so the wire format for tuples is unchanged (backward compatible).
- **Server** (`flopscope-server/src/flopscope_server/_request_handler.py`): both decoders (the live instance method and the module-level copy) decode the `__list__` tag back to a Python list, handling both str and bytes dict keys — matching the existing `__slice__`/`__ellipsis__` dual handling.

## Tests (written first, watched fail, then fixed)

- `tests/client_compat/test_list_index.py` — end-to-end: `x[[0,1]]` on 2-D (row selection + reordering), on 1-D, single-element list, nested list keys, and tuple/slice/Ellipsis round-trip regressions.
- `flopscope-client/tests/test_list_index_key.py` — encoder units: lists tagged, tuples bare, lists nested inside tuples.
- `flopscope-server/tests/test_list_index_key.py` — decoder units for both copies (str + bytes keys, nesting) plus a full `__getitem__` request asserting shape `(2, 2)` instead of the old scalar.
- Updated one legacy expectation in `flopscope-client/tests/test_bugfixes_round3.py` to the tagged form (its intent — RemoteArray inside a list key encodes as a handle dict — is unchanged).

## Verification

- Full client suite: 1354 passed
- Full server suite: 251 passed
- `make test-client-parity` gate: green
- `tests/test_client_server_parity.py` + `tests/test_serialization_parity.py` (check-sync): green
- ruff check + format: clean