### PR TITLE
test(parity): add client/in-process differential parity harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,16 @@ jobs:
       - name: "Parity GATE: fast client/in-process differential"
         run: make test-parity-fast
 
-      - name: "Parity full sweep (release gate; blocks push to main, not on pull requests)"
+      # Reports on pull requests so a divergence is seen and triaged BEFORE it
+      # can turn the release gate below red on main. Non-blocking here on
+      # purpose: the sweep takes about five minutes and runs concurrently with
+      # the rest of the job matrix, so it costs no serialised PR latency.
+      - name: "Parity full sweep (report-only on pull requests)"
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: make test-parity-full
+
+      - name: "Parity full sweep (release gate; blocks push to main)"
         if: github.event_name == 'push'
         run: make test-parity-full
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,13 @@ jobs:
       - name: "Client-parity measurement (non-blocking): numpy's own suite vs the client"
         run: make test-client-parity-measure
 
+      - name: "Parity GATE: fast client/in-process differential"
+        run: make test-parity-fast
+
+      - name: "Parity full sweep (release gate; blocks push to main, not on pull requests)"
+        if: github.event_name == 'push'
+        run: make test-parity-full
+
   client-server-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
         run: make test-parity-full
 
       - name: "Parity full sweep (release gate; blocks push to main)"
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: make test-parity-full
 
   client-server-sync:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,13 @@ jobs:
     # never fail the build). A single `uv sync --all-extras` gives the root
     # venv pyzmq/msgpack for both the client (test process) and the server
     # subprocess (the fixture falls back to the root venv in CI).
-    if: needs.detect-impact.outputs.run_numpy_compat == 'true'
+    # Also admit a manual dispatch. `detect-impact` only sets its output on a
+    # dispatch when the NumPy-compat input is ticked, so without this clause the
+    # whole job is skipped and the full parity sweep advertised as runnable
+    # on demand never actually runs.
+    if: >-
+      needs.detect-impact.outputs.run_numpy_compat == 'true' ||
+      github.event_name == 'workflow_dispatch'
     needs: [detect-impact]
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ test-client-parity-measure:  ## MEASUREMENT (non-blocking): numpy's own suite vs
 	-$(UV) pytest tests/client_compat/test_numpy_function_classes.py -n auto -q
 	-$(UV) pytest tests/client_compat/methods/test_numpy_classes.py -n auto -q
 
+.PHONY: test-parity-fast
+test-parity-fast:  ## GATE: fast client/in-process differential parity (must be green)
+	$(UV) pytest tests/parity/ -q -x --ignore=tests/parity/test_parity_full.py
+
+.PHONY: test-parity-full
+test-parity-full:  ## Full differential parity sweep (blocks releases)
+	$(UV) pytest tests/parity/test_parity_full.py -q
+
 .PHONY: client-parity-inventory
 client-parity-inventory:  ## Run the client-parity harness and emit the categorized failure inventory
 	$(UV) python scripts/client_parity_inventory.py

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,11 @@ test-parity-fast:  ## GATE: fast client/in-process differential parity (must be 
 
 .PHONY: test-parity-full
 test-parity-full:  ## Full differential parity sweep (blocks releases)
-	$(UV) pytest tests/parity/test_parity_full.py -q
+	# -s keeps stdout uncaptured so a PASSING run still prints the report:
+	# coverage counts and the per-entry allowlist match counts are the
+	# safeguard against a broad glob quietly absorbing a new divergence, and
+	# under default capture they would only ever appear on failure.
+	$(UV) pytest tests/parity/test_parity_full.py -q -s
 
 .PHONY: client-parity-inventory
 client-parity-inventory:  ## Run the client-parity harness and emit the categorized failure inventory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,10 @@ version_files = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--ignore=tests/numpy_compat --ignore=tests/client_compat -n auto"
+addopts = "--ignore=tests/numpy_compat --ignore=tests/client_compat --ignore=tests/parity -n auto"
+markers = [
+    "parity_server: differential parity test needing a live flopscope-server",
+]
 filterwarnings = [
     # flopscope's own tests call configure() on the in-process backend
     # legitimately; the participant-facing no-op notice is just noise here.

--- a/tests/client_compat/_server_fixture.py
+++ b/tests/client_compat/_server_fixture.py
@@ -22,20 +22,33 @@ _VENV_PYTHON = _SERVER_VENV if os.path.exists(_SERVER_VENV) else _ROOT_VENV
 # port offset so multiple workers don't collide on the same TCP address.
 _BASE_PORT = 15571
 
+#: First line a launched server prints on stdout when its own pre-bind probe
+#: (see ``start_server``) finds the target port already taken. Distinct from
+#: ``SERVER_READY`` so ``start_server`` can tell "failed to start" apart from
+#: "started but bound to a port someone else already holds".
+_BIND_FAILED_MARKER = "BIND_FAILED"
 
-def _worker_port() -> int:
-    """Return a per-xdist-worker port (base + worker index, or base if not xdist)."""
+
+class ServerPortInUseError(RuntimeError):
+    """``start_server`` could not claim its target port.
+
+    Raised instead of silently handing back a subprocess handle for a server
+    that never actually bound: without this check, a launch racing a
+    leftover process on the same port (a leaked server, or a socket still in
+    Linux's longer TIME_WAIT window) would return successfully while the
+    caller's client ends up talking to whatever else is listening there.
+    """
+
+
+def _worker_port(base_port: int) -> int:
+    """Return a per-xdist-worker port (*base_port* + worker index, or base)."""
     worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
     if worker_id.startswith("gw"):
         try:
-            return _BASE_PORT + int(worker_id[2:])
+            return base_port + int(worker_id[2:])
         except ValueError:
             pass
-    return _BASE_PORT
-
-
-def _make_server_url() -> str:
-    return f"tcp://127.0.0.1:{_worker_port()}"
+    return base_port
 
 
 def ensure_client_on_path() -> None:
@@ -44,15 +57,43 @@ def ensure_client_on_path() -> None:
         sys.path.insert(0, _CLIENT_SRC)
 
 
-def start_server() -> subprocess.Popen:
-    server_url = _make_server_url()
+def start_server(base_port: int = _BASE_PORT) -> subprocess.Popen:
+    """Launch a flopscope-server subprocess bound to *base_port* (+ xdist offset).
+
+    Raises ``ServerPortInUseError`` if the target port is already held by
+    another process. The launched script bind-tests the port itself, on the
+    same host/port ``FlopscopeServer.run()`` will bind, and only signals
+    ``SERVER_READY`` once that probe succeeds — a bind failure inside
+    ``run()`` itself happens deep inside a blocking call this process can't
+    observe directly, so the readiness line would otherwise go out
+    regardless of whether the real bind ever succeeds.
+    """
+    port = _worker_port(base_port)
+    server_url = f"tcp://127.0.0.1:{port}"
     os.environ["FLOPSCOPE_SERVER_URL"] = server_url
 
     script = f"""
 import sys
 sys.path.insert(0, {_REAL_SRC!r})
 sys.path.insert(0, {_SERVER_SRC!r})
+import zmq
 from flopscope_server._server import FlopscopeServer
+
+# Bind-test the exact address ourselves before signalling readiness: the
+# real bind happens inside FlopscopeServer.run(), which blocks in its recv
+# loop on success, so there is no other point at which this process could
+# observe a bind failure and report it.
+_probe_ctx = zmq.Context()
+_probe_sock = _probe_ctx.socket(zmq.REP)
+try:
+    _probe_sock.bind({server_url!r})
+except zmq.error.ZMQError as exc:
+    print("{_BIND_FAILED_MARKER}:{port}:" + str(exc), flush=True)
+    sys.exit(1)
+finally:
+    _probe_sock.close(linger=0)
+    _probe_ctx.term()
+
 print("SERVER_READY", flush=True)
 FlopscopeServer(url={server_url!r}).run()
 """
@@ -63,6 +104,14 @@ FlopscopeServer(url={server_url!r}).run()
         text=True,
     )
     line = proc.stdout.readline() if proc.stdout else ""
+    if line.startswith(_BIND_FAILED_MARKER):
+        proc.wait(timeout=5)
+        err = proc.stderr.read() if proc.stderr else ""
+        raise ServerPortInUseError(
+            f"cannot start flopscope-server on port {port} ({server_url}): "
+            f"another process already holds it ({line.strip()!r}). "
+            f"{err[:500]}".strip()
+        )
     if "SERVER_READY" not in line:
         err = proc.stderr.read() if proc.stderr else ""
         raise RuntimeError(f"flopscope-server failed to start: {line!r} / {err[:500]}")

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -15,6 +15,7 @@ is a smell that belongs in review.
 from __future__ import annotations
 
 import enum
+import fnmatch
 from dataclasses import dataclass
 
 from tests.parity.compare import DIMENSIONS, Divergence
@@ -31,6 +32,18 @@ class Category(enum.Enum):
 
 @dataclass(frozen=True)
 class Entry:
+    """One allowlisted divergence, or one root-cause-shaped family of them.
+
+    ``case_id`` is either an exact case id (``idiom/complex-mul``) or an
+    ``fnmatch`` glob (``grid/fft.*::*``) — the same idiom
+    ``tests/client_compat/conftest.py`` uses for its xfail patterns. A glob
+    lets one entry explain every divergence that shares one root cause
+    instead of forcing an individual entry per case, but it can also hide a
+    lot: see ``AllowlistResult.match_counts``, which reports exactly how many
+    divergences each entry matched, so a glob silently covering hundreds of
+    cases is visible to a reviewer rather than invisible.
+    """
+
     case_id: str
     dimension: str
     category: Category
@@ -40,6 +53,19 @@ class Entry:
     def key(self) -> tuple[str, str]:
         return (self.case_id, self.dimension)
 
+    def matches(self, divergence: Divergence) -> bool:
+        """True if this entry explains *divergence*.
+
+        The dimension must match exactly. The case id must either be
+        identical to the divergence's case id, or match it as an ``fnmatch``
+        glob.
+        """
+        if self.dimension != divergence.dimension:
+            return False
+        return divergence.case_id == self.case_id or fnmatch.fnmatch(
+            divergence.case_id, self.case_id
+        )
+
 
 @dataclass(frozen=True)
 class AllowlistResult:
@@ -47,6 +73,11 @@ class AllowlistResult:
     stale: list[Entry]
     allowed: list[Divergence]
     counts: dict[str, int]
+    #: How many divergences each entry matched. A glob entry that silently
+    #: covers hundreds of divergences must be obvious to a reviewer, not
+    #: invisible; this is what makes that visible. An entry present in
+    #: ``entries`` but absent (or mapped to 0) here is stale.
+    match_counts: dict[Entry, int]
 
 
 #: Populated by Task 11 from a first full run. Starts empty so that the eight
@@ -75,21 +106,29 @@ def validate_entries(entries: tuple[Entry, ...]) -> list[str]:
 def apply(
     divergences: list[Divergence], entries: tuple[Entry, ...] = ENTRIES
 ) -> AllowlistResult:
-    """Split *divergences* into allowed and unexplained, and find stale entries."""
-    by_key = {entry.key(): entry for entry in entries}
-    matched: set[tuple[str, str]] = set()
+    """Split *divergences* into allowed and unexplained, and find stale entries.
+
+    A divergence matched by no entry FAILS as unexplained; an entry matching
+    no divergence FAILS as stale. A divergence may be matched by more than
+    one entry (overlapping globs); it is allowed as long as at least one
+    entry matches, and every matching entry's count in ``match_counts`` is
+    incremented.
+    """
+    match_counts: dict[Entry, int] = dict.fromkeys(entries, 0)
     allowed: list[Divergence] = []
     unexplained: list[Divergence] = []
 
     for divergence in divergences:
-        if divergence.key() in by_key:
-            allowed.append(divergence)
-            matched.add(divergence.key())
-        else:
+        matching = [entry for entry in entries if entry.matches(divergence)]
+        if not matching:
             unexplained.append(divergence)
+            continue
+        allowed.append(divergence)
+        for entry in matching:
+            match_counts[entry] += 1
 
-    stale = [entry for entry in entries if entry.key() not in matched]
+    stale = [entry for entry in entries if match_counts[entry] == 0]
     counts = {category.value: 0 for category in Category}
     for entry in entries:
         counts[entry.category.value] += 1
-    return AllowlistResult(unexplained, stale, allowed, counts)
+    return AllowlistResult(unexplained, stale, allowed, counts, match_counts)

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -1924,6 +1924,35 @@ ENTRIES: tuple[Entry, ...] = (
         issue="INTERNAL-P5-family-3",
     ),
     Entry(
+        case_id="grid/savez*::*",
+        dimension="flops",
+        category=Category.ACCEPTED_DIVERGENCE,
+        reason=(
+            "In-process `numpy.savez` validates its arguments only after the op has"
+            " been charged, so the grid pattern's bad call bills 176 and then raises"
+            " TypeError. The server refuses the same call before dispatch and charges"
+            " nothing. Charging for a call that produces no result is the worse of the"
+            " two behaviours, so the client staying at zero here is deliberate -- the"
+            " same refuse-before-charging rule the server applies everywhere else."
+        ),
+        issue="INTERNAL-P3-refuse-before-charging",
+    ),
+    Entry(
+        case_id="grid/savez*::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "Both backends reject the grid pattern's bad `savez` call, but not with"
+            " the same class: in-process numpy raises `TypeError` (bases Exception,"
+            " BaseException) from its own argument validation, while the server's"
+            " refusal surfaces as a `LookupError` subclass (bases LookupError,"
+            " Exception, BaseException). Refusing is right; refusing under a"
+            " different base-class chain is not, and code catching `TypeError` sees"
+            " only one of them."
+        ),
+        issue="INTERNAL-P5-family-3",
+    ),
+    Entry(
         case_id="grid/savez::*",
         dimension="exc_type",
         category=Category.KNOWN_BUG,
@@ -2820,18 +2849,6 @@ ENTRIES: tuple[Entry, ...] = (
             "`corrcoef` returns a genuine computed scalar (or `None`) in-process for"
             " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
             " dtype where in-process there is none) instead of unwrapping it to the"
-            " equivalent bare value, so pytype disagrees."
-        ),
-        issue="INTERNAL-P2-family-5",
-    ),
-    Entry(
-        case_id="grid/ptp::*",
-        dimension="pytype",
-        category=Category.KNOWN_BUG,
-        reason=(
-            "`ptp` returns a genuine computed scalar (or `None`) in-process for this"
-            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
-            " where in-process there is none) instead of unwrapping it to the"
             " equivalent bare value, so pytype disagrees."
         ),
         issue="INTERNAL-P2-family-5",

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -80,9 +80,5465 @@ class AllowlistResult:
     match_counts: dict[Entry, int]
 
 
-#: Populated by Task 11 from a first full run. Starts empty so that the eight
-#: meta-tests and the canary in Task 6 exercise the unexplained path.
-ENTRIES: tuple[Entry, ...] = ()
+#: Populated from a full differential corpus run (see task-11-report.md for
+#: how it was derived). Each entry is grouped by root cause: a whole missing
+#: client namespace, a whole server-side error-wrapping mechanism, a single
+#: op, or a single case. `KNOWN_BUG` reaching zero is the definition of done
+#: for the whole wire-protocol programme.
+ENTRIES: tuple[Entry, ...] = (
+    Entry(
+        case_id="grid/fft.*::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fft.fft` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape. (18 ops in this family.)"
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fft.*::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fft.fft` attribute, so the client's"
+            " exception is AttributeError; in-process the call reaches a real"
+            " implementation and raises a more specific exception, so the base-class"
+            " chain differs too. (18 ops in this family.)"
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fft.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fft.fft` attribute. For grid patterns"
+            " whose arguments happen to be valid, the in-process call succeeds, while"
+            " the client always raises AttributeError before dispatch. (18 ops in this"
+            " family.)"
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fft.*::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fft.fft` attribute, so the call never"
+            " dispatches and 0 FLOPs are billed on the client, while in-process the"
+            " call runs and bills its real cost. (18 ops in this family.)"
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/random.Generator.*::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `random.Generator.bit_generator`"
+            " attribute (the dotted namespace it lives under is missing entirely on the"
+            " client), so the client raises AttributeError before the call is ever"
+            " dispatched. In-process the same dotted path resolves to numpy's real"
+            " callable, so the exact exception raised in-process instead depends on the"
+            " grid pattern's argument shape. (30 ops in this family.)"
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/random.RandomState.*::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `random.RandomState.beta` attribute (the"
+            " dotted namespace it lives under is missing entirely on the client), so"
+            " the client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape. (49 ops in this family.)"
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/linalg.*::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `linalg.cholesky` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape). (22 ops"
+            " in this family.)"
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/linalg.*::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `linalg.cholesky`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError). (22 ops in this family.)"
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/linalg.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `linalg.cholesky`'s server-side failure in a generic"
+            " `FlopscopeServerError` for a pattern where in-process the call succeeds"
+            " outright. (22 ops in this family.)"
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/stats.*::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`stats.cauchy.cdf` is listed in the core op registry, but the dotted"
+            " attribute path is not actually reachable on the in-process"
+            " `flopscope.numpy` module, so in-process this call raises AttributeError."
+            " The client's dispatch does not require the same attribute path and"
+            " reaches a real implementation instead, so it raises a different, pattern-"
+            " dependent exception (or succeeds). This is the mirror image of the"
+            " client-surface-gap family (the gap is on the in-process side here); no"
+            " family in the mapping covers that direction, so it is filed unclassified."
+            " (24 ops in this family.)"
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/stats.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`stats.cauchy.cdf`'s dotted attribute path is not reachable on the in-"
+            " process `flopscope.numpy` module, so in-process this call always raises"
+            " AttributeError, while the client's dispatch reaches a real implementation"
+            " and succeeds for patterns whose arguments are valid. Unclassified: no"
+            " given family covers an in-process (rather than client) attribute gap. (24"
+            " ops in this family.)"
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/stats.*::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`stats.cauchy.cdf`'s dotted attribute path is not reachable in-process,"
+            " so the in-process call raises before billing anything (0 FLOPs), while"
+            " the client's dispatch reaches a real implementation and bills its real"
+            " cost. Unclassified: no given family covers an in-process attribute gap."
+            " (24 ops in this family.)"
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/base_repr::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `base_repr` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/base_repr::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `base_repr` attribute. For grid patterns"
+            " whose arguments happen to be valid, the in-process call succeeds, while"
+            " the client always raises AttributeError before dispatch."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/base_repr::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `base_repr` attribute, so the call never"
+            " dispatches and 0 FLOPs are billed on the client, while in-process the"
+            " call runs and bills its real cost."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/binary_repr::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `binary_repr` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/broadcast::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `broadcast` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/errstate::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `errstate` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fromfile::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fromfile` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fromregex::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fromregex` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fromstring::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fromstring` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fromstring::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fromstring` attribute. For grid"
+            " patterns whose arguments happen to be valid, the in-process call"
+            " succeeds, while the client always raises AttributeError before dispatch."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/fromstring::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `fromstring` attribute, so the call"
+            " never dispatches and 0 FLOPs are billed on the client, while in-process"
+            " the call runs and bills its real cost."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/get_printoptions::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `get_printoptions` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/get_printoptions::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `get_printoptions` attribute. For grid"
+            " patterns whose arguments happen to be valid, the in-process call"
+            " succeeds, while the client always raises AttributeError before dispatch."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/geterr::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `geterr` attribute (the dotted namespace"
+            " it lives under is missing entirely on the client), so the client raises"
+            " AttributeError before the call is ever dispatched. In-process the same"
+            " dotted path resolves to numpy's real callable, so the exact exception"
+            " raised in-process instead depends on the grid pattern's argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/geterr::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `geterr` attribute. For grid patterns"
+            " whose arguments happen to be valid, the in-process call succeeds, while"
+            " the client always raises AttributeError before dispatch."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/isnat::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `isnat` attribute (the dotted namespace"
+            " it lives under is missing entirely on the client), so the client raises"
+            " AttributeError before the call is ever dispatched. In-process the same"
+            " dotted path resolves to numpy's real callable, so the exact exception"
+            " raised in-process instead depends on the grid pattern's argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/isnat::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `isnat` attribute, so the call never"
+            " dispatches and 0 FLOPs are billed on the client, while in-process the"
+            " call runs and bills its real cost."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/ndenumerate::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `ndenumerate` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/ndindex::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `ndindex` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/nditer::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `nditer` attribute (the dotted namespace"
+            " it lives under is missing entirely on the client), so the client raises"
+            " AttributeError before the call is ever dispatched. In-process the same"
+            " dotted path resolves to numpy's real callable, so the exact exception"
+            " raised in-process instead depends on the grid pattern's argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/set_printoptions::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `set_printoptions` attribute (the dotted"
+            " namespace it lives under is missing entirely on the client), so the"
+            " client raises AttributeError before the call is ever dispatched. In-"
+            " process the same dotted path resolves to numpy's real callable, so the"
+            " exact exception raised in-process instead depends on the grid pattern's"
+            " argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/set_printoptions::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `set_printoptions` attribute. For grid"
+            " patterns whose arguments happen to be valid, the in-process call"
+            " succeeds, while the client always raises AttributeError before dispatch."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/seterr::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `seterr` attribute (the dotted namespace"
+            " it lives under is missing entirely on the client), so the client raises"
+            " AttributeError before the call is ever dispatched. In-process the same"
+            " dotted path resolves to numpy's real callable, so the exact exception"
+            " raised in-process instead depends on the grid pattern's argument shape."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/seterr::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `seterr` attribute, so the client's"
+            " exception is AttributeError; in-process the call reaches a real"
+            " implementation and raises a more specific exception, so the base-class"
+            " chain differs too."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/seterr::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `seterr` attribute. For grid patterns"
+            " whose arguments happen to be valid, the in-process call succeeds, while"
+            " the client always raises AttributeError before dispatch."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/seterr::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `fnp` module has no `seterr` attribute, so the call never"
+            " dispatches and 0 FLOPs are billed on the client, while in-process the"
+            " call runs and bills its real cost."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="grid/array_split::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `array_split` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/clip::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `clip` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/clip::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `clip`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/compress::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `compress` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/compress::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `compress`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/corrcoef::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `corrcoef` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/corrcoef::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `corrcoef`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/cov::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `cov` and a real server-side failure is"
+            " surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/cov::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `cov`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/delete::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `delete` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/delete::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `delete`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/diff::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `diff` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/diff::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `diff`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/dot::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `dot` and a real server-side failure is"
+            " surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/dot::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `dot`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/dsplit::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `dsplit` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/extract::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `extract` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/extract::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `extract`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/fliplr::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `fliplr` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/fliplr::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `fliplr`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/flipud::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `flipud` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/flipud::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `flipud`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/full_like::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `full_like` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/gcd::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `gcd` and a real server-side failure is"
+            " surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/gcd::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `gcd`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/gradient::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `gradient` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/gradient::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `gradient`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/histogramdd::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `histogramdd` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/histogramdd::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `histogramdd`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/hsplit::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `hsplit` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/inner::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `inner` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/inner::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `inner`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/lcm::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `lcm` and a real server-side failure is"
+            " surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/lcm::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `lcm`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/mintypecode::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `mintypecode` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/mintypecode::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `mintypecode`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/nanpercentile::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `nanpercentile` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/nanquantile::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `nanquantile` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/percentile::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `percentile` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/positive::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `positive` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/positive::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `positive`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/quantile::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `quantile` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/rot90::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `rot90` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/rot90::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `rot90`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/sign::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `sign` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/sign::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `sign`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/sort::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `sort` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/sort::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `sort`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/sort_complex::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `sort_complex` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/sort_complex::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `sort_complex`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/split::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `split` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/tensordot::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `tensordot` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/tensordot::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `tensordot`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/tile::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `tile` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/trapezoid::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `trapezoid` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/trapezoid::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `trapezoid`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/trapz::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `trapz` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/trapz::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `trapz`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/vsplit::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `vsplit` and a real server-side failure"
+            " is surfaced to the client as a generic `FlopscopeServerError`, losing the"
+            " concrete exception type numpy raises in-process (which varies with the"
+            " grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.beta::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.beta` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.chisquare::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.chisquare` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.choice::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.choice` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.dirichlet::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.dirichlet` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.exponential::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.exponential` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.f::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.f` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.gamma::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.gamma` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.geometric::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.geometric` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.gumbel::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.gumbel` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.laplace::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.laplace` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.logistic::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.logistic` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.lognormal::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.lognormal` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.logseries::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.logseries` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.negative_binomial::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.negative_binomial` and a real"
+            " server-side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.noncentral_chisquare::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.noncentral_chisquare` and a"
+            " real server-side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.normal::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.normal` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.pareto::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.pareto` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.permutation::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.permutation` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.permutation::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `random.permutation`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.poisson::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.poisson` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.power::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.power` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.random::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.random` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.random_sample::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.random_sample` and a real"
+            " server-side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.ranf::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.ranf` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.rayleigh::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.rayleigh` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.sample::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.sample` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.shuffle::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.shuffle` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.shuffle::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client wraps `random.shuffle`'s server-side failure in a generic"
+            " `FlopscopeServerError`, so the exception's base-class chain collapses to"
+            " `[Exception, BaseException]` instead of the concrete in-process hierarchy"
+            " (e.g. LookupError, ValueError, ArithmeticError)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.standard_gamma::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.standard_gamma` and a real"
+            " server-side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.standard_t::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.standard_t` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.uniform::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.uniform` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.vonmises::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.vonmises` and a real server-"
+            " side failure is surfaced to the client as a generic"
+            " `FlopscopeServerError`, losing the concrete exception type numpy raises"
+            " in-process (which varies with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.wald::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.wald` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.weibull::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.weibull` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/random.zipf::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client reaches the server for `random.zipf` and a real server-side"
+            " failure is surfaced to the client as a generic `FlopscopeServerError`,"
+            " losing the concrete exception type numpy raises in-process (which varies"
+            " with the grid pattern's argument shape)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/as_symmetric::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`as_symmetric` is listed in the core op registry, but the dotted"
+            " attribute path is not actually reachable on the in-process"
+            " `flopscope.numpy` module, so in-process this call raises AttributeError."
+            " The client's dispatch does not require the same attribute path and"
+            " reaches a real implementation instead, so it raises a different, pattern-"
+            " dependent exception (or succeeds). This is the mirror image of the"
+            " client-surface-gap family (the gap is on the in-process side here); no"
+            " family in the mapping covers that direction, so it is filed unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/common_type::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`common_type` is listed in the core op registry, but the dotted attribute"
+            " path is not actually reachable on the in-process `flopscope.numpy`"
+            " module, so in-process this call raises AttributeError. The client's"
+            " dispatch does not require the same attribute path and reaches a real"
+            " implementation instead, so it raises a different, pattern-dependent"
+            " exception (or succeeds). This is the mirror image of the client-surface-"
+            " gap family (the gap is on the in-process side here); no family in the"
+            " mapping covers that direction, so it is filed unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/common_type::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`common_type`'s dotted attribute path is not reachable on the in-process"
+            " `flopscope.numpy` module, so in-process this call always raises"
+            " AttributeError, while the client's dispatch reaches a real implementation"
+            " and succeeds for patterns whose arguments are valid. Unclassified: no"
+            " given family covers an in-process (rather than client) attribute gap."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/getitem::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`getitem` is listed in the core op registry, but the dotted attribute"
+            " path is not actually reachable on the in-process `flopscope.numpy`"
+            " module, so in-process this call raises AttributeError. The client's"
+            " dispatch does not require the same attribute path and reaches a real"
+            " implementation instead, so it raises a different, pattern-dependent"
+            " exception (or succeeds). This is the mirror image of the client-surface-"
+            " gap family (the gap is on the in-process side here); no family in the"
+            " mapping covers that direction, so it is filed unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/is_symmetric::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`is_symmetric` is listed in the core op registry, but the dotted"
+            " attribute path is not actually reachable on the in-process"
+            " `flopscope.numpy` module, so in-process this call raises AttributeError."
+            " The client's dispatch does not require the same attribute path and"
+            " reaches a real implementation instead, so it raises a different, pattern-"
+            " dependent exception (or succeeds). This is the mirror image of the"
+            " client-surface-gap family (the gap is on the in-process side here); no"
+            " family in the mapping covers that direction, so it is filed unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/random.symmetric::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.symmetric` is listed in the core op registry, but the dotted"
+            " attribute path is not actually reachable on the in-process"
+            " `flopscope.numpy` module, so in-process this call raises AttributeError."
+            " The client's dispatch does not require the same attribute path and"
+            " reaches a real implementation instead, so it raises a different, pattern-"
+            " dependent exception (or succeeds). This is the mirror image of the"
+            " client-surface-gap family (the gap is on the in-process side here); no"
+            " family in the mapping covers that direction, so it is filed unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/symmetrize::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`symmetrize` is listed in the core op registry, but the dotted attribute"
+            " path is not actually reachable on the in-process `flopscope.numpy`"
+            " module, so in-process this call raises AttributeError. The client's"
+            " dispatch does not require the same attribute path and reaches a real"
+            " implementation instead, so it raises a different, pattern-dependent"
+            " exception (or succeeds). This is the mirror image of the client-surface-"
+            " gap family (the gap is on the in-process side here); no family in the"
+            " mapping covers that direction, so it is filed unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/trim_zeros::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`trim_zeros` is listed in the core op registry, but the dotted attribute"
+            " path is not actually reachable on the in-process `flopscope.numpy`"
+            " module, so in-process this call raises AttributeError. The client's"
+            " dispatch does not require the same attribute path and reaches a real"
+            " implementation instead, so it raises a different, pattern-dependent"
+            " exception (or succeeds). This is the mirror image of the client-surface-"
+            " gap family (the gap is on the in-process side here); no family in the"
+            " mapping covers that direction, so it is filed unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/cumulative_prod::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client independently raises `TypeError` for `cumulative_prod` instead"
+            " of proxying the concrete exception numpy raises in-process for this"
+            " pattern (a milder variant of the client's generic error wrapping: here"
+            " the client raises its own validation error rather than a transport"
+            " wrapper)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/cumulative_sum::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client independently raises `TypeError` for `cumulative_sum` instead"
+            " of proxying the concrete exception numpy raises in-process for this"
+            " pattern (a milder variant of the client's generic error wrapping: here"
+            " the client raises its own validation error rather than a transport"
+            " wrapper)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/einsum::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client independently raises `TypeError` for `einsum` instead of"
+            " proxying the concrete exception numpy raises in-process for this pattern"
+            " (a milder variant of the client's generic error wrapping: here the client"
+            " raises its own validation error rather than a transport wrapper)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/einsum::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client independently raises `TypeError` for `einsum` instead of"
+            " proxying the concrete exception numpy raises in-process for this pattern"
+            " (a milder variant of the client's generic error wrapping: here the client"
+            " raises its own validation error rather than a transport wrapper)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/finfo::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client independently raises `TypeError` for `finfo` instead of"
+            " proxying the concrete exception numpy raises in-process for this pattern"
+            " (a milder variant of the client's generic error wrapping: here the client"
+            " raises its own validation error rather than a transport wrapper)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/iinfo::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client independently raises `TypeError` for `iinfo` instead of"
+            " proxying the concrete exception numpy raises in-process for this pattern"
+            " (a milder variant of the client's generic error wrapping: here the client"
+            " raises its own validation error rather than a transport wrapper)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/squeeze::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client independently raises `TypeError` for `squeeze` instead of"
+            " proxying the concrete exception numpy raises in-process for this pattern"
+            " (a milder variant of the client's generic error wrapping: here the client"
+            " raises its own validation error rather than a transport wrapper)."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/load::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`load` is a file-I/O op; given the grid pattern's array argument (not a"
+            " real path), in-process `numpy.load` raises TypeError from argument"
+            " validation, while the client instead attempts to treat the argument as"
+            " file content/path and raises OSError."
+        ),
+        issue="INTERNAL-P5-family-3",
+    ),
+    Entry(
+        case_id="grid/savez::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`savez` is a file-I/O op; given the grid pattern's array argument (not a"
+            " real path), in-process `numpy.savez` raises TypeError from argument"
+            " validation, while the client instead attempts to treat the argument as"
+            " file content/path and raises OSError."
+        ),
+        issue="INTERNAL-P5-family-3",
+    ),
+    Entry(
+        case_id="grid/savez_compressed::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`savez_compressed` is a file-I/O op; given the grid pattern's array"
+            " argument (not a real path), in-process `numpy.savez_compressed` raises"
+            " TypeError from argument validation, while the client instead attempts to"
+            " treat the argument as file content/path and raises OSError."
+        ),
+        issue="INTERNAL-P5-family-3",
+    ),
+    Entry(
+        case_id="grid/astype::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`astype` raises `TypeError` in-process uniformly for these patterns; the"
+            " client instead either wraps a server failure into `FlopscopeServerError`"
+            " or raises `ValueError` directly, depending on the pattern - the concrete"
+            " exception identity does not survive the wire."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/astype::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "For some grid patterns `astype` raises in-process while the client's"
+            " dispatch succeeds and returns a value instead."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/astype::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`astype`'s exception happens at a different point in each backend's"
+            " processing, so the FLOPs billed before failing differ too."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="grid/allclose::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`allclose` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " container disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/allclose::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`allclose` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/allclose::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`allclose` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " dtype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/allclose::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`allclose` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " shape disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equal::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equal` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so container disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equal::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equal` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so pytype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equal::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equal` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so dtype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equal::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equal` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so shape disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equiv::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equiv` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so container disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equiv::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equiv` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so pytype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equiv::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equiv` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so dtype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/array_equiv::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_equiv` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so shape disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iscomplexobj::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iscomplexobj` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so container disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iscomplexobj::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iscomplexobj` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so pytype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iscomplexobj::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iscomplexobj` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so dtype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iscomplexobj::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iscomplexobj` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so shape disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isfortran::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isfortran` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " container disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isfortran::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isfortran` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isfortran::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isfortran` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " dtype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isfortran::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isfortran` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " shape disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isrealobj::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isrealobj` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " container disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isrealobj::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isrealobj` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isrealobj::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isrealobj` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " dtype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isrealobj::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isrealobj` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " shape disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isscalar::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isscalar` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " container disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isscalar::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isscalar` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isscalar::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isscalar` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " dtype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isscalar::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isscalar` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " shape disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iterable::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iterable` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " container disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iterable::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iterable` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iterable::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iterable` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " dtype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/iterable::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`iterable` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " shape disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/may_share_memory::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`may_share_memory` returns a plain Python/NumPy predicate or count value"
+            " (a bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so container disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/may_share_memory::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`may_share_memory` returns a plain Python/NumPy predicate or count value"
+            " (a bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so pytype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/may_share_memory::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`may_share_memory` returns a plain Python/NumPy predicate or count value"
+            " (a bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so dtype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/may_share_memory::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`may_share_memory` returns a plain Python/NumPy predicate or count value"
+            " (a bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so shape disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/shares_memory::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`shares_memory` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so container disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/shares_memory::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`shares_memory` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so pytype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/shares_memory::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`shares_memory` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so dtype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/shares_memory::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`shares_memory` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so shape disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/ndim::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`ndim` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " container disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/ndim::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`ndim` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/ndim::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`ndim` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " dtype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/ndim::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`ndim` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " shape disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/size::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`size` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " container disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/size::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`size` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/size::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`size` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " dtype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/size::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`size` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " shape disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/count_nonzero::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`count_nonzero` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so container disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/count_nonzero::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`count_nonzero` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so pytype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/count_nonzero::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`count_nonzero` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so dtype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/count_nonzero::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`count_nonzero` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so shape disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/linalg.matrix_rank::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.matrix_rank` returns a plain Python/NumPy predicate or count"
+            " value (a bool or an int) in-process for this pattern; the client wraps"
+            " the same result in a `RemoteScalar` proxy instead of unwrapping it to the"
+            " bare value, so container disagrees (the same mechanism as the"
+            " `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/linalg.matrix_rank::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.matrix_rank` returns a plain Python/NumPy predicate or count"
+            " value (a bool or an int) in-process for this pattern; the client wraps"
+            " the same result in a `RemoteScalar` proxy instead of unwrapping it to the"
+            " bare value, so pytype disagrees (the same mechanism as the"
+            " `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/linalg.matrix_rank::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.matrix_rank` returns a plain Python/NumPy predicate or count"
+            " value (a bool or an int) in-process for this pattern; the client wraps"
+            " the same result in a `RemoteScalar` proxy instead of unwrapping it to the"
+            " bare value, so dtype disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/linalg.matrix_rank::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.matrix_rank` returns a plain Python/NumPy predicate or count"
+            " value (a bool or an int) in-process for this pattern; the client wraps"
+            " the same result in a `RemoteScalar` proxy instead of unwrapping it to the"
+            " bare value, so shape disagrees (the same mechanism as the `ndim`-returns-"
+            " int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isfinite::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isfinite` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isinf::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isinf` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/isnan::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`isnan` returns a plain Python/NumPy predicate or count value (a bool or"
+            " an int) in-process for this pattern; the client wraps the same result in"
+            " a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/lexsort::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`lexsort` returns a plain Python/NumPy predicate or count value (a bool"
+            " or an int) in-process for this pattern; the client wraps the same result"
+            " in a `RemoteScalar` proxy instead of unwrapping it to the bare value, so"
+            " pytype disagrees (the same mechanism as the `ndim`-returns-int case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/searchsorted::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`searchsorted` returns a plain Python/NumPy predicate or count value (a"
+            " bool or an int) in-process for this pattern; the client wraps the same"
+            " result in a `RemoteScalar` proxy instead of unwrapping it to the bare"
+            " value, so pytype disagrees (the same mechanism as the `ndim`-returns-int"
+            " case)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/trace::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`trace` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/linalg.norm::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.norm` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/linalg.trace::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.trace` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/linalg.vector_norm::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.vector_norm` returns a genuine computed scalar (or `None`) in-"
+            " process for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/trapezoid::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`trapezoid` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/trapz::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`trapz` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/corrcoef::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`corrcoef` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/ptp::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`ptp` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/take::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`take` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/trim_zeros::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`trim_zeros` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/vdot::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`vdot` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/linalg.cond::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.cond` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/linalg.multi_dot::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.multi_dot` returns a genuine computed scalar (or `None`) in-"
+            " process for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/poly::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`poly` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/poly::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`poly` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/poly::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`poly` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/poly::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`poly` returns a genuine computed scalar (or `None`) in-process for this"
+            " pattern; the client wraps it in a `RemoteScalar` proxy (reporting a dtype"
+            " where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so shape disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/polyval::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`polyval` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/mintypecode::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`mintypecode` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/mintypecode::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`mintypecode` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/mintypecode::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`mintypecode` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/mintypecode::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`mintypecode` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so shape disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/min_scalar_type::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`min_scalar_type` returns a genuine computed scalar (or `None`) in-"
+            " process for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/min_scalar_type::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`min_scalar_type` returns a genuine computed scalar (or `None`) in-"
+            " process for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/min_scalar_type::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`min_scalar_type` returns a genuine computed scalar (or `None`) in-"
+            " process for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/result_type::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`result_type` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/result_type::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`result_type` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/result_type::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`result_type` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/linalg.matrix_norm::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.matrix_norm` returns a genuine computed scalar (or `None`) in-"
+            " process for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/copyto::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`copyto` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/copyto::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`copyto` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/copyto::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`copyto` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/copyto::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`copyto` returns a genuine computed scalar (or `None`) in-process for"
+            " this pattern; the client wraps it in a `RemoteScalar` proxy (reporting a"
+            " dtype where in-process there is none) instead of unwrapping it to the"
+            " equivalent bare value, so shape disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/fill_diagonal::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fill_diagonal` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/fill_diagonal::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fill_diagonal` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/fill_diagonal::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fill_diagonal` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/fill_diagonal::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fill_diagonal` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so shape disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.seed::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.seed` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.seed::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.seed` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.seed::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.seed` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.seed::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.seed` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so shape disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.shuffle::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.shuffle` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.shuffle::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.shuffle` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.shuffle::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.shuffle` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so dtype disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/random.shuffle::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`random.shuffle` returns a genuine computed scalar (or `None`) in-process"
+            " for this pattern; the client wraps it in a `RemoteScalar` proxy"
+            " (reporting a dtype where in-process there is none) instead of unwrapping"
+            " it to the equivalent bare value, so shape disagrees."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="grid/convolve::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`convolve` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/cov::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`cov` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/diff::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`diff` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/ediff1d::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`ediff1d` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/gradient::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`gradient` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/kron::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`kron` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/linalg.outer::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.outer` returns a real array/tuple in-process for this pattern,"
+            " but its specific type identity (an ndarray subclass, a namedtuple, or a"
+            " list) is not preserved once it crosses to the client, so pytype"
+            " disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/outer::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`outer` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/sort_complex::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`sort_complex` returns a real array/tuple in-process for this pattern,"
+            " but its specific type identity (an ndarray subclass, a namedtuple, or a"
+            " list) is not preserved once it crosses to the client, so pytype"
+            " disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/diag::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`diag` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/diagflat::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`diagflat` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/expand_dims::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`expand_dims` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/ones::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`ones` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/zeros::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`zeros` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/bmat::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`bmat` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/unique_all::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`unique_all` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/unique_all::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`unique_all` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/unique_counts::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`unique_counts` returns a real array/tuple in-process for this pattern,"
+            " but its specific type identity (an ndarray subclass, a namedtuple, or a"
+            " list) is not preserved once it crosses to the client, so container"
+            " disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/unique_counts::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`unique_counts` returns a real array/tuple in-process for this pattern,"
+            " but its specific type identity (an ndarray subclass, a namedtuple, or a"
+            " list) is not preserved once it crosses to the client, so pytype"
+            " disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/unique_inverse::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`unique_inverse` returns a real array/tuple in-process for this pattern,"
+            " but its specific type identity (an ndarray subclass, a namedtuple, or a"
+            " list) is not preserved once it crosses to the client, so container"
+            " disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/unique_inverse::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`unique_inverse` returns a real array/tuple in-process for this pattern,"
+            " but its specific type identity (an ndarray subclass, a namedtuple, or a"
+            " list) is not preserved once it crosses to the client, so pytype"
+            " disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/linalg.qr::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.qr` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/linalg.qr::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.qr` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/linalg.svd::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.svd` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/linalg.svd::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`linalg.svd` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/array_split::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_split` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/array_split::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`array_split` returns a real array/tuple in-process for this pattern, but"
+            " its specific type identity (an ndarray subclass, a namedtuple, or a list)"
+            " is not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/hsplit::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`hsplit` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/hsplit::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`hsplit` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/split::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`split` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so container disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/split::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`split` returns a real array/tuple in-process for this pattern, but its"
+            " specific type identity (an ndarray subclass, a namedtuple, or a list) is"
+            " not preserved once it crosses to the client, so pytype disagrees."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="types/array-array-f::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `array-array-f` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/array-array-f::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `array-array-f` value has no clean wire encoding on the client, so"
+            " the exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/array-array-f::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `array-array-f`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/array-array-f::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `array-array-f` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/bytes::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `bytes` value has no clean wire encoding on the client; depending on"
+            " where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/bytes::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `bytes` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/complex::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `complex` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/complex::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `complex` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/complex::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `complex` value for"
+            " this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/complex::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `complex` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/datetime::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `datetime` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/datetime::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `datetime` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/datetime::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `datetime` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/datetime::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `datetime` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/decimal::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `decimal` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/decimal::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `decimal` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/decimal::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `decimal` value for"
+            " this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/decimal::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `decimal` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dict::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dict` value has no clean wire encoding on the client; depending on"
+            " where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dict::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dict` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dict-with-handle::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dict-with-handle` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dict-with-handle::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dict-with-handle` value has no clean wire encoding on the client, so"
+            " the exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dict-with-handle::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `dict-with-handle`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dict-with-handle::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dict-with-handle` value fails to encode onto the wire before the"
+            " call dispatches, so the client bills 0 FLOPs where in-process the call"
+            " ran and billed a nonzero amount (or vice versa when the value encodes but"
+            " the in-process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dtype-named-object::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dtype-named-object` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dtype-named-object::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dtype-named-object` value has no clean wire encoding on the client,"
+            " so the exception it raises there has a different base-class chain than"
+            " the concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/dtype-named-object::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `dtype-named-object` value fails to encode onto the wire before the"
+            " call dispatches, so the client bills 0 FLOPs where in-process the call"
+            " ran and billed a nonzero amount (or vice versa when the value encodes but"
+            " the in-process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/ellipsis::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `ellipsis` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/ellipsis::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `ellipsis` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/ellipsis::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `ellipsis` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/fraction::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `fraction` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/fraction::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `fraction` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/fraction::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `fraction` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/fraction::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `fraction` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/frozenset::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `frozenset` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/frozenset::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `frozenset` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/frozenset::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `frozenset` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/frozenset::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `frozenset` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/generator::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `generator` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/generator::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `generator` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/generator::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `generator` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/handle-lookalike::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `handle-lookalike` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/handle-lookalike::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `handle-lookalike` value has no clean wire encoding on the client, so"
+            " the exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/handle-lookalike::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `handle-lookalike`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/handle-lookalike::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `handle-lookalike` value fails to encode onto the wire before the"
+            " call dispatches, so the client bills 0 FLOPs where in-process the call"
+            " ran and billed a nonzero amount (or vice versa when the value encodes but"
+            " the in-process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-int::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `huge-int` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-int::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `huge-int` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-int::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `huge-int` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-int::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `huge-int` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-negative-int::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `huge-negative-int` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-negative-int::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `huge-negative-int` value has no clean wire encoding on the client,"
+            " so the exception it raises there has a different base-class chain than"
+            " the concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-negative-int::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `huge-negative-int`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/huge-negative-int::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `huge-negative-int` value fails to encode onto the wire before the"
+            " call dispatches, so the client bills 0 FLOPs where in-process the call"
+            " ran and billed a nonzero amount (or vice versa when the value encodes but"
+            " the in-process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-max::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `int64-max` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-max::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `int64-max` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-min::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `int64-min` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-min::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `int64-min` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-min-minus-one::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `int64-min-minus-one` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-min-minus-one::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `int64-min-minus-one` value has no clean wire encoding on the client,"
+            " so the exception it raises there has a different base-class chain than"
+            " the concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-min-minus-one::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `int64-min-minus-"
+            " one` value for this argument position; the client cannot encode it onto"
+            " the wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int64-min-minus-one::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `int64-min-minus-one` value fails to encode onto the wire before the"
+            " call dispatches, so the client bills 0 FLOPs where in-process the call"
+            " ran and billed a nonzero amount (or vice versa when the value encodes but"
+            " the in-process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-bool::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-bool` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-bool::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-bool` value for"
+            " this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-bool::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-bool` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex128::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-complex128` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex128::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-complex128` value has no clean wire encoding on the client, so"
+            " the exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex128::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-complex128`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex128::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-complex128` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex64::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-complex64` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex64::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-complex64` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex64::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-complex64`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-complex64::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-complex64` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float16::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-float16` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float16::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-float16` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float16::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-float16` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float16::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-float16` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float32::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-float32` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float32::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-float32` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float32::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-float32` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-float32::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-float32` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-int64::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-int64` value has no clean wire encoding on the client; depending"
+            " on where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-int64::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-int64` value"
+            " for this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-int64::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-int64` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-0d::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-ndarray-0d` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-0d::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-ndarray-0d` value has no clean wire encoding on the client, so"
+            " the exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-0d::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-ndarray-0d`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-0d::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-ndarray-0d` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-1d::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-ndarray-1d` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-1d::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-ndarray-1d` value has no clean wire encoding on the client, so"
+            " the exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-1d::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `np-ndarray-1d`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/np-ndarray-1d::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `np-ndarray-1d` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/range::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `range` value has no clean wire encoding on the client; depending on"
+            " where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/range::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `range` value for"
+            " this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/range::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `range` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/remote-array::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `remote-array` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/remote-array::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `remote-array` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/remote-array::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `remote-array` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/set::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `set` value has no clean wire encoding on the client; depending on"
+            " where it appears, the client either raises `RemoteSerializationError`"
+            " directly while encoding the argument, or reaches a different failure than"
+            " the equivalent in-process rejection (numpy either accepts the value"
+            " directly or raises its own `TypeError`/`ValueError`/`IndexError` while"
+            " in-process handles it structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/set::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `set` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/set::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `set` value for"
+            " this argument position; the client cannot encode it onto the wire and"
+            " raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/set::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `set` value fails to encode onto the wire before the call dispatches,"
+            " so the client bills 0 FLOPs where in-process the call ran and billed a"
+            " nonzero amount (or vice versa when the value encodes but the in-process"
+            " side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/slice-object::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `slice-object` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/slice-object::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "In-process, numpy accepts or structurally handles the `slice-object`"
+            " value for this argument position; the client cannot encode it onto the"
+            " wire and raises instead."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/slice-object::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `slice-object` value fails to encode onto the wire before the call"
+            " dispatches, so the client bills 0 FLOPs where in-process the call ran and"
+            " billed a nonzero amount (or vice versa when the value encodes but the in-"
+            " process side rejects it first)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/uint64-max::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `uint64-max` value has no clean wire encoding on the client;"
+            " depending on where it appears, the client either raises"
+            " `RemoteSerializationError` directly while encoding the argument, or"
+            " reaches a different failure than the equivalent in-process rejection"
+            " (numpy either accepts the value directly or raises its own"
+            " `TypeError`/`ValueError`/`IndexError` while in-process handles it"
+            " structurally)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/uint64-max::*",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `uint64-max` value has no clean wire encoding on the client, so the"
+            " exception it raises there has a different base-class chain than the"
+            " concrete in-process exception."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/bytearray::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `bytearray` value's wire encoding is inconsistent by argument"
+            " position: some positions raise `ValueError` in-process against"
+            " `FlopscopeServerError` on the client, others raise `TypeError` in-process"
+            " against `ValueError` on the client - the client never reproduces the"
+            " concrete in-process exception for this value."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/bytearray::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `bytearray` value's wire encoding is inconsistent by argument"
+            " position: where it fails to encode at all the client bills 0 against a"
+            " nonzero in-process cost; where it does encode (list-element) the client"
+            " bills one FLOP less than in-process for the same call."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/memoryview::*",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `memoryview` value's wire encoding is inconsistent by argument"
+            " position: some positions raise `ValueError` in-process against"
+            " `FlopscopeServerError` on the client, others raise `TypeError` in-process"
+            " against `ValueError` on the client - the client never reproduces the"
+            " concrete in-process exception for this value."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/memoryview::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `memoryview` value's wire encoding is inconsistent by argument"
+            " position: where it fails to encode at all the client bills 0 against a"
+            " nonzero in-process cost; where it does encode (list-element) the client"
+            " bills one FLOP less than in-process for the same call."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/int-enum::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "An `IntEnum` member used as a scalar operand promotes the result to"
+            " `float64` in-process but only to `float32` on the client (or vice versa"
+            " depending on the position), so the two backends disagree on the promoted"
+            " dtype for the same arithmetic."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="types/int-enum::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "Indexing with an `IntEnum` member returns a bare `float32` scalar in-"
+            " process but a `RemoteScalar` proxy on the client."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="types/int-enum::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "An `IntEnum` member used as a scalar operand promotes to a different"
+            " dtype on each backend (see the accompanying `dtype` entry), which changes"
+            " the billed FLOP count for the same arithmetic."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="types/remote-scalar::list-element",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.concatenate([V, V[0]])` bills 7 FLOPs in-process but 14 on the"
+            " client for the identical call - a pure cost-model mismatch with no"
+            " accompanying outcome, dtype, or value divergence."
+        ),
+        issue="INTERNAL-P3-family-13",
+    ),
+    Entry(
+        case_id="types/remote-scalar::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "A remote scalar handle (`V[0]`) used as an `asarray`/second-positional"
+            " argument round-trips as `float32` in-process but `float64` on the client."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="types/remote-scalar::constructor",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.asarray(V[0])` promotes to a different dtype on each backend (see"
+            " the accompanying `dtype` entry), which changes the billed FLOP count for"
+            " the same call."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="types/nested-list::index-key",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[[[1.0]]]` raises in-process (a triply-nested list is not a valid"
+            " index) but the client's indexing accepts it and returns a value instead."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="types/nested-list::index-key",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[[[1.0]]]` raises before billing anything in-process (0 FLOPs), while"
+            " the client's indexing accepts the value and bills 4 FLOPs."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="idiom/scalar-float32-add",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[0] + V[1]` returns a bare `float32` in-process but a `RemoteScalar`"
+            " proxy on the client."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="idiom/scalar-int-array-dtype",
+        dimension="value",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.array(10) * I` produces different element values in-process (int64"
+            " arithmetic) than on the client, which promotes to float64."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="idiom/scalar-int-array-dtype",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.array(10) * I` returns `int64` in-process but `float64` on the"
+            " client - the two backends promote the scalar-times-int-array"
+            " multiplication differently."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="idiom/scalar-int-array-dtype",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The dtype promotion difference in `fnp.array(10) * I` (see the"
+            " accompanying `dtype`/`value` entries) also changes the billed FLOP count."
+        ),
+        issue="INTERNAL-P2-family-1",
+    ),
+    Entry(
+        case_id="idiom/float-index",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[2.5]` raises `IndexError` in-process (a float is not a valid index)"
+            " but the client coerces it and returns a value."
+        ),
+        issue="INTERNAL-P5-family-2",
+    ),
+    Entry(
+        case_id="idiom/float-slice-bound",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[: 7 / 2]` raises in-process (a float slice bound is invalid) but the"
+            " client coerces it and returns a value."
+        ),
+        issue="INTERNAL-P5-family-2",
+    ),
+    Entry(
+        case_id="idiom/handle-lookalike-string",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.sum('a0')` raises `TypeError` in-process (numpy rejects the string"
+            " outright) but the client's content-sniffing treats `'a0'` as a lookalike"
+            " for a remote handle and raises `KeyError` instead."
+        ),
+        issue="INTERNAL-P5-family-3",
+    ),
+    Entry(
+        case_id="idiom/handle-lookalike-string",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `KeyError` (a `LookupError`) for `fnp.sum('a0')` has a"
+            " different base-class chain than the in-process `TypeError`."
+        ),
+        issue="INTERNAL-P5-family-3",
+    ),
+    Entry(
+        case_id="idiom/handle-lookalike-string",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.sum('a0')` bills 1 FLOP in-process before rejecting the string; the"
+            " client's handle-lookalike sniffing rejects it before billing anything (0"
+            " FLOPs)."
+        ),
+        issue="INTERNAL-P5-family-3",
+    ),
+    Entry(
+        case_id="idiom/complex-scalar-mul",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "A Python `complex` scalar has no wire form: `fnp.astype(V, 'complex64') *"
+            " 1j` succeeds in-process but raises on the client (the harness canary for"
+            " this family)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="idiom/complex-scalar-mul",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client bills a partial cost (6 FLOPs) before failing to encode the"
+            " Python `complex` operand, against 42 FLOPs for the completed in-process"
+            " call."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="idiom/slice-bound-remote",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[: fnp.argmax(V)]` (a remote scalar used as a slice bound) succeeds in-"
+            " process but raises on the client."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="idiom/asarray-complex-list",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.asarray([1 + 2j, 3 - 1j])` (a list of Python `complex` scalars)"
+            " succeeds in-process but raises on the client, which cannot encode"
+            " `complex` onto the wire."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="idiom/asarray-complex-list",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client bills 0 FLOPs failing to encode the complex list, against 8"
+            " FLOPs for the completed in-process call."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="idiom/complex-element-read",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.full((2,), 1.0, dtype='complex128')[0]` returns a bare complex"
+            " scalar in-process but raises on the client, which cannot pack a complex"
+            " scalar into its response."
+        ),
+        issue="INTERNAL-P2-family-5",
+    ),
+    Entry(
+        case_id="idiom/tuple-axis-sum",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.sum(A, axis=(0, 1))` (a tuple axis) succeeds in-process but raises"
+            " on the client - the tuple does not survive encoding as an `axis` argument"
+            " (matches the `grid/*::axis-tuple` pattern across every reduction op)."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="idiom/split-returns-list",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.split(V, 2) + [V]` succeeds in-process, where `split` returns a"
+            " `list` that concatenates with `[V]`; on the client `split` returns a"
+            " `tuple` instead, so the same `+` raises `TypeError`."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="idiom/out-of-bounds-index",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[99]` raises `IndexError` in-process; the client wraps the same failure"
+            " in a generic `FlopscopeServerError` instead."
+        ),
+        issue="INTERNAL-P5-family-7",
+    ),
+    Entry(
+        case_id="idiom/out-of-bounds-index",
+        dimension="exc_bases",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's `FlopscopeServerError` for `V[99]` has a flat `[Exception,"
+            " BaseException]` base-class chain instead of `IndexError`'s `LookupError`"
+            " chain."
+        ),
+        issue="INTERNAL-P5-family-7",
+    ),
+    Entry(
+        case_id="idiom/string-array-read",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.asarray(['foo', 'bar']).tolist()` succeeds in-process; the client"
+            " cannot decode the string array's dtype and raises instead. Family 8"
+            " (undecodable dtypes) has no phase assigned in the mapping provided for"
+            " this task, so this is filed as unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="idiom/fft-rfft",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.fft.rfft(V)` succeeds in-process; the client's `fnp` module has no"
+            " `fft` submodule at all, so it raises `AttributeError` (matches the whole"
+            " `grid/fft.*` client-surface gap)."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="idiom/fft-rfft",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client's missing `fft` submodule means the call never dispatches and"
+            " bills 0 FLOPs, against 45 for the completed in-process call."
+        ),
+        issue="INTERNAL-P4-family-9",
+    ),
+    Entry(
+        case_id="idiom/huge-int-operand",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V * 2**70` (an int too large for any wire integer format) succeeds in-"
+            " process via Python's arbitrary-precision arithmetic; the client cannot"
+            " encode it and raises instead."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="idiom/huge-int-operand",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The client bills 0 FLOPs failing to encode the huge int operand, against"
+            " 6 for the completed in-process call."
+        ),
+        issue="INTERNAL-P5-family-10",
+    ),
+    Entry(
+        case_id="idiom/ndim-returns-int",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.ndim(A)` returns a bare `int` in-process (no dtype); the client"
+            " wraps it in a `RemoteScalar` proxy that reports `int64`."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="idiom/ndim-returns-int",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.ndim(A)` returns a bare `int` in-process (no shape); the client's"
+            " `RemoteScalar` proxy reports a `[]` shape instead."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="idiom/ndim-returns-int",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.ndim(A)` returns a bare `int` (container `scalar`) in-process; the"
+            " client wraps it in an array-shaped proxy instead."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="idiom/ndim-returns-int",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.ndim(A)` returns a bare `int` in-process but a `RemoteScalar` proxy"
+            " on the client (the harness's own precedent case for this family)."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/empty*::*",
+        dimension="value",
+        category=Category.PROXY_INHERENT,
+        reason=(
+            "`fnp.empty`/`fnp.empty_like` return uninitialized memory; their"
+            " contents are non-deterministic implementation details that cannot be"
+            " made to match between two independent allocations, in-process or"
+            " remote, even in principle."
+        ),
+    ),
+    Entry(
+        case_id="grid/random.[!GR]*::*",
+        dimension="pytype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "Several legacy `random.*` sampling/selection functions (e.g."
+            " `random.choice` picking a single element, `random.poisson` called"
+            " with no arguments) return a bare Python/NumPy scalar in-process for"
+            " these patterns; the client wraps the same result in a `RemoteScalar`"
+            " proxy instead of unwrapping it (the same mechanism as the"
+            " `ndim`-returns-int case). Uses `[!GR]` to exclude"
+            " `random.Generator.*`/`random.RandomState.*`, which are covered by"
+            " their own client-surface entries."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/random.[!GR]*::*",
+        dimension="container",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The same legacy `random.*` scalar-wrapping mechanism as the `pytype`"
+            " entry above: in-process these calls return a bare scalar (container"
+            " `scalar`), while the client wraps the result in an array-shaped"
+            " proxy."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/random.[!GR]*::*",
+        dimension="dtype",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The same legacy `random.*` scalar-wrapping mechanism as the `pytype`"
+            " entry above: in-process these calls return a bare scalar with no"
+            " `dtype`, while the client's wrapping proxy reports one."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/random.[!GR]*::*",
+        dimension="shape",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The same legacy `random.*` scalar-wrapping mechanism as the `pytype`"
+            " entry above: in-process these calls return a bare scalar with no"
+            " `shape`, while the client's wrapping proxy reports `[]`."
+        ),
+        issue="INTERNAL-P5-family-12",
+    ),
+    Entry(
+        case_id="grid/result_type::*",
+        dimension="value",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`result_type` returns a NumPy dtype-class object in-process,"
+            " fingerprinted via this harness's generic `repr`-based fallback (e.g."
+            " `dtype('float32')`); the client instead returns a plain descriptive"
+            " string (`'float32'`) for the same result. This is a dtype-object"
+            " undecodability issue (family 8), which has no phase assigned in the"
+            " mapping provided for this task, so it is filed as unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/min_scalar_type::*",
+        dimension="value",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`min_scalar_type` returns a NumPy dtype-class object in-process,"
+            " fingerprinted via this harness's generic `repr`-based fallback (e.g."
+            " `dtype('float32')`); the client instead returns a plain descriptive"
+            " string (`'float32'`) for the same result. This is a dtype-object"
+            " undecodability issue (family 8), which has no phase assigned in the"
+            " mapping provided for this task, so it is filed as unclassified."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="grid/*::axis-tuple",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "Passing a tuple `axis` (e.g. `axis=(0, 1)`) succeeds in-process for every"
+            " reduction op the grid drives this way, but raises on the client - the"
+            " tuple does not survive encoding as an `axis` argument (the same defect as"
+            " the `idiom/tuple-axis-sum` canary)."
+        ),
+        issue="INTERNAL-P2-family-6",
+    ),
+    Entry(
+        case_id="grid/array::*",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.array(X)` bills a nonzero amount in-process (a real copy) but the"
+            " client always bills 0, treating the reconstruction as a free passthrough"
+            " of the existing remote handle - a pure cost-model mismatch."
+        ),
+        issue="INTERNAL-P3-family-13",
+    ),
+    Entry(
+        case_id="grid/array::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.array(X, axis=...)` raises in-process (`array` does not accept an"
+            " `axis` keyword) but the client silently accepts it and returns a value -"
+            " the client is more permissive than in-process argument validation."
+            " Unclassified: this is a validation gap, not a case any given family"
+            " cleanly covers."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="types/memoryview::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `memoryview` value's wire encoding is inconsistent by argument"
+            " position: in-process it is always accepted, while the client rejects it"
+            " outright in some positions (`index-key`, `list-element`) and accepts it"
+            " in others."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/bytearray::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "The `bytearray` value's wire encoding is inconsistent by argument"
+            " position: in-process it is always accepted, while the client rejects it"
+            " outright in some positions (`index-key`, `list-element`) and accepts it"
+            " in others."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/remote-scalar::index-key",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`V[V[0]]` (indexing with a remote scalar handle) raises in-process (a"
+            " non-Python-int index) but the client's indexing accepts it and returns a"
+            " value instead."
+        ),
+        issue="INTERNAL-P5-unclassified",
+    ),
+    Entry(
+        case_id="types/remote-scalar::dict-literal",
+        dimension="exc_type",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.multiply(V, {'k': V[0]})` (a remote scalar nested in a dict literal)"
+            " raises `TypeError` in-process; the client's argument encoder does not"
+            " recurse into `dict` values the way it does for `list`/`tuple`, so it"
+            " raises `RemoteSerializationError` while trying to encode the dict itself."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/remote-scalar::dict-literal",
+        dimension="flops",
+        category=Category.KNOWN_BUG,
+        reason=(
+            "`fnp.multiply(V, {'k': V[0]})` bills 6 FLOPs in-process before rejecting"
+            " the dict argument; the client's encoder rejects the dict before billing"
+            " anything (0 FLOPs)."
+        ),
+        issue="INTERNAL-P2-family-4",
+    ),
+)
 
 
 def validate_entries(entries: tuple[Entry, ...]) -> list[str]:

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -5356,17 +5356,6 @@ ENTRIES: tuple[Entry, ...] = (
         issue="INTERNAL-P5-family-12",
     ),
     Entry(
-        case_id="grid/empty*::*",
-        dimension="value",
-        category=Category.PROXY_INHERENT,
-        reason=(
-            "`fnp.empty`/`fnp.empty_like` return uninitialized memory; their"
-            " contents are non-deterministic implementation details that cannot be"
-            " made to match between two independent allocations, in-process or"
-            " remote, even in principle."
-        ),
-    ),
-    Entry(
         case_id="grid/random.[!GR]*::*",
         dimension="pytype",
         category=Category.KNOWN_BUG,

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -1,0 +1,95 @@
+"""Known client/in-process divergences, with a written reason for each.
+
+Strictness runs in BOTH directions:
+
+* a divergence with no entry FAILS (a new regression);
+* an entry with no matching divergence FAILS as stale and must be deleted;
+* a KNOWN_BUG entry without an issue link FAILS at load time.
+
+Fixing a defect therefore forces the deletion of its entry in the same pull
+request. ``KNOWN_BUG`` reaching zero is the definition of done for the whole
+wire-protocol programme. ``PROXY_INHERENT`` should stay small; a creeping count
+is a smell that belongs in review.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+from tests.parity.compare import DIMENSIONS, Divergence
+
+
+class Category(enum.Enum):
+    #: Cannot work through a remote proxy, ever (e.g. a local buffer pointer).
+    PROXY_INHERENT = "proxy-inherent"
+    #: A deliberate, documented product choice.
+    ACCEPTED_DIVERGENCE = "accepted"
+    #: A real defect, tracked, not yet fixed.
+    KNOWN_BUG = "known-bug"
+
+
+@dataclass(frozen=True)
+class Entry:
+    case_id: str
+    dimension: str
+    category: Category
+    reason: str
+    issue: str | None = None
+
+    def key(self) -> tuple[str, str]:
+        return (self.case_id, self.dimension)
+
+
+@dataclass(frozen=True)
+class AllowlistResult:
+    unexplained: list[Divergence]
+    stale: list[Entry]
+    allowed: list[Divergence]
+    counts: dict[str, int]
+
+
+#: Populated by Task 11 from a first full run. Starts empty so that the eight
+#: meta-tests and the canary in Task 6 exercise the unexplained path.
+ENTRIES: tuple[Entry, ...] = ()
+
+
+def validate_entries(entries: tuple[Entry, ...]) -> list[str]:
+    """Return a list of schema problems; empty means valid."""
+    problems: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for entry in entries:
+        where = f"{entry.case_id}[{entry.dimension}]"
+        if entry.dimension not in DIMENSIONS:
+            problems.append(f"{where}: {entry.dimension!r} is not a known dimension")
+        if not entry.reason.strip():
+            problems.append(f"{where}: every entry needs a non-empty reason")
+        if entry.category is Category.KNOWN_BUG and not (entry.issue or "").strip():
+            problems.append(f"{where}: category known-bug requires an issue link")
+        if entry.key() in seen:
+            problems.append(f"{where}: duplicate entry")
+        seen.add(entry.key())
+    return problems
+
+
+def apply(
+    divergences: list[Divergence], entries: tuple[Entry, ...] = ENTRIES
+) -> AllowlistResult:
+    """Split *divergences* into allowed and unexplained, and find stale entries."""
+    by_key = {entry.key(): entry for entry in entries}
+    matched: set[tuple[str, str]] = set()
+    allowed: list[Divergence] = []
+    unexplained: list[Divergence] = []
+
+    for divergence in divergences:
+        if divergence.key() in by_key:
+            allowed.append(divergence)
+            matched.add(divergence.key())
+        else:
+            unexplained.append(divergence)
+
+    stale = [entry for entry in entries if entry.key() not in matched]
+    counts = {category.value: 0 for category in Category}
+    for entry in entries:
+        counts[entry.category.value] += 1
+    return AllowlistResult(unexplained, stale, allowed, counts)

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -80,11 +80,12 @@ class AllowlistResult:
     match_counts: dict[Entry, int]
 
 
-#: Populated from a full differential corpus run (see task-11-report.md for
-#: how it was derived). Each entry is grouped by root cause: a whole missing
-#: client namespace, a whole server-side error-wrapping mechanism, a single
-#: op, or a single case. `KNOWN_BUG` reaching zero is the definition of done
-#: for the whole wire-protocol programme.
+#: Populated from a full differential corpus run: both backends were driven
+#: over the whole case corpus, every divergence found was triaged, and each
+#: entry below records one root cause. Each entry is grouped by root cause: a
+#: whole missing client namespace, a whole server-side error-wrapping
+#: mechanism, a single op, or a single case. `KNOWN_BUG` reaching zero is the
+#: definition of done for the whole wire-protocol programme.
 ENTRIES: tuple[Entry, ...] = (
     Entry(
         case_id="grid/fft.*::*",
@@ -5451,8 +5452,8 @@ ENTRIES: tuple[Entry, ...] = (
         category=Category.KNOWN_BUG,
         reason=(
             "`fnp.array(X)` bills a nonzero amount in-process (a real copy) but the"
-            " client always bills 0, treating the reconstruction as a free passthrough"
-            " of the existing remote handle - a pure cost-model mismatch."
+            " client always bills 0 for the same call - a pure cost-model mismatch"
+            " between the two backends' `array` implementations."
         ),
         issue="INTERNAL-P3-family-13",
     ),

--- a/tests/parity/case.py
+++ b/tests/parity/case.py
@@ -34,11 +34,12 @@ class Case:
     tags: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
-        if "/" not in self.id:
+        parts = self.id.split("/", 1)
+        if len(parts) != 2 or not parts[0] or not parts[1]:
             raise ValueError(f"case id {self.id!r} must be '<source>/<name>'")
 
     def family(self) -> str | None:
-        """Return the audit family number this case covers, if tagged."""
+        """Return the defect-family label this case covers, if tagged."""
         for tag in self.tags:
             if tag.startswith("family:"):
                 return tag.split(":", 1)[1]

--- a/tests/parity/case.py
+++ b/tests/parity/case.py
@@ -1,0 +1,62 @@
+"""Serialisable description of one differential parity case.
+
+Cases are DATA, not closures: they cross a process boundary to the workers and
+are referenced by id from allowlist entries, so they must be serialisable and
+greppable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Case:
+    """One expression to evaluate identically on both backends.
+
+    Parameters
+    ----------
+    id:
+        Stable, structured ``<source>/<name>`` identifier. Allowlist entries
+        reference it; renaming a case orphans its entry (which fails the build
+        under strict allowlisting, by design).
+    source:
+        Python expression evaluated with ``fnp`` and the standard fixtures bound.
+    setup:
+        Optional statements executed before ``source``, in the same namespace.
+    tags:
+        Free-form markers, e.g. ``family:6``, ``tier:fast``, ``requires:numpy``.
+    """
+
+    id: str
+    source: str
+    setup: str = ""
+    tags: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        if "/" not in self.id:
+            raise ValueError(f"case id {self.id!r} must be '<source>/<name>'")
+
+    def family(self) -> str | None:
+        """Return the audit family number this case covers, if tagged."""
+        for tag in self.tags:
+            if tag.startswith("family:"):
+                return tag.split(":", 1)[1]
+        return None
+
+    def to_json(self) -> dict:
+        return {
+            "id": self.id,
+            "source": self.source,
+            "setup": self.setup,
+            "tags": sorted(self.tags),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict) -> Case:
+        return cls(
+            id=data["id"],
+            source=data["source"],
+            setup=data.get("setup", ""),
+            tags=frozenset(data.get("tags", ())),
+        )

--- a/tests/parity/compare.py
+++ b/tests/parity/compare.py
@@ -1,0 +1,76 @@
+"""Diff two observation records dimension by dimension.
+
+Each dimension is compared and reported independently so that allowlisting a
+dtype divergence still lets a value divergence in the same case fail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+#: Every dimension the harness can report, in report order.
+DIMENSIONS: tuple[str, ...] = (
+    "outcome",
+    "exc_type",
+    "exc_bases",
+    "value",
+    "dtype",
+    "shape",
+    "container",
+    "pytype",
+    "flops",
+)
+
+#: Compared only when BOTH sides returned a value.
+_RETURNED_ONLY = ("value", "dtype", "shape", "container", "pytype")
+
+#: Compared only when BOTH sides raised.
+_RAISED_ONLY = ("exc_type", "exc_bases")
+
+
+@dataclass(frozen=True)
+class Divergence:
+    """One dimension on which the two backends disagreed for one case."""
+
+    case_id: str
+    dimension: str
+    inproc: Any
+    client: Any
+
+    def key(self) -> tuple[str, str]:
+        """Allowlist key: divergences are allowlisted per (case, dimension)."""
+        return (self.case_id, self.dimension)
+
+
+def compare_observations(case_id: str, inproc: dict, client: dict) -> list[Divergence]:
+    """Return every dimension on which *inproc* and *client* disagree."""
+    out: list[Divergence] = []
+
+    def add(dimension: str) -> None:
+        out.append(
+            Divergence(case_id, dimension, inproc.get(dimension), client.get(dimension))
+        )
+
+    if inproc.get("outcome") != client.get("outcome"):
+        add("outcome")
+        # Outcomes differ, so the shape-specific dimensions are not comparable.
+        # FLOPs still are: charging for a call that failed on one side only is
+        # exactly the billing defect this harness exists to catch.
+        if inproc.get("flops") != client.get("flops"):
+            add("flops")
+        return out
+
+    outcome = inproc.get("outcome")
+    if outcome == "returned":
+        for dimension in _RETURNED_ONLY:
+            if inproc.get(dimension) != client.get(dimension):
+                add(dimension)
+    elif outcome == "raised":
+        for dimension in _RAISED_ONLY:
+            if inproc.get(dimension) != client.get(dimension):
+                add(dimension)
+
+    if inproc.get("flops") != client.get("flops"):
+        add("flops")
+    return out

--- a/tests/parity/corpus/__init__.py
+++ b/tests/parity/corpus/__init__.py
@@ -1,0 +1,16 @@
+"""Assemble every corpus source into one list of cases."""
+
+from __future__ import annotations
+
+from tests.parity.case import Case
+from tests.parity.corpus import idioms
+
+
+def all_cases() -> list[Case]:
+    """Every case from every source."""
+    return list(idioms.CASES)
+
+
+def fast_cases() -> list[Case]:
+    """The blocking tier: one case per family, plus the surface check."""
+    return [case for case in all_cases() if "tier:fast" in case.tags]

--- a/tests/parity/corpus/__init__.py
+++ b/tests/parity/corpus/__init__.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from tests.parity.case import Case
-from tests.parity.corpus import idioms
+from tests.parity.corpus import idioms, registry_grid
 
 
 def all_cases() -> list[Case]:
     """Every case from every source."""
-    return list(idioms.CASES)
+    return list(idioms.CASES) + list(registry_grid.build())
 
 
 def fast_cases() -> list[Case]:

--- a/tests/parity/corpus/__init__.py
+++ b/tests/parity/corpus/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from tests.parity.case import Case
-from tests.parity.corpus import idioms, registry_grid
+from tests.parity.corpus import idioms, registry_grid, type_universe
 
 
 def all_cases() -> list[Case]:
     """Every case from every source."""
-    return list(idioms.CASES) + list(registry_grid.build())
+    return (
+        list(idioms.CASES) + list(registry_grid.build()) + list(type_universe.build())
+    )
 
 
 def fast_cases() -> list[Case]:

--- a/tests/parity/corpus/idioms.py
+++ b/tests/parity/corpus/idioms.py
@@ -1,0 +1,105 @@
+"""Participant-shaped expressions that generated corpora cannot produce.
+
+Hand-maintained on purpose: small, highest-signal, and the regression ratchet.
+Every future participant-reported failure gets a case here BEFORE it gets a fix.
+"""
+
+from __future__ import annotations
+
+from tests.parity.case import Case
+
+_FAST = "tier:fast"
+
+CASES: tuple[Case, ...] = (
+    # Family 1 - scalar semantics
+    Case(
+        id="idiom/scalar-float32-add",
+        source="V[0] + V[1]",
+        tags=frozenset({"family:1", _FAST}),
+    ),
+    Case(
+        id="idiom/scalar-int-array-dtype",
+        source="fnp.array(10) * I",
+        tags=frozenset({"family:1"}),
+    ),
+    # Family 2 - index coercion
+    Case(
+        id="idiom/float-index",
+        source="V[2.5]",
+        tags=frozenset({"family:2", _FAST}),
+    ),
+    Case(
+        id="idiom/float-slice-bound",
+        source="V[: 7 / 2]",
+        tags=frozenset({"family:2"}),
+    ),
+    # Family 3 - content sniffing
+    Case(
+        id="idiom/handle-lookalike-string",
+        source="fnp.sum('a0')",
+        tags=frozenset({"family:3", _FAST}),
+    ),
+    # Family 4 - partial encoding
+    Case(
+        id="idiom/complex-scalar-mul",
+        source="fnp.astype(V, 'complex64') * 1j",
+        tags=frozenset({"family:4", _FAST}),
+    ),
+    Case(
+        id="idiom/slice-bound-remote",
+        source="V[: fnp.argmax(V)]",
+        tags=frozenset({"family:4"}),
+    ),
+    Case(
+        id="idiom/asarray-complex-list",
+        source="fnp.asarray([1 + 2j, 3 - 1j])",
+        tags=frozenset({"family:4"}),
+    ),
+    # Family 5 - response packing
+    Case(
+        id="idiom/complex-element-read",
+        source="fnp.full((2,), 1.0, dtype='complex128')[0]",
+        tags=frozenset({"family:5", _FAST}),
+    ),
+    # Family 6 - container identity
+    Case(
+        id="idiom/tuple-axis-sum",
+        source="fnp.sum(A, axis=(0, 1))",
+        tags=frozenset({"family:6", _FAST}),
+    ),
+    Case(
+        id="idiom/split-returns-list",
+        source="fnp.split(V, 2) + [V]",
+        tags=frozenset({"family:6"}),
+    ),
+    # Family 7 - exception identity
+    Case(
+        id="idiom/out-of-bounds-index",
+        source="V[99]",
+        tags=frozenset({"family:7", _FAST}),
+    ),
+    # Family 8 - undecodable dtypes
+    Case(
+        id="idiom/string-array-read",
+        source="fnp.asarray(['foo', 'bar']).tolist()",
+        tags=frozenset({"family:8", _FAST}),
+    ),
+    # Family 9 - client surface
+    Case(
+        id="idiom/fft-rfft",
+        source="fnp.fft.rfft(V)",
+        tags=frozenset({"family:9", _FAST}),
+    ),
+    # Family 10 - error wrapping
+    Case(
+        id="idiom/huge-int-operand",
+        source="V * 2**70",
+        tags=frozenset({"family:10", _FAST}),
+    ),
+    # Family 12 - predicate return types
+    Case(
+        id="idiom/ndim-returns-int",
+        source="fnp.ndim(A)",
+        tags=frozenset({"family:12", _FAST}),
+    ),
+)

--- a/tests/parity/corpus/registry_grid.py
+++ b/tests/parity/corpus/registry_grid.py
@@ -110,16 +110,68 @@ SEGFAULT_EXCLUDED_CASE_IDS: frozenset[str] = frozenset(
     for pattern in patterns
 )
 
+#: UNINITIALIZED-MEMORY EXCLUSIONS - do not remove without re-measuring.
+#:
+#: `empty` and `empty_like` return arbitrary, uninitialized memory by
+#: contract (see their docstrings in `src/flopscope/_array_ops.py`); their
+#: *contents* cannot ever be meaningfully compared between two independent
+#: allocations, in-process or remote, even in principle - unlike ordinary
+#: nondeterminism (e.g. an unseeded random draw), no amount of seeding fixes
+#: this, because numpy deliberately does not initialize the buffer. These
+#: are the only two ops in the core registry with this contract (checked:
+#: `grep -rn uninitial src` turns up nothing else).
+#:
+#: The registry search above found the *ops*; this maps each one to the
+#: exact patterns that actually produce a "returned" outcome carrying such a
+#: value (confirmed by running every `PATTERNS` entry for both ops through
+#: the in-process backend directly). Every other pattern for these two ops
+#: raises a normal, catchable, deterministic exception (mismatched arity or
+#: an invalid `shape`/`dtype` argument) and stays in the corpus - only the
+#: patterns whose value is genuinely incomparable are excluded.
+_UNINITIALIZED_VALUE_PATTERNS_BY_OP: dict[str, tuple[str, ...]] = {
+    # `fnp.empty(I)` (`I` is an int64 array) is accepted as a `shape` tuple;
+    # `fnp.empty(E)` (`E` is an empty float32 array) is accepted as an empty
+    # `shape` tuple, i.e. a 0-d output. Every other pattern passes a value
+    # `numpy.empty`'s `shape` parameter rejects outright (a float array, a
+    # bool array, an unexpected keyword, ...), which raises deterministically
+    # and is left in the corpus.
+    "empty": ("integer", "empty"),
+    # `fnp.empty_like(x)` succeeds for any single positional array-like
+    # argument, copying its shape (and, by default, its dtype). Every
+    # pattern that instead supplies a second positional argument, an `axis`/
+    # `keepdims` keyword, or no argument at all raises deterministically
+    # (`empty_like` has no such parameters) and is left in the corpus.
+    "empty_like": ("array", "vector", "dtype", "integer", "boolean", "empty", "zero-d"),
+}
+
+#: The 9 exact `grid/<op>::<pattern>` case ids that
+#: `_UNINITIALIZED_VALUE_PATTERNS_BY_OP` names, precomputed once so both
+#: `build()` and `undriven()` read the same set instead of recomputing it.
+UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS: frozenset[str] = frozenset(
+    f"grid/{op}::{pattern}"
+    for op, patterns in _UNINITIALIZED_VALUE_PATTERNS_BY_OP.items()
+    for pattern in patterns
+)
+
+#: Every case id `build()` refuses to drive, from any cause, unioned once so
+#: `build()`'s filter and `undriven()`'s reporting always agree.
+_ALL_EXCLUDED_CASE_IDS: frozenset[str] = (
+    SEGFAULT_EXCLUDED_CASE_IDS | UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS
+)
+
 
 def undriven() -> dict[str, str]:
     """Grid cases no run can safely include, with the reason. Counted, not
     dropped.
 
-    Two kinds of entry can appear here:
+    Three kinds of entry can appear here:
 
     * a case excluded because it segfaults the worker (see
       `SEGFAULT_EXCLUDED_CASE_IDS` above) - populated below from real
       measurement;
+    * a case excluded because its return value is uninitialized memory (see
+      `UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS` above) - also populated below
+      from real measurement;
     * (populated from a first full run, currently none) an op whose every
       remaining pattern raises identically on BOTH backends, which is not
       being exercised, and saying so is more honest than reporting it as
@@ -133,7 +185,18 @@ def undriven() -> dict[str, str]:
         "call with an array fixture standing in for `self`; uncatchable, "
         "so excluded from the corpus rather than fed to a worker"
     )
-    return dict.fromkeys(sorted(SEGFAULT_EXCLUDED_CASE_IDS), segfault_reason)
+    uninitialized_value_reason = (
+        "returns uninitialized memory by contract (`empty`/`empty_like`); its"
+        " value can never be meaningfully compared between two independent"
+        " allocations, so excluded from the corpus rather than compared"
+    )
+    reasons = dict.fromkeys(sorted(SEGFAULT_EXCLUDED_CASE_IDS), segfault_reason)
+    reasons.update(
+        dict.fromkeys(
+            sorted(UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS), uninitialized_value_reason
+        )
+    )
+    return reasons
 
 
 def build() -> tuple[Case, ...]:
@@ -145,5 +208,5 @@ def build() -> tuple[Case, ...]:
         )
         for op in op_names()
         for pattern_name, template in PATTERNS
-        if f"grid/{op}::{pattern_name}" not in SEGFAULT_EXCLUDED_CASE_IDS
+        if f"grid/{op}::{pattern_name}" not in _ALL_EXCLUDED_CASE_IDS
     )

--- a/tests/parity/corpus/registry_grid.py
+++ b/tests/parity/corpus/registry_grid.py
@@ -1,0 +1,79 @@
+"""Source 1: every registered op crossed with a fixed set of argument patterns.
+
+An op that works in-process and raises AttributeError on the client shows up as
+an `outcome` divergence, which is how this source catches a whole missing
+surface without anyone hand-listing it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from functools import lru_cache
+
+from tests.parity.case import Case
+
+_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+#: (pattern name, source template). ``{op}`` is the dotted op name.
+PATTERNS: tuple[tuple[str, str], ...] = (
+    ("array", "fnp.{op}(A)"),
+    ("array-pair", "fnp.{op}(A, B)"),
+    ("vector", "fnp.{op}(V)"),
+    ("axis-int", "fnp.{op}(A, axis=0)"),
+    ("axis-tuple", "fnp.{op}(A, axis=(0, 1))"),
+    ("axis-negative", "fnp.{op}(A, axis=-1)"),
+    ("keepdims", "fnp.{op}(A, axis=0, keepdims=True)"),
+    ("dtype", "fnp.{op}(A, dtype='float64')"),
+    ("scalar-operand", "fnp.{op}(V, 2.0)"),
+    ("integer", "fnp.{op}(I)"),
+    ("boolean", "fnp.{op}(M)"),
+    ("empty", "fnp.{op}(E)"),
+    ("zero-d", "fnp.{op}(S)"),
+    ("no-arg", "fnp.{op}()"),
+)
+
+_DUMP_NAMES = """
+import json, sys
+sys.path.insert(0, {root!r})
+from flopscope._registry import REGISTRY
+print(json.dumps(sorted(REGISTRY)))
+"""
+
+
+@lru_cache(maxsize=1)
+def op_names() -> list[str]:
+    """Return every op name from the CORE registry (the source of truth)."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _DUMP_NAMES.format(root=os.path.join(_ROOT, "src"))],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def undriven() -> dict[str, str]:
+    """Ops no generic pattern can drive, with the reason. Counted, not dropped.
+
+    Populated from the first full run: an op whose every pattern raises
+    identically on BOTH backends is not being exercised, and saying so is more
+    honest than reporting it as agreement.
+    """
+    return {}
+
+
+def build() -> tuple[Case, ...]:
+    return tuple(
+        Case(
+            id=f"grid/{op}::{pattern_name}",
+            source=template.format(op=op),
+            tags=frozenset({"src:grid", f"pattern:{pattern_name}"}),
+        )
+        for op in op_names()
+        for pattern_name, template in PATTERNS
+    )

--- a/tests/parity/corpus/registry_grid.py
+++ b/tests/parity/corpus/registry_grid.py
@@ -57,14 +57,83 @@ def op_names() -> list[str]:
     return json.loads(proc.stdout)
 
 
-def undriven() -> dict[str, str]:
-    """Ops no generic pattern can drive, with the reason. Counted, not dropped.
+#: SEGFAULT EXCLUSIONS - do not remove without re-measuring.
+#:
+#: These three ops crash the in-process worker with SIGSEGV (exit 139) for
+#: the patterns listed below, confirmed by running each case in its own
+#: subprocess and observing the return code directly. A segfault is
+#: uncatchable by any Python `try`/`except` (`tests/parity/worker.py` /
+#: `tests/parity/runner.py`'s restart machinery exists for exactly this
+#: class of crash), so these cases must never be fed to a worker at all -
+#: they are excluded here, at corpus-assembly time, rather than relying on
+#: the runner to survive them.
+#:
+#: All three are unbound-method calls (`fnp.random.RandomState.get_state(A)`
+#: etc.) where a plain array fixture stands in for `self`; the patterns that
+#: crash are exactly the ones that pass a fixture as the first positional
+#: argument with no extra keyword (`array`, `array-pair`, `vector`,
+#: `scalar-operand`, `integer`, `boolean`, `empty`, `zero-d`) - the patterns
+#: that add a keyword argument (`axis-int`, `axis-tuple`, `axis-negative`,
+#: `keepdims`, `dtype`) raise a normal, catchable `TypeError` instead
+#: (rejected before the C code ever dereferences `self`), and `no-arg`
+#: never supplies a `self` at all.
+_SEGFAULT_PATTERNS_BY_OP: dict[str, tuple[str, ...]] = {
+    "random.RandomState.get_state": (
+        "array",
+        "array-pair",
+        "vector",
+        "scalar-operand",
+        "integer",
+        "boolean",
+        "empty",
+        "zero-d",
+    ),
+    "random.RandomState.seed": (
+        "array",
+        "array-pair",
+        "vector",
+        "scalar-operand",
+        "integer",
+        "boolean",
+        "empty",
+        "zero-d",
+    ),
+    "random.Generator.spawn": ("scalar-operand",),
+}
 
-    Populated from the first full run: an op whose every pattern raises
-    identically on BOTH backends is not being exercised, and saying so is more
-    honest than reporting it as agreement.
+#: The 17 exact `grid/<op>::<pattern>` case ids that `_SEGFAULT_PATTERNS_BY_OP`
+#: names, precomputed once so both `build()` and `undriven()` read the same
+#: set instead of recomputing it.
+SEGFAULT_EXCLUDED_CASE_IDS: frozenset[str] = frozenset(
+    f"grid/{op}::{pattern}"
+    for op, patterns in _SEGFAULT_PATTERNS_BY_OP.items()
+    for pattern in patterns
+)
+
+
+def undriven() -> dict[str, str]:
+    """Grid cases no run can safely include, with the reason. Counted, not
+    dropped.
+
+    Two kinds of entry can appear here:
+
+    * a case excluded because it segfaults the worker (see
+      `SEGFAULT_EXCLUDED_CASE_IDS` above) - populated below from real
+      measurement;
+    * (populated from a first full run, currently none) an op whose every
+      remaining pattern raises identically on BOTH backends, which is not
+      being exercised, and saying so is more honest than reporting it as
+      agreement.
+
+    Either way, an entry here means "not in `build()`'s output, and here is
+    why", so coverage counts stay honest instead of silently shrinking.
     """
-    return {}
+    segfault_reason = (
+        "SIGSEGV (exit 139) in the in-process backend: an unbound-method "
+        "call with an array fixture standing in for `self`; uncatchable, "
+        "so excluded from the corpus rather than fed to a worker"
+    )
+    return dict.fromkeys(sorted(SEGFAULT_EXCLUDED_CASE_IDS), segfault_reason)
 
 
 def build() -> tuple[Case, ...]:
@@ -76,4 +145,5 @@ def build() -> tuple[Case, ...]:
         )
         for op in op_names()
         for pattern_name, template in PATTERNS
+        if f"grid/{op}::{pattern_name}" not in SEGFAULT_EXCLUDED_CASE_IDS
     )

--- a/tests/parity/corpus/type_universe.py
+++ b/tests/parity/corpus/type_universe.py
@@ -1,0 +1,70 @@
+"""Source 2: exotic argument values crossed with argument POSITION.
+
+Position matters as much as type: the same value behaves differently as a
+positional argument, a keyword, a list element, an index key and a slice bound.
+"""
+
+from __future__ import annotations
+
+from tests.parity.case import Case
+
+_NP = frozenset({"requires:numpy"})
+_NONE: frozenset[str] = frozenset()
+
+#: (name, expression producing the value, extra tags)
+VALUES: tuple[tuple[str, str, frozenset[str]], ...] = (
+    ("complex", "1j", _NONE),
+    ("range", "range(2)", _NONE),
+    ("set", "{1, 2}", _NONE),
+    ("frozenset", "frozenset({1, 2})", _NONE),
+    ("generator", "(x for x in [1, 2])", _NONE),
+    ("memoryview", "memoryview(b'\\x01\\x02')", _NONE),
+    ("bytearray", "bytearray(b'\\x01\\x02')", _NONE),
+    ("bytes", "b'\\x01\\x02'", _NONE),
+    ("array-array-f", "__import__('array').array('f', [1.0, 2.0])", _NONE),
+    ("decimal", "__import__('decimal').Decimal('1.5')", _NONE),
+    ("fraction", "__import__('fractions').Fraction(1, 2)", _NONE),
+    ("datetime", "__import__('datetime').date(2026, 7, 25)", _NONE),
+    ("slice-object", "slice(0, 2)", _NONE),
+    ("ellipsis", "...", _NONE),
+    ("int-enum", "__import__('enum').IntEnum('E', {'A': 1}).A", _NONE),
+    ("huge-int", "2**70", _NONE),
+    ("int64-max", "2**63 - 1", _NONE),
+    ("uint64-max", "2**64 - 1", _NONE),
+    ("nested-list", "[[[1.0]]]", _NONE),
+    ("dict", "{'k': 1}", _NONE),
+    ("dict-with-handle", "{'k': V}", _NONE),
+    ("handle-lookalike", "'a0'", _NONE),
+    ("dtype-named-object", "type('S', (), {'name': 'float32'})()", _NONE),
+    ("remote-array", "V", _NONE),
+    ("remote-scalar", "V[0]", _NONE),
+    ("np-float32", "__import__('numpy').float32(1.5)", _NP),
+    ("np-int64", "__import__('numpy').int64(3)", _NP),
+    ("np-bool", "__import__('numpy').bool_(True)", _NP),
+    ("np-float16", "__import__('numpy').float16(1.5)", _NP),
+    ("np-ndarray-1d", "__import__('numpy').array([1.0, 2.0])", _NP),
+    ("np-ndarray-0d", "__import__('numpy').array(1.0)", _NP),
+)
+
+#: (name, template containing {value})
+POSITIONS: tuple[tuple[str, str], ...] = (
+    ("positional", "fnp.multiply(V, {value})"),
+    ("keyword", "fnp.clip(V, a_min=0.0, a_max={value})"),
+    ("list-element", "fnp.concatenate([V, {value}])"),
+    ("index-key", "V[{value}]"),
+    ("slice-bound", "V[:{value}]"),
+    ("dict-value", "fnp.where(M, {value}, 0.0)"),
+    ("constructor", "fnp.asarray({value})"),
+)
+
+
+def build() -> tuple[Case, ...]:
+    return tuple(
+        Case(
+            id=f"types/{value_name}::{position_name}",
+            source=template.format(value=value_source),
+            tags=frozenset({"src:types", f"value:{value_name}"}) | extra,
+        )
+        for value_name, value_source, extra in VALUES
+        for position_name, template in POSITIONS
+    )

--- a/tests/parity/corpus/type_universe.py
+++ b/tests/parity/corpus/type_universe.py
@@ -31,6 +31,9 @@ VALUES: tuple[tuple[str, str, frozenset[str]], ...] = (
     ("huge-int", "2**70", _NONE),
     ("int64-max", "2**63 - 1", _NONE),
     ("uint64-max", "2**64 - 1", _NONE),
+    ("int64-min", "-(2**63)", _NONE),
+    ("int64-min-minus-one", "-(2**63) - 1", _NONE),
+    ("huge-negative-int", "-(2**70)", _NONE),
     ("nested-list", "[[[1.0]]]", _NONE),
     ("dict", "{'k': 1}", _NONE),
     ("dict-with-handle", "{'k': V}", _NONE),
@@ -42,6 +45,8 @@ VALUES: tuple[tuple[str, str, frozenset[str]], ...] = (
     ("np-int64", "__import__('numpy').int64(3)", _NP),
     ("np-bool", "__import__('numpy').bool_(True)", _NP),
     ("np-float16", "__import__('numpy').float16(1.5)", _NP),
+    ("np-complex64", "__import__('numpy').complex64(1 + 2j)", _NP),
+    ("np-complex128", "__import__('numpy').complex128(1 + 2j)", _NP),
     ("np-ndarray-1d", "__import__('numpy').array([1.0, 2.0])", _NP),
     ("np-ndarray-0d", "__import__('numpy').array(1.0)", _NP),
 )
@@ -53,7 +58,8 @@ POSITIONS: tuple[tuple[str, str], ...] = (
     ("list-element", "fnp.concatenate([V, {value}])"),
     ("index-key", "V[{value}]"),
     ("slice-bound", "V[:{value}]"),
-    ("dict-value", "fnp.where(M, {value}, 0.0)"),
+    ("second-positional", "fnp.where(M, {value}, 0.0)"),
+    ("dict-literal", "fnp.multiply(V, {{'k': {value}}})"),
     ("constructor", "fnp.asarray({value})"),
 )
 
@@ -63,7 +69,10 @@ def build() -> tuple[Case, ...]:
         Case(
             id=f"types/{value_name}::{position_name}",
             source=template.format(value=value_source),
-            tags=frozenset({"src:types", f"value:{value_name}"}) | extra,
+            tags=frozenset(
+                {"src:types", f"value:{value_name}", f"position:{position_name}"}
+            )
+            | extra,
         )
         for value_name, value_source, extra in VALUES
         for position_name, template in POSITIONS

--- a/tests/parity/observe.py
+++ b/tests/parity/observe.py
@@ -2,9 +2,9 @@
 
 THE RULE: these functions RECORD, they do not NORMALISE. Materialising an array
 via ``tolist()`` is fine *because* dtype, shape and the Python type are recorded
-separately alongside it. Replacing those with the materialised value is what
-blinded ``tests/client_compat`` to every dtype divergence in the 2026-07-25
-audit.
+separately alongside it. Replacing those fields with just the materialised
+value would make every dtype divergence between backends invisible, no matter
+how many tests were layered on top of ``tests/client_compat`` afterwards.
 """
 
 from __future__ import annotations
@@ -26,7 +26,16 @@ def fingerprint(value: Any) -> str:
 
     Floats become their IEEE-754 bit pattern, so ``nan``, ``-0.0`` and last-ULP
     differences are all distinguishable. Every scalar carries a type tag, so
-    ``1``, ``1.0`` and ``True`` never collide.
+    ``1``, ``1.0`` and ``True`` never collide. String and bytes encodings carry
+    an explicit length prefix so structural separators inside the content
+    (``,``, ``[``, ``]``) can never be mistaken for container structure.
+
+    The ``?:`` branch at the end is a last-resort, non-exact fallback for
+    values of a type this module does not model (it falls back to ``repr``,
+    which is not guaranteed to be injective or stable). Callers that need
+    exactness — this harness's whole purpose — must materialise unmodelled
+    types (e.g. numpy scalars) down to a modelled Python type before calling
+    ``fingerprint``, the way ``observe_result`` does via ``_materialize``.
     """
     if isinstance(value, bool):
         return f"b:{value}"
@@ -42,9 +51,10 @@ def fingerprint(value: Any) -> str:
             + struct.pack(">d", value.imag).hex()
         )
     if isinstance(value, str):
-        return f"s:{value}"
+        return f"s:{len(value)}:{value}"
     if isinstance(value, (bytes, bytearray)):
-        return "y:" + bytes(value).hex()
+        hexdigits = bytes(value).hex()
+        return f"y:{len(hexdigits)}:{hexdigits}"
     if value is None:
         return "n:"
     if isinstance(value, (list, tuple)):
@@ -53,10 +63,10 @@ def fingerprint(value: Any) -> str:
 
 
 def _container_of(value: Any) -> str:
-    if isinstance(value, tuple) and hasattr(value, "_fields"):
-        fields = ",".join(getattr(value, "_fields"))  # noqa: B009
-        return f"namedtuple:{type(value).__name__}({fields})"
     if isinstance(value, tuple):
+        fields = getattr(value, "_fields", None)
+        if fields is not None:
+            return f"namedtuple:{type(value).__name__}({','.join(fields)})"
         return "tuple"
     if isinstance(value, list):
         return "list"
@@ -71,6 +81,13 @@ def _materialize(value: Any) -> Any:
         return tolist()
     if isinstance(value, (list, tuple)):
         return [_materialize(item) for item in value]
+    item = getattr(value, "item", None)
+    if callable(item):
+        # Zero-argument `.item()` is how numpy scalars (np.float32, np.int64,
+        # ...) unwrap to a plain Python scalar; they aren't subclasses of the
+        # builtin types `fingerprint` models, so without this they'd fall
+        # through to its inexact `?:` fallback.
+        return item()
     return value
 
 

--- a/tests/parity/observe.py
+++ b/tests/parity/observe.py
@@ -78,7 +78,15 @@ def _container_of(value: Any) -> str:
 def _materialize(value: Any) -> Any:
     tolist = getattr(value, "tolist", None)
     if callable(tolist):
-        return tolist()
+        try:
+            return tolist()
+        except Exception:
+            # A `tolist` attribute that promises the ndarray protocol but
+            # blows up when actually called (e.g. `value` is a class, so
+            # `tolist` is an unbound function expecting `self`) must not
+            # take the whole recording down with it. Fall back to the raw
+            # value, same as if `tolist` had never been callable.
+            return value
     if isinstance(value, (list, tuple)):
         return [_materialize(item) for item in value]
     item = getattr(value, "item", None)
@@ -109,15 +117,69 @@ def _pytype_of(value: Any) -> str:
     return _ARRAY_WRAPPER_TOKEN if name in _ARRAY_WRAPPER_CLASS_NAMES else name
 
 
+#: A real dtype's ``str()`` is always a short label (``"float32"``,
+#: ``"dtype('complex128')"``, ...). A misattributed descriptor's default
+#: repr (e.g. ``"<attribute 'dtype' of 'X' objects>"`` for a class's
+#: getset_descriptor, ``"<property object at 0x...>"`` for a class's
+#: property) is not, which is how this tells the two apart without
+#: hard-coding any backend's dtype type: both are the generic
+#: ``<... at 0x...>`` / ``<... of ... objects>`` shape Python's default
+#: ``__repr__``/``__str__`` produces for objects with no custom string form,
+#: i.e. angle-bracket-wrapped end to end. A genuine dtype string is never
+#: wrapped like that (numpy's own byte-order-prefixed forms, e.g.
+#: ``"<U10"``, start with ``<`` but do not end with ``>``).
+_MAX_PLAUSIBLE_DTYPE_LEN = 64
+
+
+def _shape_of(value: Any) -> list | None:
+    """Return ``value.shape`` as a list, or ``None`` if it is not genuinely one.
+
+    ``value`` may be a class rather than an instance (a real defect this
+    harness has observed from the registry under test), in which case a
+    ``.shape`` attribute implemented as a C-level getset descriptor resolves
+    to the descriptor object itself rather than a tuple. ``list()`` on that
+    raises, so it must be validated before use, not just null-checked.
+    """
+    shape = getattr(value, "shape", None)
+    if not isinstance(shape, (tuple, list)):
+        return None
+    if not all(isinstance(dim, int) and not isinstance(dim, bool) for dim in shape):
+        return None
+    return list(shape)
+
+
+def _dtype_of(value: Any) -> str | None:
+    """Return ``str(value.dtype)``, or ``None`` if that is not a plausible dtype.
+
+    Same hazard as ``_shape_of``: on a misbehaving ``value`` the ``dtype``
+    attribute can be a descriptor object rather than a real dtype. ``str()``
+    on it will not raise, so this also rejects the implausible-looking
+    result (long, multi-line, or otherwise not dtype-shaped) rather than
+    recording it as if it were faithful.
+    """
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return None
+    try:
+        text = str(dtype)
+    except Exception:
+        return None
+    if not isinstance(text, str) or not text:
+        return None
+    if len(text) > _MAX_PLAUSIBLE_DTYPE_LEN or "\n" in text:
+        return None
+    if text.startswith("<") and text.endswith(">"):
+        return None
+    return text
+
+
 def observe_result(value: Any, flops: int) -> dict:
     """Record a successful return."""
-    shape = getattr(value, "shape", None)
-    dtype = getattr(value, "dtype", None)
     return {
         "outcome": "returned",
         "pytype": _pytype_of(value),
-        "dtype": None if dtype is None else str(dtype),
-        "shape": None if shape is None else list(shape),
+        "dtype": _dtype_of(value),
+        "shape": _shape_of(value),
         "container": _container_of(value),
         "value": fingerprint(_materialize(value)),
         "flops": flops,
@@ -140,6 +202,21 @@ def observe_exception(exc: BaseException, flops: int) -> dict:
         "exc_type": type(exc).__name__,
         "exc_bases": bases,
         "exc_msg": str(exc),
+        "flops": flops,
+    }
+
+
+def observe_record_failure(exc: BaseException, flops: int) -> dict:
+    """Record that the harness itself failed to describe a result.
+
+    A last-resort outcome for when ``observe_result`` itself raises despite
+    its own defenses (an object hostile enough to defeat ``_shape_of``,
+    ``_dtype_of`` and ``_materialize`` alike). The case is still recorded,
+    with the FLOP delta preserved, rather than taking the worker down.
+    """
+    return {
+        "outcome": "record_failed",
+        "exc_type": type(exc).__name__,
         "flops": flops,
     }
 

--- a/tests/parity/observe.py
+++ b/tests/parity/observe.py
@@ -54,7 +54,7 @@ def fingerprint(value: Any) -> str:
 
 def _container_of(value: Any) -> str:
     if isinstance(value, tuple) and hasattr(value, "_fields"):
-        fields = ",".join(value._fields)
+        fields = ",".join(getattr(value, "_fields"))  # noqa: B009
         return f"namedtuple:{type(value).__name__}({fields})"
     if isinstance(value, tuple):
         return "tuple"

--- a/tests/parity/observe.py
+++ b/tests/parity/observe.py
@@ -1,0 +1,117 @@
+"""Record what a backend actually did. Pure functions, no backend imports.
+
+THE RULE: these functions RECORD, they do not NORMALISE. Materialising an array
+via ``tolist()`` is fine *because* dtype, shape and the Python type are recorded
+separately alongside it. Replacing those with the materialised value is what
+blinded ``tests/client_compat`` to every dtype divergence in the 2026-07-25
+audit.
+"""
+
+from __future__ import annotations
+
+import builtins
+import struct
+from typing import Any
+
+_BUILTIN_EXCEPTIONS = {
+    name
+    for name in dir(builtins)
+    if isinstance(getattr(builtins, name), type)
+    and issubclass(getattr(builtins, name), BaseException)
+}
+
+
+def fingerprint(value: Any) -> str:
+    """Return a canonical, exact string fingerprint of *value*.
+
+    Floats become their IEEE-754 bit pattern, so ``nan``, ``-0.0`` and last-ULP
+    differences are all distinguishable. Every scalar carries a type tag, so
+    ``1``, ``1.0`` and ``True`` never collide.
+    """
+    if isinstance(value, bool):
+        return f"b:{value}"
+    if isinstance(value, int):
+        return f"i:{value}"
+    if isinstance(value, float):
+        return "f:" + struct.pack(">d", value).hex()
+    if isinstance(value, complex):
+        return (
+            "c:"
+            + struct.pack(">d", value.real).hex()
+            + ":"
+            + struct.pack(">d", value.imag).hex()
+        )
+    if isinstance(value, str):
+        return f"s:{value}"
+    if isinstance(value, (bytes, bytearray)):
+        return "y:" + bytes(value).hex()
+    if value is None:
+        return "n:"
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(fingerprint(item) for item in value) + "]"
+    return f"?:{type(value).__name__}:{value!r}"
+
+
+def _container_of(value: Any) -> str:
+    if isinstance(value, tuple) and hasattr(value, "_fields"):
+        fields = ",".join(value._fields)
+        return f"namedtuple:{type(value).__name__}({fields})"
+    if isinstance(value, tuple):
+        return "tuple"
+    if isinstance(value, list):
+        return "list"
+    if hasattr(value, "shape") and hasattr(value, "tolist"):
+        return "array"
+    return "scalar"
+
+
+def _materialize(value: Any) -> Any:
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return tolist()
+    if isinstance(value, (list, tuple)):
+        return [_materialize(item) for item in value]
+    return value
+
+
+def observe_result(value: Any, flops: int) -> dict:
+    """Record a successful return."""
+    shape = getattr(value, "shape", None)
+    dtype = getattr(value, "dtype", None)
+    return {
+        "outcome": "returned",
+        "pytype": type(value).__name__,
+        "dtype": None if dtype is None else str(dtype),
+        "shape": None if shape is None else list(shape),
+        "container": _container_of(value),
+        "value": fingerprint(_materialize(value)),
+        "flops": flops,
+    }
+
+
+def observe_exception(exc: BaseException, flops: int) -> dict:
+    """Record a raised exception by CLASS, not by message.
+
+    Messages legitimately differ between backends and would be pure noise; the
+    class is the contract. The message is still carried for triage.
+    """
+    bases = [
+        cls.__name__
+        for cls in type(exc).__mro__[1:]
+        if cls.__name__ in _BUILTIN_EXCEPTIONS
+    ]
+    return {
+        "outcome": "raised",
+        "exc_type": type(exc).__name__,
+        "exc_bases": bases,
+        "exc_msg": str(exc),
+        "flops": flops,
+    }
+
+
+def observe_timeout(flops: int) -> dict:
+    return {"outcome": "timeout", "flops": flops}
+
+
+def observe_worker_died() -> dict:
+    return {"outcome": "worker_died", "flops": 0}

--- a/tests/parity/observe.py
+++ b/tests/parity/observe.py
@@ -91,13 +91,31 @@ def _materialize(value: Any) -> Any:
     return value
 
 
+#: The two backends' concrete array-wrapper classes. Two implementations of
+#: the same array type are necessarily two different classes, so comparing
+#: their raw names would report a "pytype" divergence on essentially every
+#: array-returning case, drowning any real signal. Collapsed here to one
+#: shared token. Scalar wrapper classes (e.g. the client's ``RemoteScalar``)
+#: are deliberately excluded from this collapse: a plain Python ``bool`` or
+#: ``int`` on one backend against a wrapper object on the other means a value
+#: failed to unwrap the way it should have, which is a real defect that
+#: "pytype" exists to catch.
+_ARRAY_WRAPPER_CLASS_NAMES = frozenset({"FlopscopeArray", "RemoteArray"})
+_ARRAY_WRAPPER_TOKEN = "<array-wrapper>"
+
+
+def _pytype_of(value: Any) -> str:
+    name = type(value).__name__
+    return _ARRAY_WRAPPER_TOKEN if name in _ARRAY_WRAPPER_CLASS_NAMES else name
+
+
 def observe_result(value: Any, flops: int) -> dict:
     """Record a successful return."""
     shape = getattr(value, "shape", None)
     dtype = getattr(value, "dtype", None)
     return {
         "outcome": "returned",
-        "pytype": type(value).__name__,
+        "pytype": _pytype_of(value),
         "dtype": None if dtype is None else str(dtype),
         "shape": None if shape is None else list(shape),
         "container": _container_of(value),

--- a/tests/parity/report.py
+++ b/tests/parity/report.py
@@ -1,0 +1,53 @@
+"""Render a parity run into something a human can act on.
+
+Coverage counts are printed on every run: silent truncation is what makes a
+green suite untrustworthy.
+"""
+
+from __future__ import annotations
+
+from tests.parity.allowlist import AllowlistResult
+from tests.parity.runner import RunResult
+
+
+def render(result: RunResult, allow: AllowlistResult, coverage: dict) -> str:
+    lines: list[str] = ["=== flopscope client/in-process parity ==="]
+
+    if result.infrastructure_failure:
+        lines.append(f"INFRASTRUCTURE FAILURE: {result.infrastructure_failure}")
+        return "\n".join(lines)
+
+    if coverage:
+        lines.append("")
+        lines.append("Coverage:")
+        for key, value in sorted(coverage.items()):
+            lines.append(f"  {key}: {value}")
+
+    lines.append("")
+    lines.append(f"Allowlist: {dict(sorted(allow.counts.items()))}")
+
+    if allow.unexplained:
+        lines.append("")
+        lines.append(f"UNEXPLAINED DIVERGENCES ({len(allow.unexplained)}):")
+        for divergence in allow.unexplained:
+            lines.append(
+                f"  {divergence.case_id} [{divergence.dimension}] "
+                f"inproc={divergence.inproc!r} client={divergence.client!r}"
+            )
+
+    if allow.stale:
+        lines.append("")
+        lines.append(f"STALE ALLOWLIST ENTRIES ({len(allow.stale)}) - delete these:")
+        for entry in allow.stale:
+            lines.append(f"  {entry.case_id} [{entry.dimension}] {entry.reason}")
+
+    if result.flaky:
+        lines.append("")
+        lines.append(f"FLAKY (quarantined, not parity failures) ({len(result.flaky)}):")
+        for case_id in result.flaky:
+            lines.append(f"  {case_id}")
+
+    if not allow.unexplained and not allow.stale:
+        lines.append("")
+        lines.append("No unexplained divergences and no stale entries.")
+    return "\n".join(lines)

--- a/tests/parity/report.py
+++ b/tests/parity/report.py
@@ -26,6 +26,19 @@ def render(result: RunResult, allow: AllowlistResult, coverage: dict) -> str:
     lines.append("")
     lines.append(f"Allowlist: {dict(sorted(allow.counts.items()))}")
 
+    if allow.match_counts:
+        lines.append("")
+        lines.append("Allowlist entries (match count - a glob can hide a lot):")
+        by_count = sorted(
+            allow.match_counts.items(),
+            key=lambda pair: (-pair[1], pair[0].case_id, pair[0].dimension),
+        )
+        for entry, count in by_count:
+            lines.append(
+                f"  [{count:>5}] {entry.case_id} [{entry.dimension}] "
+                f"({entry.category.value}) {entry.reason}"
+            )
+
     if allow.unexplained:
         lines.append("")
         lines.append(f"UNEXPLAINED DIVERGENCES ({len(allow.unexplained)}):")

--- a/tests/parity/runner.py
+++ b/tests/parity/runner.py
@@ -2,6 +2,12 @@
 
 The parent process MUST NOT import either backend: doing so silently pins one
 of them for the whole run. Only workers import a backend.
+
+A worker can die mid-corpus (a segfault in native code, for instance, which no
+Python ``try``/``except`` can catch). That must cost only the one in-flight
+case: the parent records that single case as ``worker_died`` and restarts a
+fresh worker on the cases after it, rather than backfilling every case the
+dead worker never got to as fake failures.
 """
 
 from __future__ import annotations
@@ -32,6 +38,18 @@ _CONNECTION_MARKERS = ("ConnectionError", "ZMQError", "Again")
 #: How much of a failing worker's stderr to fold into the infrastructure
 #: failure message; the full text still lives on ``RunResult.stderr``.
 _STDERR_EXCERPT_LEN = 500
+#: Hard ceiling on how many times ``_run_backend`` will restart a dying
+#: worker for one backend's run. Without this, a corpus that kills the
+#: worker on literally every case (e.g. a broken import) would restart
+#: forever, one case at a time, and never finish.
+_MAX_WORKER_RESTARTS = 50
+#: A worker that needed at least this many restarts is not "unlucky on a
+#: couple of cases" any more: it is trending toward burning through the
+#: whole restart budget above, which itself always counts as
+#: infrastructure. Set well under the cap (a fifth of it) so a run that is
+#: clearly heading for exhaustion is reported honestly rather than only
+#: once it actually hits the ceiling.
+_SYSTEMIC_RESTART_THRESHOLD = 10
 
 
 @dataclass
@@ -40,16 +58,43 @@ class RunResult:
     flaky: list[str] = field(default_factory=list)
     observations: dict[str, dict[str, dict]] = field(default_factory=dict)
     #: Captured worker stderr from each backend's first run, keyed by backend
-    #: name. Empty string when a backend produced no stderr output.
+    #: name. Empty string when a backend produced no stderr output. When a
+    #: worker was restarted mid-run, this is every restart's stderr for that
+    #: run, concatenated in order.
     stderr: dict[str, str] = field(default_factory=dict)
+    #: How many times each backend's worker was restarted after dying
+    #: mid-corpus, keyed by backend name, from each backend's first run. 0
+    #: for a clean run; a nonzero count is normal (one segfaulting case
+    #: costs exactly one restart) but a large one is a red flag on its own -
+    #: see ``_looks_like_infrastructure``.
+    restarts: dict[str, int] = field(default_factory=dict)
     infrastructure_failure: str | None = None
 
 
-def _run_backend(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str]:
-    """Run the whole corpus on one backend.
+def _run_worker(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str]:
+    """Run *cases* through exactly ONE worker process; no restart on death.
 
-    Returns ``(observations by case id, captured stderr text)``. ``stderr`` is
-    ``""`` when the worker produced none.
+    Returns ``(observations by case id for every case the worker actually
+    emitted a record for, captured stderr text)``. ``stderr`` is ``""`` when
+    the worker produced none. If the worker dies partway through *cases*, the
+    returned dict simply has fewer entries than ``cases`` - the caller
+    (``_run_backend``) is what turns "fewer entries than expected" into a
+    ``worker_died`` record and a restart; this function only ever reports
+    what the worker actually said.
+
+    Empirically verified (not just assumed): the worker flushes stdout after
+    every case (see ``worker.run_stream``), and a killed child's already
+    -flushed writes are sitting in the OS pipe buffer, which survives the
+    process's death - closing the write end just signals EOF to the reader.
+    ``subprocess.run`` drains stdout concurrently while the child runs, so
+    nothing flushed before a segfault is lost. Confirmed by feeding a worker
+    two cheap cases followed by the real segfaulting
+    ``grid/random.Generator.spawn::scalar-operand`` case: the worker exits
+    139 with no traceback, and stdout still contains the two prior cases'
+    records in full. Because of this, cases are fed to the worker in one
+    shot per restart (the whole remaining slice), not in small chunks: there
+    is nothing further to lose to buffering, and chunking would only add
+    process-spawn overhead.
     """
     env = dict(os.environ)
     env["PYTHONPATH"] = _ROOT + os.pathsep + env.get("PYTHONPATH", "")
@@ -69,9 +114,10 @@ def _run_backend(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str]
         stderr = proc.stderr
     except subprocess.TimeoutExpired as exc:
         # A hung worker never gets to print anything more; treat whatever it
-        # emitted before the hang as final and let the setdefault loop below
-        # fill in the rest as worker_died so a stuck backend can't wedge the
-        # whole run.
+        # emitted before the hang as final. `_run_backend` treats a timeout
+        # exactly like a death: the next unrecorded case is marked
+        # worker_died and a fresh worker resumes after it, so a stuck
+        # backend can't wedge the whole run.
         stdout = exc.stdout if isinstance(exc.stdout, str) else ""
         stderr = exc.stderr if isinstance(exc.stderr, str) else ""
     out: dict[str, dict] = {}
@@ -81,26 +127,90 @@ def _run_backend(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str]
             continue
         record = json.loads(line)
         out[record.pop("id")] = record
-    # A worker that died mid-corpus leaves later cases unrecorded.
-    for case in cases:
-        out.setdefault(case.id, observe_worker_died())
     return out, stderr or ""
 
 
-def _looks_like_infrastructure(observations: dict[str, dict]) -> bool:
-    """A backend counts as having failed to run the corpus — as opposed to
-    merely producing individual failing cases — when either:
+def _run_backend(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str, int]:
+    """Run the whole corpus on one backend, restarting the worker on death.
 
+    Feeds *cases* to a worker via ``_run_worker``. If the worker exits before
+    every case in the slice it was given got a record, exactly ONE case pays
+    for that death - the next case after the ones it did emit records for,
+    per the worker's in-order-per-line protocol - and a fresh worker resumes
+    from the case after that. This repeats until every case has a record or
+    ``_MAX_WORKER_RESTARTS`` is exhausted, at which point every remaining
+    case is marked ``worker_died`` and the loop stops (so a pathological
+    corpus that kills the worker on every case cannot loop forever).
+
+    Returns ``(observations by case id, captured stderr text, restart
+    count)``. ``stderr`` is every worker invocation's stderr for this run,
+    concatenated in order (empty ones dropped); ``""`` when none produced
+    any.
+    """
+    out: dict[str, dict] = {}
+    stderr_chunks: list[str] = []
+    restarts = 0
+    start = 0
+    while start < len(cases):
+        remaining = cases[start:]
+        emitted, stderr_text = _run_worker(backend, remaining)
+        if stderr_text:
+            stderr_chunks.append(stderr_text)
+        out.update(emitted)
+        if len(emitted) >= len(remaining):
+            # The worker produced a record for every case it was given: it
+            # made it through the rest of the corpus.
+            break
+        # The worker died (or hung and was killed on timeout) before
+        # finishing. It emits one record per case, in order, so the count of
+        # records it did emit is exactly how far it got; the next case in
+        # the slice it was fed is the one that killed it.
+        died_case = cases[start + len(emitted)]
+        out[died_case.id] = observe_worker_died()
+        start = start + len(emitted) + 1
+        if start >= len(cases):
+            break  # that was the last case; nothing left to resume.
+        if restarts >= _MAX_WORKER_RESTARTS:
+            # Restart budget exhausted: stop trying to resume and mark
+            # everything still unrun as dead, same as a single run used to
+            # do for the whole corpus.
+            for case in cases[start:]:
+                out.setdefault(case.id, observe_worker_died())
+            break
+        restarts += 1
+    return out, "\n".join(stderr_chunks), restarts
+
+
+def _looks_like_infrastructure(
+    observations: dict[str, dict], restarts: int = 0
+) -> bool:
+    """A backend counts as having failed to run the corpus — as opposed to
+    merely producing individual failing cases — when any of:
+
+    - the worker needed ``_SYSTEMIC_RESTART_THRESHOLD`` or more restarts to
+      get through the corpus (this subsumes hitting ``_MAX_WORKER_RESTARTS``
+      outright, since the cap is well above the threshold). Now that a dying
+      worker costs only the one case that killed it, a handful of restarts
+      (one segfaulting case among thousands, say) is normal and expected;
+      this many is the worker dying over and over, not bad luck on a couple
+      of cases,
     - a majority of cases never got the chance to raise anything (the worker
-      died outright, so there is no exception to compare), or
+      died outright, so there is no exception to compare) — kept as a
+      fallback for callers that pass observations without a restart count,
+      and for the pathological case of a corpus so small the restart cap
+      fills it with ``worker_died`` before ``_SYSTEMIC_RESTART_THRESHOLD`` is
+      reached, or
     - a majority raised the exact same transport-failure exception type.
 
-    The "exact same type" requirement is deliberate: a corpus where different
-    cases fail for different reasons (including a domain exception a corpus
-    family provokes on purpose, e.g. ``NoBudgetContextError``) is real
-    per-case signal, not a broken backend, and must not be swallowed here.
+    The "exact same type" requirement on the last one is deliberate: a corpus
+    where different cases fail for different reasons (including a domain
+    exception a corpus family provokes on purpose, e.g.
+    ``NoBudgetContextError``) is real per-case signal, not a broken backend,
+    and must not be swallowed here.
     """
     if not observations:
+        return True
+    if restarts >= _SYSTEMIC_RESTART_THRESHOLD:
         return True
     total = len(observations)
     died = sum(
@@ -142,18 +252,25 @@ def run_corpus(cases: list[Case]) -> RunResult:
     server = start_server()
     try:
         for backend in _BACKENDS:
-            observations, stderr_text = _run_backend(backend, cases)
+            observations, stderr_text, restarts = _run_backend(backend, cases)
             first[backend] = observations
             result.stderr[backend] = stderr_text
-            if _looks_like_infrastructure(first[backend]):
+            result.restarts[backend] = restarts
+            if _looks_like_infrastructure(first[backend], restarts):
                 excerpt = stderr_text.strip()[:_STDERR_EXCERPT_LEN]
                 detail = f" worker stderr: {excerpt!r}" if excerpt else ""
+                restart_note = (
+                    f" ({restarts} worker restart{'s' if restarts != 1 else ''})"
+                    if restarts
+                    else ""
+                )
                 result.infrastructure_failure = (
                     f"{backend} backend failed to run the corpus; this is an "
-                    f"infrastructure failure, not a parity failure.{detail}"
+                    f"infrastructure failure, not a parity failure."
+                    f"{restart_note}{detail}"
                 )
                 return result
-            second[backend], _ = _run_backend(backend, cases)
+            second[backend], _, _ = _run_backend(backend, cases)
     finally:
         stop_server(server)
 

--- a/tests/parity/runner.py
+++ b/tests/parity/runner.py
@@ -1,0 +1,126 @@
+"""Drive both backends over the corpus and diff the results.
+
+The parent process MUST NOT import either backend: doing so silently pins one
+of them for the whole run. Only workers import a backend.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+from tests.client_compat._server_fixture import start_server, stop_server
+from tests.parity.case import Case
+from tests.parity.compare import Divergence, compare_observations
+from tests.parity.observe import observe_worker_died
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_BACKENDS = ("inproc", "client")
+_CASE_TIMEOUT_S = 30.0
+#: Hard ceiling on one backend's whole-corpus run, regardless of case count.
+_RUN_TIMEOUT_CAP_S = 1800.0
+_CONNECTION_MARKERS = ("ConnectionError", "Again", "ZMQError", "NoBudgetContext")
+
+
+@dataclass
+class RunResult:
+    divergences: list[Divergence] = field(default_factory=list)
+    flaky: list[str] = field(default_factory=list)
+    observations: dict[str, dict[str, dict]] = field(default_factory=dict)
+    infrastructure_failure: str | None = None
+
+
+def _run_backend(backend: str, cases: list[Case]) -> dict[str, dict]:
+    """Run the whole corpus on one backend; return observations by case id."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    payload = "".join(json.dumps(case.to_json()) + "\n" for case in cases)
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "tests.parity.worker", f"--backend={backend}"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=_ROOT,
+            env=env,
+            timeout=min(_CASE_TIMEOUT_S * max(len(cases), 1), _RUN_TIMEOUT_CAP_S),
+            check=False,
+        )
+        stdout = proc.stdout
+    except subprocess.TimeoutExpired as exc:
+        # A hung worker never gets to print anything more; treat whatever it
+        # emitted before the hang as final and let the setdefault loop below
+        # fill in the rest as worker_died so a stuck backend can't wedge the
+        # whole run.
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+    out: dict[str, dict] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        record = json.loads(line)
+        out[record.pop("id")] = record
+    # A worker that died mid-corpus leaves later cases unrecorded.
+    for case in cases:
+        out.setdefault(case.id, observe_worker_died())
+    return out
+
+
+def _looks_like_infrastructure(observations: dict[str, dict]) -> bool:
+    if not observations:
+        return True
+    bad = sum(
+        1
+        for obs in observations.values()
+        if obs.get("outcome") == "worker_died"
+        or any(marker in str(obs.get("exc_type", "")) for marker in _CONNECTION_MARKERS)
+    )
+    return bad > len(observations) // 2
+
+
+def run_corpus(cases: list[Case]) -> RunResult:
+    """Run *cases* on both backends twice each and diff the results.
+
+    The client backend needs a live flopscope-server. ``start_server`` sets
+    ``FLOPSCOPE_SERVER_URL`` in this process's environment, which
+    ``_run_backend`` inherits into the worker; it also allocates a per-xdist
+    -worker port, so concurrent pytest workers do not collide.
+    """
+    result = RunResult()
+    first: dict[str, dict[str, dict]] = {}
+    second: dict[str, dict[str, dict]] = {}
+
+    server = start_server()
+    try:
+        for backend in _BACKENDS:
+            first[backend] = _run_backend(backend, cases)
+            if _looks_like_infrastructure(first[backend]):
+                result.infrastructure_failure = (
+                    f"{backend} backend failed to run the corpus; this is an "
+                    f"infrastructure failure, not a parity failure"
+                )
+                return result
+            second[backend] = _run_backend(backend, cases)
+    finally:
+        stop_server(server)
+
+    result.observations = first
+
+    for case in cases:
+        # Self-check: a backend that disagrees with itself is nondeterministic.
+        flaky = any(
+            first[backend].get(case.id) != second[backend].get(case.id)
+            for backend in _BACKENDS
+        )
+        if flaky:
+            result.flaky.append(case.id)
+            continue
+        result.divergences.extend(
+            compare_observations(
+                case.id, first["inproc"][case.id], first["client"][case.id]
+            )
+        )
+    return result

--- a/tests/parity/runner.py
+++ b/tests/parity/runner.py
@@ -26,6 +26,12 @@ from tests.parity.observe import observe_worker_died
 
 _ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _BACKENDS = ("inproc", "client")
+#: Own port range for this harness's server, well clear of
+#: ``tests/client_compat``'s (15571 + one slot per xdist worker, so up to the
+#: high 15500s on a many-core CI box). A leaked or TIME_WAIT-lingering server
+#: from that suite must never be mistakable for this harness's own — the two
+#: harnesses can otherwise run back-to-back in the same CI job.
+_PARITY_BASE_PORT = 15671
 _CASE_TIMEOUT_S = 30.0
 #: Hard ceiling on one backend's whole-corpus run, regardless of case count.
 _RUN_TIMEOUT_CAP_S = 1800.0
@@ -37,7 +43,7 @@ _RUN_TIMEOUT_CAP_S = 1800.0
 _CONNECTION_MARKERS = ("ConnectionError", "ZMQError", "Again")
 #: How much of a failing worker's stderr to fold into the infrastructure
 #: failure message; the full text still lives on ``RunResult.stderr``.
-_STDERR_EXCERPT_LEN = 500
+_STDERR_EXCERPT_LEN = 2500
 #: Hard ceiling on how many times ``_run_backend`` will restart a dying
 #: worker for one backend's run. Without this, a corpus that kills the
 #: worker on literally every case (e.g. a broken import) would restart
@@ -249,7 +255,7 @@ def run_corpus(cases: list[Case]) -> RunResult:
     first: dict[str, dict[str, dict]] = {}
     second: dict[str, dict[str, dict]] = {}
 
-    server = start_server()
+    server = start_server(_PARITY_BASE_PORT)
     try:
         for backend in _BACKENDS:
             observations, stderr_text, restarts = _run_backend(backend, cases)
@@ -257,7 +263,10 @@ def run_corpus(cases: list[Case]) -> RunResult:
             result.stderr[backend] = stderr_text
             result.restarts[backend] = restarts
             if _looks_like_infrastructure(first[backend], restarts):
-                excerpt = stderr_text.strip()[:_STDERR_EXCERPT_LEN]
+                # Keep the TAIL, not the head: a Python traceback puts the
+                # exception type and message last, so truncating from the front
+                # reliably discards the only part worth reading.
+                excerpt = stderr_text.strip()[-_STDERR_EXCERPT_LEN:]
                 detail = f" worker stderr: {excerpt!r}" if excerpt else ""
                 restart_note = (
                     f" ({restarts} worker restart{'s' if restarts != 1 else ''})"

--- a/tests/parity/runner.py
+++ b/tests/parity/runner.py
@@ -10,6 +10,7 @@ import json
 import os
 import subprocess
 import sys
+from collections import Counter
 from dataclasses import dataclass, field
 
 from tests.client_compat._server_fixture import start_server, stop_server
@@ -22,7 +23,15 @@ _BACKENDS = ("inproc", "client")
 _CASE_TIMEOUT_S = 30.0
 #: Hard ceiling on one backend's whole-corpus run, regardless of case count.
 _RUN_TIMEOUT_CAP_S = 1800.0
-_CONNECTION_MARKERS = ("ConnectionError", "Again", "ZMQError", "NoBudgetContext")
+#: Genuine transport failures only. A domain exception (e.g.
+#: ``NoBudgetContextError``) that a corpus deliberately provokes on both
+#: backends must NOT appear here: it would make a majority of a legitimate
+#: corpus family look like a dead backend and silently swallow every
+#: divergence.
+_CONNECTION_MARKERS = ("ConnectionError", "ZMQError", "Again")
+#: How much of a failing worker's stderr to fold into the infrastructure
+#: failure message; the full text still lives on ``RunResult.stderr``.
+_STDERR_EXCERPT_LEN = 500
 
 
 @dataclass
@@ -30,11 +39,18 @@ class RunResult:
     divergences: list[Divergence] = field(default_factory=list)
     flaky: list[str] = field(default_factory=list)
     observations: dict[str, dict[str, dict]] = field(default_factory=dict)
+    #: Captured worker stderr from each backend's first run, keyed by backend
+    #: name. Empty string when a backend produced no stderr output.
+    stderr: dict[str, str] = field(default_factory=dict)
     infrastructure_failure: str | None = None
 
 
-def _run_backend(backend: str, cases: list[Case]) -> dict[str, dict]:
-    """Run the whole corpus on one backend; return observations by case id."""
+def _run_backend(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str]:
+    """Run the whole corpus on one backend.
+
+    Returns ``(observations by case id, captured stderr text)``. ``stderr`` is
+    ``""`` when the worker produced none.
+    """
     env = dict(os.environ)
     env["PYTHONPATH"] = _ROOT + os.pathsep + env.get("PYTHONPATH", "")
     payload = "".join(json.dumps(case.to_json()) + "\n" for case in cases)
@@ -50,12 +66,14 @@ def _run_backend(backend: str, cases: list[Case]) -> dict[str, dict]:
             check=False,
         )
         stdout = proc.stdout
+        stderr = proc.stderr
     except subprocess.TimeoutExpired as exc:
         # A hung worker never gets to print anything more; treat whatever it
         # emitted before the hang as final and let the setdefault loop below
         # fill in the rest as worker_died so a stuck backend can't wedge the
         # whole run.
         stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
     out: dict[str, dict] = {}
     for line in stdout.splitlines():
         line = line.strip()
@@ -66,19 +84,41 @@ def _run_backend(backend: str, cases: list[Case]) -> dict[str, dict]:
     # A worker that died mid-corpus leaves later cases unrecorded.
     for case in cases:
         out.setdefault(case.id, observe_worker_died())
-    return out
+    return out, stderr or ""
 
 
 def _looks_like_infrastructure(observations: dict[str, dict]) -> bool:
+    """A backend counts as having failed to run the corpus — as opposed to
+    merely producing individual failing cases — when either:
+
+    - a majority of cases never got the chance to raise anything (the worker
+      died outright, so there is no exception to compare), or
+    - a majority raised the exact same transport-failure exception type.
+
+    The "exact same type" requirement is deliberate: a corpus where different
+    cases fail for different reasons (including a domain exception a corpus
+    family provokes on purpose, e.g. ``NoBudgetContextError``) is real
+    per-case signal, not a broken backend, and must not be swallowed here.
+    """
     if not observations:
         return True
-    bad = sum(
-        1
-        for obs in observations.values()
-        if obs.get("outcome") == "worker_died"
-        or any(marker in str(obs.get("exc_type", "")) for marker in _CONNECTION_MARKERS)
+    total = len(observations)
+    died = sum(
+        1 for obs in observations.values() if obs.get("outcome") == "worker_died"
     )
-    return bad > len(observations) // 2
+    if died > total // 2:
+        return True
+    transport_exc_types = [
+        str(obs.get("exc_type", ""))
+        for obs in observations.values()
+        if any(marker in str(obs.get("exc_type", "")) for marker in _CONNECTION_MARKERS)
+    ]
+    if not transport_exc_types:
+        return False
+    _most_common_type, most_common_count = Counter(transport_exc_types).most_common(1)[
+        0
+    ]
+    return most_common_count > total // 2
 
 
 def run_corpus(cases: list[Case]) -> RunResult:
@@ -89,6 +129,12 @@ def run_corpus(cases: list[Case]) -> RunResult:
     ``_run_backend`` inherits into the worker; it also allocates a per-xdist
     -worker port, so concurrent pytest workers do not collide.
     """
+    if not cases:
+        # A later stage that filters cases by tag can legitimately end up
+        # with nothing to run; that is a trivially clean result, not an
+        # infrastructure failure.
+        return RunResult()
+
     result = RunResult()
     first: dict[str, dict[str, dict]] = {}
     second: dict[str, dict[str, dict]] = {}
@@ -96,14 +142,18 @@ def run_corpus(cases: list[Case]) -> RunResult:
     server = start_server()
     try:
         for backend in _BACKENDS:
-            first[backend] = _run_backend(backend, cases)
+            observations, stderr_text = _run_backend(backend, cases)
+            first[backend] = observations
+            result.stderr[backend] = stderr_text
             if _looks_like_infrastructure(first[backend]):
+                excerpt = stderr_text.strip()[:_STDERR_EXCERPT_LEN]
+                detail = f" worker stderr: {excerpt!r}" if excerpt else ""
                 result.infrastructure_failure = (
                     f"{backend} backend failed to run the corpus; this is an "
-                    f"infrastructure failure, not a parity failure"
+                    f"infrastructure failure, not a parity failure.{detail}"
                 )
                 return result
-            second[backend] = _run_backend(backend, cases)
+            second[backend], _ = _run_backend(backend, cases)
     finally:
         stop_server(server)
 

--- a/tests/parity/runner.py
+++ b/tests/parity/runner.py
@@ -77,6 +77,19 @@ class RunResult:
     infrastructure_failure: str | None = None
 
 
+def _as_text(value) -> str:
+    """Decode subprocess output that may arrive as bytes.
+
+    ``TimeoutExpired`` carries bytes on ``.stdout``/``.stderr`` even when the
+    call requested text mode, so callers must not assume ``str``.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value).decode("utf-8", "replace")
+    return ""
+
+
 def _run_worker(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str]:
     """Run *cases* through exactly ONE worker process; no restart on death.
 
@@ -124,8 +137,14 @@ def _run_worker(backend: str, cases: list[Case]) -> tuple[dict[str, dict], str]:
         # exactly like a death: the next unrecorded case is marked
         # worker_died and a fresh worker resumes after it, so a stuck
         # backend can't wedge the whole run.
-        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
-        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        # `TimeoutExpired` carries BYTES on .stdout/.stderr even when the call
+        # passed text=True, so treating a non-str as "no output" would discard
+        # every record the worker flushed before it hung. `_run_backend` would
+        # then blame the first case of the remaining slice instead of the one
+        # that actually hung, misattributing the death and re-running cases the
+        # worker had already completed.
+        stdout = _as_text(exc.stdout)
+        stderr = _as_text(exc.stderr)
     out: dict[str, dict] = {}
     for line in stdout.splitlines():
         line = line.strip()
@@ -287,8 +306,18 @@ def run_corpus(cases: list[Case]) -> RunResult:
 
     for case in cases:
         # Self-check: a backend that disagrees with itself is nondeterministic.
+        # Compare only the modeled dimensions, via the same comparator used for
+        # the real diff. Comparing whole records would also compare `exc_msg`,
+        # which the comparator deliberately ignores because messages carry
+        # process-specific detail like memory addresses -- a case whose message
+        # merely differs between two worker processes would be quarantined and
+        # then skipped entirely, silently shrinking what the gate compares.
         flaky = any(
-            first[backend].get(case.id) != second[backend].get(case.id)
+            compare_observations(
+                case.id,
+                first[backend].get(case.id, {}),
+                second[backend].get(case.id, {}),
+            )
             for backend in _BACKENDS
         )
         if flaky:

--- a/tests/parity/test_allowlist_unit.py
+++ b/tests/parity/test_allowlist_unit.py
@@ -1,0 +1,93 @@
+"""Strictness runs in BOTH directions: unexplained divergences fail, and so do
+stale entries. Fixing a bug therefore forces deletion of its entry in the same
+pull request, so the list cannot accumulate dead weight."""
+
+from __future__ import annotations
+
+from tests.parity.allowlist import Category, Entry, apply, validate_entries
+from tests.parity.compare import Divergence
+
+_DIV = Divergence("idiom/complex-mul", "outcome", "returned", "raised")
+
+_ENTRY = Entry(
+    case_id="idiom/complex-mul",
+    dimension="outcome",
+    category=Category.KNOWN_BUG,
+    reason="Family 4: Python complex falls through _encode_arg.",
+    issue="https://github.com/AIcrowd/flopscope/issues/1",
+)
+
+
+def test_unexplained_divergence_is_reported():
+    result = apply([_DIV], entries=())
+    assert result.unexplained == [_DIV]
+    assert result.stale == []
+
+
+def test_explained_divergence_is_allowed():
+    result = apply([_DIV], entries=(_ENTRY,))
+    assert result.unexplained == []
+    assert result.allowed == [_DIV]
+
+
+def test_stale_entry_is_reported():
+    result = apply([], entries=(_ENTRY,))
+    assert result.stale == [_ENTRY]
+
+
+def test_allowlist_is_keyed_per_dimension_not_per_case():
+    value_div = Divergence("idiom/complex-mul", "value", "f:aa", "f:bb")
+    result = apply([_DIV, value_div], entries=(_ENTRY,))
+    assert result.allowed == [_DIV]
+    assert result.unexplained == [value_div]
+
+
+def test_counts_are_reported_per_category():
+    result = apply([_DIV], entries=(_ENTRY,))
+    assert result.counts["known-bug"] == 1
+    assert result.counts["proxy-inherent"] == 0
+
+
+def test_known_bug_without_issue_fails_validation():
+    bad = Entry(
+        case_id="a/b",
+        dimension="value",
+        category=Category.KNOWN_BUG,
+        reason="tracked",
+        issue=None,
+    )
+    problems = validate_entries((bad,))
+    assert any("requires an issue link" in p for p in problems)
+
+
+def test_empty_reason_fails_validation():
+    bad = Entry(
+        case_id="a/b",
+        dimension="value",
+        category=Category.PROXY_INHERENT,
+        reason="   ",
+    )
+    problems = validate_entries((bad,))
+    assert any("non-empty reason" in p for p in problems)
+
+
+def test_unknown_dimension_fails_validation():
+    bad = Entry(
+        case_id="a/b",
+        dimension="colour",
+        category=Category.PROXY_INHERENT,
+        reason="n/a",
+    )
+    problems = validate_entries((bad,))
+    assert any("not a known dimension" in p for p in problems)
+
+
+def test_duplicate_entries_fail_validation():
+    problems = validate_entries((_ENTRY, _ENTRY))
+    assert any("duplicate" in p for p in problems)
+
+
+def test_shipped_entries_are_valid():
+    from tests.parity.allowlist import ENTRIES
+
+    assert validate_entries(ENTRIES) == []

--- a/tests/parity/test_allowlist_unit.py
+++ b/tests/parity/test_allowlist_unit.py
@@ -91,3 +91,69 @@ def test_shipped_entries_are_valid():
     from tests.parity.allowlist import ENTRIES
 
     assert validate_entries(ENTRIES) == []
+
+
+def test_glob_case_id_matches_every_case_it_covers():
+    glob_entry = Entry(
+        case_id="grid/fft.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason="Family 9: fft submodule is missing from the client surface.",
+        issue="INTERNAL-P4-family-9",
+    )
+    div_a = Divergence("grid/fft.rfft::array", "outcome", "returned", "raised")
+    div_b = Divergence("grid/fft.fftn::vector", "outcome", "returned", "raised")
+    result = apply([div_a, div_b], entries=(glob_entry,))
+    assert result.unexplained == []
+    assert result.stale == []
+    assert set(result.allowed) == {div_a, div_b}
+
+
+def test_glob_case_id_does_not_match_outside_its_pattern():
+    glob_entry = Entry(
+        case_id="grid/fft.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason="Family 9.",
+        issue="INTERNAL-P4-family-9",
+    )
+    unrelated = Divergence("grid/sum::array", "outcome", "returned", "raised")
+    result = apply([unrelated], entries=(glob_entry,))
+    assert result.unexplained == [unrelated]
+    # The entry matched nothing, so it is stale, exactly like a literal entry.
+    assert result.stale == [glob_entry]
+
+
+def test_glob_entry_still_requires_dimension_to_match_exactly():
+    glob_entry = Entry(
+        case_id="grid/fft.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason="Family 9.",
+        issue="INTERNAL-P4-family-9",
+    )
+    value_div = Divergence("grid/fft.rfft::array", "value", "1", "2")
+    result = apply([value_div], entries=(glob_entry,))
+    assert result.unexplained == [value_div]
+    assert result.stale == [glob_entry]
+
+
+def test_match_counts_are_reported_per_entry():
+    glob_entry = Entry(
+        case_id="grid/fft.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason="Family 9.",
+        issue="INTERNAL-P4-family-9",
+    )
+    div_a = Divergence("grid/fft.rfft::array", "outcome", "returned", "raised")
+    div_b = Divergence("grid/fft.fftn::vector", "outcome", "returned", "raised")
+    result = apply([_DIV, div_a, div_b], entries=(_ENTRY, glob_entry))
+    assert result.match_counts[_ENTRY] == 1
+    assert result.match_counts[glob_entry] == 2
+
+
+def test_unmatched_entry_has_a_zero_match_count():
+    result = apply([], entries=(_ENTRY,))
+    assert result.match_counts[_ENTRY] == 0
+    assert result.stale == [_ENTRY]

--- a/tests/parity/test_case_unit.py
+++ b/tests/parity/test_case_unit.py
@@ -38,3 +38,14 @@ def test_case_is_hashable_and_frozen():
     assert {case}
     with pytest.raises(AttributeError):
         case.source = "2"  # type: ignore[misc]
+
+
+def test_id_segments_must_be_non_empty():
+    for bad in ("/", "foo/", "/bar"):
+        with pytest.raises(ValueError, match="must be '<source>/<name>'"):
+            Case(id=bad, source="1")
+
+
+def test_id_name_segment_may_contain_slashes():
+    # Names legitimately contain further separators, e.g. grid op ids.
+    assert Case(id="grid/fft.rfft::axis-int", source="1").id.startswith("grid/")

--- a/tests/parity/test_case_unit.py
+++ b/tests/parity/test_case_unit.py
@@ -1,0 +1,40 @@
+"""Unit tests for the Case descriptor. Pure — no backend, no server."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.parity.case import Case
+
+
+def test_round_trips_through_json():
+    case = Case(
+        id="idiom/slice-bound-remote",
+        source="V[: fnp.argmax(V)]",
+        setup="",
+        tags=frozenset({"family:4", "tier:fast"}),
+    )
+    assert Case.from_json(case.to_json()) == case
+
+
+def test_tags_are_order_independent_in_json():
+    a = Case(id="x/y", source="1", tags=frozenset({"b", "a"}))
+    b = Case(id="x/y", source="1", tags=frozenset({"a", "b"}))
+    assert a.to_json() == b.to_json()
+
+
+def test_family_extracts_the_family_tag():
+    assert Case(id="x/y", source="1", tags=frozenset({"family:6"})).family() == "6"
+    assert Case(id="x/y", source="1").family() is None
+
+
+def test_id_must_be_structured():
+    with pytest.raises(ValueError, match="must be '<source>/<name>'"):
+        Case(id="noslash", source="1")
+
+
+def test_case_is_hashable_and_frozen():
+    case = Case(id="x/y", source="1")
+    assert {case}
+    with pytest.raises(AttributeError):
+        case.source = "2"  # type: ignore[misc]

--- a/tests/parity/test_compare_unit.py
+++ b/tests/parity/test_compare_unit.py
@@ -1,0 +1,99 @@
+"""Meta-tests: prove the comparator can SEE each dimension.
+
+A parity harness that silently detects nothing is worse than none, because it
+manufactures confidence. Each test below breaks exactly one dimension and
+asserts the comparator reports exactly that dimension.
+"""
+
+from __future__ import annotations
+
+from tests.parity.compare import compare_observations
+from tests.parity.observe import observe_exception, observe_result
+
+
+def _returned(**overrides) -> dict:
+    base = observe_result(1.0, flops=10)
+    base.update(overrides)
+    return base
+
+
+def _dims(inproc: dict, client: dict) -> set[str]:
+    return {d.dimension for d in compare_observations("x/y", inproc, client)}
+
+
+def test_identical_observations_produce_no_divergence():
+    assert compare_observations("x/y", _returned(), _returned()) == []
+
+
+def test_detects_outcome():
+    inproc = _returned()
+    client = observe_exception(TypeError("nope"), flops=10)
+    assert _dims(inproc, client) == {"outcome"}
+
+
+def test_detects_value():
+    assert _dims(_returned(), _returned(value="f:different")) == {"value"}
+
+
+def test_detects_dtype():
+    assert _dims(_returned(dtype="float32"), _returned(dtype="float64")) == {"dtype"}
+
+
+def test_detects_shape():
+    assert _dims(_returned(shape=[2, 3]), _returned(shape=[6])) == {"shape"}
+
+
+def test_detects_container():
+    assert _dims(_returned(container="tuple"), _returned(container="list")) == {
+        "container"
+    }
+
+
+def test_detects_pytype():
+    assert _dims(_returned(pytype="bool"), _returned(pytype="RemoteScalar")) == {
+        "pytype"
+    }
+
+
+def test_detects_flops():
+    assert _dims(_returned(flops=3198), _returned(flops=0)) == {"flops"}
+
+
+def test_detects_exception_class():
+    inproc = observe_exception(IndexError("a"), flops=1)
+    client = observe_exception(RuntimeError("b"), flops=1)
+    dims = _dims(inproc, client)
+    assert "exc_type" in dims
+
+
+def test_ignores_exception_message_differences():
+    inproc = observe_exception(IndexError("index 10 is out of bounds"), flops=1)
+    client = observe_exception(IndexError("out of range"), flops=1)
+    assert _dims(inproc, client) == set()
+
+
+def test_flops_compared_even_when_both_raise():
+    # The billing family: both raise, but only one charged for it.
+    inproc = observe_exception(TypeError("x"), flops=0)
+    client = observe_exception(TypeError("x"), flops=341648)
+    assert _dims(inproc, client) == {"flops"}
+
+
+def test_value_dimensions_skipped_when_both_raise():
+    inproc = observe_exception(TypeError("x"), flops=0)
+    client = observe_exception(TypeError("x"), flops=0)
+    assert _dims(inproc, client) == set()
+
+
+def test_reports_multiple_dimensions_independently():
+    inproc = _returned(dtype="float32", flops=10)
+    client = _returned(dtype="float64", flops=20)
+    assert _dims(inproc, client) == {"dtype", "flops"}
+
+
+def test_divergence_carries_both_sides():
+    (div,) = compare_observations("x/y", _returned(dtype="a"), _returned(dtype="b"))
+    assert div.case_id == "x/y"
+    assert div.dimension == "dtype"
+    assert div.inproc == "a"
+    assert div.client == "b"

--- a/tests/parity/test_compare_unit.py
+++ b/tests/parity/test_compare_unit.py
@@ -17,6 +17,12 @@ def _returned(**overrides) -> dict:
     return base
 
 
+def _raised(**overrides) -> dict:
+    base = observe_exception(ValueError("x"), flops=10)
+    base.update(overrides)
+    return base
+
+
 def _dims(inproc: dict, client: dict) -> set[str]:
     return {d.dimension for d in compare_observations("x/y", inproc, client)}
 
@@ -60,10 +66,10 @@ def test_detects_flops():
 
 
 def test_detects_exception_class():
+    # IndexError and KeyError share builtin ancestry, so only exc_type differs.
     inproc = observe_exception(IndexError("a"), flops=1)
-    client = observe_exception(RuntimeError("b"), flops=1)
-    dims = _dims(inproc, client)
-    assert "exc_type" in dims
+    client = observe_exception(KeyError("b"), flops=1)
+    assert _dims(inproc, client) == {"exc_type"}
 
 
 def test_ignores_exception_message_differences():
@@ -72,11 +78,33 @@ def test_ignores_exception_message_differences():
     assert _dims(inproc, client) == set()
 
 
+def test_detects_exception_ancestry_in_isolation():
+    # Same class name, different builtin ancestry: exactly the drift that
+    # happens when an exception is reconstructed across the wire.
+    inproc = _raised(exc_bases=["Exception", "BaseException"])
+    client = _raised(exc_bases=["LookupError", "Exception", "BaseException"])
+    assert _dims(inproc, client) == {"exc_bases"}
+
+
 def test_flops_compared_even_when_both_raise():
     # The billing family: both raise, but only one charged for it.
     inproc = observe_exception(TypeError("x"), flops=0)
     client = observe_exception(TypeError("x"), flops=341648)
     assert _dims(inproc, client) == {"flops"}
+
+
+def test_outcome_and_flops_both_reported_when_both_differ():
+    # The defect this harness exists to catch: one backend fails the call and
+    # still charges for it. Both dimensions must be reported, independently.
+    inproc = _returned(flops=0)
+    client = observe_exception(TypeError("nope"), flops=341648)
+    assert _dims(inproc, client) == {"outcome", "flops"}
+
+
+def test_outcome_alone_reported_when_flops_agree():
+    inproc = _returned(flops=10)
+    client = observe_exception(TypeError("nope"), flops=10)
+    assert _dims(inproc, client) == {"outcome"}
 
 
 def test_value_dimensions_skipped_when_both_raise():

--- a/tests/parity/test_corpus_unit.py
+++ b/tests/parity/test_corpus_unit.py
@@ -1,0 +1,47 @@
+"""The corpus must be well-formed before it is worth running."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from tests.parity.corpus import all_cases, fast_cases
+
+
+def test_every_case_id_is_unique():
+    ids = [case.id for case in all_cases()]
+    assert len(ids) == len(set(ids))
+
+
+def test_every_idiom_case_names_a_family():
+    for case in all_cases():
+        if case.id.startswith("idiom/"):
+            assert case.family() is not None, f"{case.id} has no family tag"
+
+
+def test_fast_cases_are_a_subset_tagged_for_the_fast_tier():
+    fast = fast_cases()
+    assert fast, "the fast tier must not be empty"
+    for case in fast:
+        assert "tier:fast" in case.tags
+    assert set(fast).issubset(set(all_cases()))
+
+
+def test_every_family_has_at_least_one_fast_case():
+    families: set[str] = cast(
+        set[str], {c.family() for c in all_cases() if c.family() is not None}
+    )
+    fast_families: set[str] = cast(
+        set[str], {c.family() for c in fast_cases() if c.family() is not None}
+    )
+    assert families == fast_families, (
+        f"families with no fast-tier case: {sorted(families - fast_families)}"
+    )
+
+
+def test_no_audit_prose_leaked_into_the_corpus():
+    # The repo is public; the audit is not.
+    import pathlib
+
+    text = pathlib.Path("tests/parity/corpus/idioms.py").read_text()
+    for banned in ("exploit", "budget bypass", "participant-venv"):
+        assert banned not in text.lower()

--- a/tests/parity/test_observe_unit.py
+++ b/tests/parity/test_observe_unit.py
@@ -100,3 +100,19 @@ def test_observe_exception_records_only_builtin_ancestors():
 def test_terminal_outcomes():
     assert observe_timeout(flops=3)["outcome"] == "timeout"
     assert observe_worker_died()["outcome"] == "worker_died"
+
+
+def test_container_fingerprints_do_not_collide_on_separator_chars():
+    # Structural separators appearing inside string content must not make two
+    # different values fingerprint identically.
+    assert fingerprint(["s:x", "y"]) != fingerprint(["s:x,s:y"])
+    assert fingerprint(["a", "b"]) != fingerprint(["a,b"])
+    assert fingerprint([""]) != fingerprint([])
+
+
+def test_materialize_unwraps_item_style_scalars():
+    class ItemScalar:
+        def item(self):
+            return 1.5
+
+    assert observe_result(ItemScalar(), flops=0)["value"] == fingerprint(1.5)

--- a/tests/parity/test_observe_unit.py
+++ b/tests/parity/test_observe_unit.py
@@ -7,6 +7,7 @@ import math
 from tests.parity.observe import (
     fingerprint,
     observe_exception,
+    observe_record_failure,
     observe_result,
     observe_timeout,
     observe_worker_died,
@@ -140,6 +141,66 @@ def test_array_wrapper_classes_do_not_diverge_on_pytype():
     inproc = observe_result(FlopscopeArray(), flops=0)
     client = observe_result(RemoteArray(), flops=0)
     assert inproc["pytype"] == client["pytype"]
+
+
+def test_observe_result_survives_a_class_whose_shape_is_a_descriptor():
+    # Real-world crash: some registry operations return a *class* rather
+    # than an instance (e.g. `numpy.common_type` handing back a scalar
+    # type). On a class, `.shape` resolves through the descriptor protocol
+    # to the descriptor object itself (a `getset_descriptor` in the real
+    # crash; a `property` object here, which triggers the identical hazard
+    # without depending on numpy). `list()` on that raises unless guarded.
+    class Weird:
+        @property
+        def shape(self):
+            return (2, 3)
+
+    obs = observe_result(Weird, flops=0)
+    assert obs["outcome"] == "returned"
+    assert obs["shape"] is None
+
+
+def test_observe_result_treats_a_shape_with_non_integer_elements_as_absent():
+    class FakeArray:
+        shape = ("rows", "cols")
+
+        def tolist(self):
+            return [[1.0]]
+
+    obs = observe_result(FakeArray(), flops=0)
+    assert obs["shape"] is None
+
+
+def test_observe_result_survives_a_class_whose_dtype_is_a_descriptor():
+    class Weird:
+        @property
+        def dtype(self):
+            return "float32"
+
+    obs = observe_result(Weird, flops=0)
+    assert obs["outcome"] == "returned"
+    assert obs["dtype"] is None
+
+
+def test_observe_result_survives_a_tolist_that_raises():
+    class Weird:
+        shape = (2,)
+        dtype = "float32"
+
+        def tolist(self):
+            raise RuntimeError("boom")
+
+    obs = observe_result(Weird(), flops=0)
+    assert obs["outcome"] == "returned"
+    # Falls back to fingerprinting the value itself rather than propagating.
+    assert obs["value"] is not None
+
+
+def test_observe_record_failure_reports_outcome_and_exception_class():
+    obs = observe_record_failure(TypeError("not iterable"), flops=11)
+    assert obs["outcome"] == "record_failed"
+    assert obs["exc_type"] == "TypeError"
+    assert obs["flops"] == 11
 
 
 def test_plain_bool_against_a_scalar_wrapper_still_diverges_on_pytype():

--- a/tests/parity/test_observe_unit.py
+++ b/tests/parity/test_observe_unit.py
@@ -1,0 +1,102 @@
+"""Unit tests for fingerprinting and observation records. Pure — no backend."""
+
+from __future__ import annotations
+
+import math
+
+from tests.parity.observe import (
+    fingerprint,
+    observe_exception,
+    observe_result,
+    observe_timeout,
+    observe_worker_died,
+)
+
+
+def test_distinguishes_int_float_and_bool():
+    assert fingerprint(1) != fingerprint(1.0)
+    assert fingerprint(1) != fingerprint(True)
+    assert fingerprint(1.0) != fingerprint(True)
+
+
+def test_distinguishes_signed_zero():
+    assert fingerprint(0.0) != fingerprint(-0.0)
+
+
+def test_nan_fingerprints_equal_to_itself():
+    # float('nan') != float('nan'), but their bit patterns match, which is what
+    # we need: two backends both returning NaN must compare equal.
+    assert fingerprint(float("nan")) == fingerprint(float("nan"))
+
+
+def test_distinguishes_last_ulp():
+    # This is Family 1: allclose passes these, we must not.
+    a = 0.30000000447034836
+    b = 0.30000001192092896
+    assert math.isclose(a, b, rel_tol=1e-7)  # allclose would accept
+    assert fingerprint(a) != fingerprint(b)  # we do not
+
+
+def test_fingerprints_nested_lists_elementwise():
+    assert fingerprint([[1.0, 2.0]]) == fingerprint([[1.0, 2.0]])
+    assert fingerprint([[1.0, 2.0]]) != fingerprint([[1.0, 2.0000000000000004]])
+
+
+def test_distinguishes_complex():
+    assert fingerprint(complex(1, 2)) != fingerprint(complex(1, 3))
+    assert fingerprint(complex(1, 0)) != fingerprint(1.0)
+
+
+def test_observe_result_records_type_dtype_shape_container():
+    class FakeArray:
+        dtype = "float32"
+        shape = (2, 3)
+
+        def tolist(self):
+            return [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+
+    obs = observe_result(FakeArray(), flops=42)
+    assert obs["outcome"] == "returned"
+    assert obs["pytype"] == "FakeArray"
+    assert obs["dtype"] == "float32"
+    assert obs["shape"] == [2, 3]
+    assert obs["container"] == "array"
+    assert obs["flops"] == 42
+    assert obs["value"] == fingerprint([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+
+def test_observe_result_detects_namedtuple_container():
+    import collections
+
+    Pair = collections.namedtuple("Pair", "U S")
+    obs = observe_result(Pair(1, 2), flops=0)
+    assert obs["container"] == "namedtuple:Pair(U,S)"
+
+
+def test_observe_result_distinguishes_tuple_from_list():
+    assert observe_result((1, 2), flops=0)["container"] == "tuple"
+    assert observe_result([1, 2], flops=0)["container"] == "list"
+
+
+def test_observe_exception_records_class_and_builtin_ancestry():
+    obs = observe_exception(IndexError("out of bounds"), flops=7)
+    assert obs["outcome"] == "raised"
+    assert obs["exc_type"] == "IndexError"
+    assert "LookupError" in obs["exc_bases"]
+    assert obs["flops"] == 7
+    assert obs["exc_msg"] == "out of bounds"
+
+
+def test_observe_exception_records_only_builtin_ancestors():
+    class Custom(ValueError):
+        pass
+
+    obs = observe_exception(Custom("x"), flops=0)
+    assert obs["exc_type"] == "Custom"
+    assert "ValueError" in obs["exc_bases"]
+    assert "Custom" not in obs["exc_bases"]
+
+
+def test_terminal_outcomes():
+    assert observe_timeout(flops=3)["outcome"] == "timeout"
+    assert observe_worker_died()["outcome"] == "worker_died"

--- a/tests/parity/test_observe_unit.py
+++ b/tests/parity/test_observe_unit.py
@@ -116,3 +116,45 @@ def test_materialize_unwraps_item_style_scalars():
             return 1.5
 
     assert observe_result(ItemScalar(), flops=0)["value"] == fingerprint(1.5)
+
+
+def test_array_wrapper_classes_do_not_diverge_on_pytype():
+    # inproc's `FlopscopeArray` and the client's `RemoteArray` are two
+    # different classes by construction (two implementations of the same
+    # array type); raw class names would report a spurious divergence on
+    # every single array-returning case. They must collapse to one token.
+    class FlopscopeArray:
+        dtype = "float32"
+        shape = ()
+
+        def tolist(self):
+            return 1.0
+
+    class RemoteArray:
+        dtype = "float32"
+        shape = ()
+
+        def tolist(self):
+            return 1.0
+
+    inproc = observe_result(FlopscopeArray(), flops=0)
+    client = observe_result(RemoteArray(), flops=0)
+    assert inproc["pytype"] == client["pytype"]
+
+
+def test_plain_bool_against_a_scalar_wrapper_still_diverges_on_pytype():
+    # A plain Python bool on one backend against a wrapper object on the
+    # other means a value failed to unwrap the way it should have — this
+    # is the real defect class "pytype" exists to catch, and the array-
+    # wrapper collapse above must not blind the harness to it.
+    class RemoteScalar:
+        dtype = "bool"
+        shape = ()
+
+        def tolist(self):
+            return True
+
+    inproc = observe_result(True, flops=0)
+    client = observe_result(RemoteScalar(), flops=0)
+    assert inproc["pytype"] != client["pytype"]
+    assert inproc["pytype"] == "bool"

--- a/tests/parity/test_parity_fast.py
+++ b/tests/parity/test_parity_fast.py
@@ -38,5 +38,15 @@ def test_corpus_has_not_silently_shrunk():
 def test_fast_tier_has_no_unexplained_divergences():
     result = run_corpus(fast_cases())
     assert result.infrastructure_failure is None, result.infrastructure_failure
+    # The 11 fast cases are deterministic now that the RNG is seeded, so the
+    # twice-run self-check flagging any of them flaky is never expected
+    # variation - it quarantines the case from comparison entirely (see
+    # ``run_corpus``), which is exactly the silent-agreement failure this
+    # harness exists to prevent. Any flakiness here is a real regression.
+    assert not result.flaky, (
+        f"{len(result.flaky)} fast-tier case(s) flagged flaky (expected 0); "
+        f"these were skipped from comparison instead of being checked: "
+        f"{result.flaky}"
+    )
     allow = apply(result.divergences, ENTRIES)
     assert not allow.unexplained, render(result, allow, coverage={})

--- a/tests/parity/test_parity_fast.py
+++ b/tests/parity/test_parity_fast.py
@@ -1,0 +1,42 @@
+"""Tier 1: blocks every pull request. Target: under 60 seconds.
+
+This is the fix for the gap this whole project exists to close: a parity
+signal already existed in this repository (``make test-client-parity-measure``)
+and never blocked anything, because its recipe lines are prefixed with ``-``
+and its CI step is labelled non-blocking. Nothing here may use that pattern —
+every test in this module is a real gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.parity.allowlist import ENTRIES, apply, validate_entries
+from tests.parity.compare import DIMENSIONS
+from tests.parity.corpus import all_cases, fast_cases, registry_grid
+from tests.parity.report import render
+from tests.parity.runner import run_corpus
+
+
+def test_allowlist_schema_is_valid():
+    assert validate_entries(ENTRIES) == []
+
+
+def test_every_dimension_is_spelled_consistently():
+    for entry in ENTRIES:
+        assert entry.dimension in DIMENSIONS
+
+
+def test_corpus_has_not_silently_shrunk():
+    # Guards against the corpus quietly losing ops, which would look like
+    # green because there is simply nothing left to diverge on.
+    assert len(registry_grid.op_names()) > 500
+    assert len(all_cases()) > len(fast_cases())
+
+
+@pytest.mark.parity_server
+def test_fast_tier_has_no_unexplained_divergences():
+    result = run_corpus(fast_cases())
+    assert result.infrastructure_failure is None, result.infrastructure_failure
+    allow = apply(result.divergences, ENTRIES)
+    assert not allow.unexplained, render(result, allow, coverage={})

--- a/tests/parity/test_parity_full.py
+++ b/tests/parity/test_parity_full.py
@@ -14,6 +14,18 @@ from tests.parity.corpus import all_cases, registry_grid
 from tests.parity.report import render
 from tests.parity.runner import run_corpus
 
+#: The full corpus's flaky count (cases the twice-run self-check found
+#: nondeterministic and therefore quarantined from comparison - see
+#: ``run_corpus``) measured stable at 50 across three consecutive full-
+#: corpus runs. The ceiling below leaves headroom above that baseline so
+#: ordinary run-to-run variation passes, while a systemic regression (e.g.
+#: nondeterminism spreading to more ops, or the server hiccupping between a
+#: backend's two passes) still fails. Retune this deliberately, from a fresh
+#: measurement, rather than by guesswork, if it ever starts failing on
+#: otherwise-healthy runs.
+_MEASURED_FLAKY_BASELINE = 50
+_FLAKY_CEILING = 60
+
 
 @pytest.mark.parity_server
 def test_full_corpus_has_no_unexplained_divergences_and_no_stale_entries():
@@ -29,5 +41,11 @@ def test_full_corpus_has_no_unexplained_divergences_and_no_stale_entries():
     }
     report = render(result, allow, coverage)
     print(report)
+    assert len(result.flaky) <= _FLAKY_CEILING, (
+        f"{len(result.flaky)} flaky cases exceeds the ceiling of "
+        f"{_FLAKY_CEILING} (measured baseline {_MEASURED_FLAKY_BASELINE}); "
+        f"an unbounded flaky count silently shrinks what actually gets "
+        f"compared. {report}"
+    )
     assert not allow.unexplained, report
     assert not allow.stale, report

--- a/tests/parity/test_parity_full.py
+++ b/tests/parity/test_parity_full.py
@@ -1,0 +1,33 @@
+"""Tier 2: the entire corpus. Release-blocking, not on the pull-request path.
+
+At ~8,900 cases this takes on the order of five minutes, which is too slow to
+block a pull request but appropriate as a release gate. See
+``tests/parity/test_parity_fast.py`` for the tier that blocks every PR.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.parity.allowlist import ENTRIES, apply
+from tests.parity.corpus import all_cases, registry_grid
+from tests.parity.report import render
+from tests.parity.runner import run_corpus
+
+
+@pytest.mark.parity_server
+def test_full_corpus_has_no_unexplained_divergences_and_no_stale_entries():
+    cases = all_cases()
+    result = run_corpus(cases)
+    assert result.infrastructure_failure is None, result.infrastructure_failure
+    allow = apply(result.divergences, ENTRIES)
+    coverage = {
+        "cases": len(cases),
+        "ops_enumerated": len(registry_grid.op_names()),
+        "ops_undriven": len(registry_grid.undriven()),
+        "flaky": len(result.flaky),
+    }
+    report = render(result, allow, coverage)
+    print(report)
+    assert not allow.unexplained, report
+    assert not allow.stale, report

--- a/tests/parity/test_registry_grid_unit.py
+++ b/tests/parity/test_registry_grid_unit.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from tests.parity.corpus import registry_grid
+
+
+def test_enumerates_the_core_registry():
+    names = registry_grid.op_names()
+    assert len(names) > 500, f"expected the full registry, got {len(names)}"
+    assert "sum" in names
+    assert "fft.rfft" in names
+
+
+def test_builds_one_case_per_op_and_pattern():
+    cases = registry_grid.build()
+    assert len(cases) == len(registry_grid.op_names()) * len(registry_grid.PATTERNS)
+
+
+def test_case_ids_encode_op_and_pattern():
+    ids = {case.id for case in registry_grid.build()}
+    assert "grid/sum::axis-tuple" in ids
+
+
+def test_tuple_axis_is_one_of_the_patterns():
+    assert "axis-tuple" in {name for name, _ in registry_grid.PATTERNS}
+
+
+def test_undriven_ops_are_reported_not_dropped():
+    # Whatever cannot be driven must be COUNTED, never silently skipped.
+    assert isinstance(registry_grid.undriven(), dict)

--- a/tests/parity/test_registry_grid_unit.py
+++ b/tests/parity/test_registry_grid_unit.py
@@ -10,10 +10,14 @@ def test_enumerates_the_core_registry():
     assert "fft.rfft" in names
 
 
-def test_builds_one_case_per_op_and_pattern_minus_segfault_exclusions():
+def test_builds_one_case_per_op_and_pattern_minus_exclusions():
     cases = registry_grid.build()
     full_grid = len(registry_grid.op_names()) * len(registry_grid.PATTERNS)
-    assert len(cases) == full_grid - len(registry_grid.SEGFAULT_EXCLUDED_CASE_IDS)
+    excluded = (
+        registry_grid.SEGFAULT_EXCLUDED_CASE_IDS
+        | registry_grid.UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS
+    )
+    assert len(cases) == full_grid - len(excluded)
 
 
 def test_case_ids_encode_op_and_pattern():
@@ -51,3 +55,29 @@ def test_exactly_seventeen_cases_are_segfault_excluded():
     # Pinned to the measured count so a silent change in the exclusion set
     # (accidentally widening or narrowing it) fails loudly.
     assert len(registry_grid.SEGFAULT_EXCLUDED_CASE_IDS) == 17
+
+
+def test_uninitialized_value_cases_are_excluded_from_the_built_corpus():
+    # `empty`/`empty_like` return uninitialized memory for these patterns;
+    # their value can never be meaningfully compared, so they must never
+    # reach `build()`'s output.
+    ids = {case.id for case in registry_grid.build()}
+    assert registry_grid.UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS, (
+        "exclusion set must not be empty"
+    )
+    assert ids.isdisjoint(registry_grid.UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS)
+
+
+def test_undriven_accounts_for_every_uninitialized_value_exclusion():
+    # Silent truncation is the failure mode this harness exists to prevent:
+    # every excluded case must be COUNTED somewhere, with a reason attached.
+    undriven = registry_grid.undriven()
+    for case_id in registry_grid.UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS:
+        assert case_id in undriven
+        assert undriven[case_id].strip()
+
+
+def test_exactly_nine_cases_are_uninitialized_value_excluded():
+    # Pinned to the measured count so a silent change in the exclusion set
+    # (accidentally widening or narrowing it) fails loudly.
+    assert len(registry_grid.UNINITIALIZED_VALUE_EXCLUDED_CASE_IDS) == 9

--- a/tests/parity/test_registry_grid_unit.py
+++ b/tests/parity/test_registry_grid_unit.py
@@ -10,9 +10,10 @@ def test_enumerates_the_core_registry():
     assert "fft.rfft" in names
 
 
-def test_builds_one_case_per_op_and_pattern():
+def test_builds_one_case_per_op_and_pattern_minus_segfault_exclusions():
     cases = registry_grid.build()
-    assert len(cases) == len(registry_grid.op_names()) * len(registry_grid.PATTERNS)
+    full_grid = len(registry_grid.op_names()) * len(registry_grid.PATTERNS)
+    assert len(cases) == full_grid - len(registry_grid.SEGFAULT_EXCLUDED_CASE_IDS)
 
 
 def test_case_ids_encode_op_and_pattern():
@@ -27,3 +28,26 @@ def test_tuple_axis_is_one_of_the_patterns():
 def test_undriven_ops_are_reported_not_dropped():
     # Whatever cannot be driven must be COUNTED, never silently skipped.
     assert isinstance(registry_grid.undriven(), dict)
+
+
+def test_segfaulting_cases_are_excluded_from_the_built_corpus():
+    # These 17 case ids crash the in-process worker (SIGSEGV, exit 139); a
+    # crash cannot be caught, so they must never reach `build()`'s output.
+    ids = {case.id for case in registry_grid.build()}
+    assert registry_grid.SEGFAULT_EXCLUDED_CASE_IDS, "exclusion set must not be empty"
+    assert ids.isdisjoint(registry_grid.SEGFAULT_EXCLUDED_CASE_IDS)
+
+
+def test_undriven_accounts_for_every_segfault_exclusion():
+    # Silent truncation is the failure mode this harness exists to prevent:
+    # every excluded case must be COUNTED somewhere, with a reason attached.
+    undriven = registry_grid.undriven()
+    for case_id in registry_grid.SEGFAULT_EXCLUDED_CASE_IDS:
+        assert case_id in undriven
+        assert undriven[case_id].strip()
+
+
+def test_exactly_seventeen_cases_are_segfault_excluded():
+    # Pinned to the measured count so a silent change in the exclusion set
+    # (accidentally widening or narrowing it) fails loudly.
+    assert len(registry_grid.SEGFAULT_EXCLUDED_CASE_IDS) == 17

--- a/tests/parity/test_report_unit.py
+++ b/tests/parity/test_report_unit.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from tests.parity.allowlist import apply
+from tests.parity.compare import Divergence
+from tests.parity.report import render
+from tests.parity.runner import RunResult
+
+
+def test_report_lists_unexplained_divergences_with_both_sides():
+    div = Divergence("idiom/x", "dtype", "float32", "float64")
+    text = render(RunResult(divergences=[div]), apply([div]), coverage={})
+    assert "idiom/x" in text
+    assert "dtype" in text
+    assert "float32" in text
+    assert "float64" in text
+
+
+def test_report_states_coverage_counts():
+    text = render(
+        RunResult(),
+        apply([]),
+        coverage={"ops_enumerated": 617, "ops_driven": 470, "ops_undriven": 147},
+    )
+    assert "617" in text
+    assert "470" in text
+    assert "147" in text
+
+
+def test_report_flags_stale_entries_explicitly():
+    from tests.parity.allowlist import Category, Entry
+
+    entry = Entry("a/b", "value", Category.PROXY_INHERENT, "reason")
+    text = render(RunResult(), apply([], entries=(entry,)), coverage={})
+    assert "stale" in text.lower()
+    assert "a/b" in text
+
+
+def test_report_names_flaky_cases_separately_from_divergences():
+    text = render(RunResult(flaky=["grid/random::vector"]), apply([]), coverage={})
+    assert "flaky" in text.lower()
+    assert "grid/random::vector" in text

--- a/tests/parity/test_report_unit.py
+++ b/tests/parity/test_report_unit.py
@@ -39,3 +39,25 @@ def test_report_names_flaky_cases_separately_from_divergences():
     text = render(RunResult(flaky=["grid/random::vector"]), apply([]), coverage={})
     assert "flaky" in text.lower()
     assert "grid/random::vector" in text
+
+
+def test_report_prints_each_entrys_match_count():
+    from tests.parity.allowlist import Category, Entry
+
+    glob_entry = Entry(
+        case_id="grid/fft.*::*",
+        dimension="outcome",
+        category=Category.KNOWN_BUG,
+        reason="Family 9: fft submodule missing client-side.",
+        issue="INTERNAL-P4-family-9",
+    )
+    div_a = Divergence("grid/fft.rfft::array", "outcome", "returned", "raised")
+    div_b = Divergence("grid/fft.fftn::vector", "outcome", "returned", "raised")
+    text = render(
+        RunResult(divergences=[div_a, div_b]),
+        apply([div_a, div_b], entries=(glob_entry,)),
+        coverage={},
+    )
+    # A glob covering two divergences must show that count, not hide it.
+    assert "grid/fft.*::*" in text
+    assert "[    2]" in text

--- a/tests/parity/test_runner_integration.py
+++ b/tests/parity/test_runner_integration.py
@@ -1,0 +1,47 @@
+"""End-to-end: both backends, a real server, a known divergence.
+
+This is the CANARY. `idiom/complex-scalar-mul` is the 2026-07-25 seed bug: a
+Python complex operand cannot cross the wire. If this test stops reporting a
+divergence, either the bug was fixed (delete the canary and its allowlist entry)
+or the harness plumbing silently broke (fix the harness).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.parity.case import Case
+from tests.parity.runner import run_corpus
+
+pytestmark = pytest.mark.parity_server
+
+
+def test_identical_expressions_agree_on_both_backends():
+    result = run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
+    assert result.infrastructure_failure is None
+    assert result.divergences == []
+    assert result.flaky == []
+
+
+def test_canary_complex_scalar_diverges():
+    result = run_corpus(
+        [Case(id="idiom/complex-scalar-mul", source="fnp.astype(V, 'complex64') * 1j")]
+    )
+    assert result.infrastructure_failure is None
+    dims = {d.dimension for d in result.divergences}
+    assert "outcome" in dims, (
+        "the seed bug no longer diverges: either it was fixed (delete this "
+        "canary) or the harness plumbing is broken (fix the harness)"
+    )
+
+
+def test_tuple_axis_diverges():
+    result = run_corpus([Case(id="t/tuple-axis", source="fnp.sum(A, axis=(0, 1))")])
+    assert "outcome" in {d.dimension for d in result.divergences}
+
+
+def test_observations_are_recorded_for_both_backends():
+    result = run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
+    assert set(result.observations) == {"inproc", "client"}
+    assert "t/sum" in result.observations["inproc"]
+    assert "t/sum" in result.observations["client"]

--- a/tests/parity/test_runner_integration.py
+++ b/tests/parity/test_runner_integration.py
@@ -1,9 +1,11 @@
 """End-to-end: both backends, a real server, a known divergence.
 
-This is the CANARY. `idiom/complex-scalar-mul` is the 2026-07-25 seed bug: a
-Python complex operand cannot cross the wire. If this test stops reporting a
-divergence, either the bug was fixed (delete the canary and its allowlist entry)
-or the harness plumbing silently broke (fix the harness).
+This is the CANARY. `idiom/complex-scalar-mul` multiplies an array by a plain
+Python `complex` scalar; that operand cannot cross the wire to the client
+backend, so the two backends disagree on the outcome. If this test stops
+reporting a divergence, either the underlying defect was fixed (delete the
+canary and its allowlist entry) or the harness plumbing silently broke (fix
+the harness).
 """
 
 from __future__ import annotations

--- a/tests/parity/test_runner_unit.py
+++ b/tests/parity/test_runner_unit.py
@@ -124,19 +124,25 @@ def test_run_backend_surfaces_worker_stderr_on_failure():
     assert restarts == 0
 
 
-def test_run_backend_handles_a_subprocess_timeout(monkeypatch):
+@pytest.mark.parametrize("encode", [str, lambda s: s.encode("utf-8")], ids=["str", "bytes"])
+def test_run_backend_handles_a_subprocess_timeout(monkeypatch, encode):
     # `_run_backend`'s TimeoutExpired handler is exercised without a
     # genuinely hanging worker: `subprocess.run` is monkeypatched to raise it
     # directly, carrying partial stdout for one case as it would if the
     # worker had produced output before hanging.
+    #
+    # Parametrized over str AND bytes on purpose: a real TimeoutExpired carries
+    # BYTES even when the call requested text mode. A str-only test passes even
+    # if the handler drops byte output, which would silently discard every
+    # record the worker completed before hanging.
     completed_line = json.dumps({"id": "t/first", "outcome": "returned", "flops": 0})
 
     def _raise_timeout(*args, **kwargs):
         raise subprocess.TimeoutExpired(
             cmd=["worker"],
             timeout=1,
-            output=completed_line + "\n",
-            stderr="partial stderr",
+            output=encode(completed_line + "\n"),
+            stderr=encode("partial stderr"),
         )
 
     monkeypatch.setattr(runner.subprocess, "run", _raise_timeout)

--- a/tests/parity/test_runner_unit.py
+++ b/tests/parity/test_runner_unit.py
@@ -2,16 +2,19 @@
 
 `test_runner_integration.py` proves the happy path end to end against real
 backends and a real server, but that suite is slow to run repeatedly while
-iterating on failure handling. These tests isolate three specific properties
-with fakes instead: a worker that dies mid-corpus does not lose the rest of
-the run, a majority-broken backend is reported as infrastructure rather than
-thousands of individual divergences, and the server is stopped even when a
+iterating on failure handling. These tests isolate specific properties with
+fakes instead: a worker that dies mid-corpus does not lose the rest of the
+run, a majority-broken backend is reported as infrastructure rather than
+thousands of individual divergences (while a majority *domain* exception,
+like probing outside a budget context, is not), worker stderr reaches the
+result instead of being dropped, and the server is stopped even when a
 backend run raises partway through — none of which need a live server or a
 real worker subprocess to verify.
 """
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 
@@ -33,15 +36,54 @@ def test_a_worker_that_dies_mid_corpus_backfills_the_rest_as_worker_died():
         Case(id="t/kill", source="1", setup="import os; os._exit(1)"),
         Case(id="t/never-reached", source="1"),
     ]
-    observations = _run_backend("inproc", cases)
+    observations, _stderr = _run_backend("inproc", cases)
     assert set(observations) == {"t/kill", "t/never-reached"}
     assert observations["t/kill"] == observe_worker_died()
     assert observations["t/never-reached"] == observe_worker_died()
 
 
 def test_a_normal_run_is_unaffected_by_the_worker_died_fallback():
-    observations = _run_backend("inproc", [Case(id="t/sum", source="fnp.sum(V)")])
+    observations, _stderr = _run_backend(
+        "inproc", [Case(id="t/sum", source="fnp.sum(V)")]
+    )
     assert observations["t/sum"]["outcome"] == "returned"
+
+
+def test_run_backend_surfaces_worker_stderr_on_failure():
+    # An invalid --backend value never reaches any case-execution code: it is
+    # rejected by argparse before the worker touches stdin, so this fails
+    # deterministically and fast, without needing a live server or a crafted
+    # Case to provoke a real crash.
+    cases = [Case(id="t/sum", source="fnp.sum(V)")]
+    observations, stderr_text = _run_backend("not-a-real-backend", cases)
+    assert observations == {"t/sum": observe_worker_died()}
+    assert stderr_text != ""
+    assert "not-a-real-backend" in stderr_text
+
+
+def test_run_backend_handles_a_subprocess_timeout(monkeypatch):
+    # `_run_backend`'s TimeoutExpired handler is exercised without a
+    # genuinely hanging worker: `subprocess.run` is monkeypatched to raise it
+    # directly, carrying partial stdout for one case as it would if the
+    # worker had produced output before hanging.
+    completed_line = json.dumps({"id": "t/first", "outcome": "returned", "flops": 0})
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=["worker"],
+            timeout=1,
+            output=completed_line + "\n",
+            stderr="partial stderr",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", _raise_timeout)
+
+    cases = [Case(id="t/first", source="1"), Case(id="t/second", source="1")]
+    observations, stderr_text = _run_backend("inproc", cases)
+
+    assert observations["t/first"]["outcome"] == "returned"
+    assert observations["t/second"] == observe_worker_died()
+    assert stderr_text == "partial stderr"
 
 
 def test_looks_like_infrastructure_on_empty_observations():
@@ -57,11 +99,57 @@ def test_looks_like_infrastructure_when_most_cases_died():
     assert _looks_like_infrastructure(observations) is True
 
 
+def test_looks_like_infrastructure_when_most_cases_died_even_with_mixed_exc_types():
+    # A dead worker produces no exception at all, so worker_died must
+    # dominate regardless of what the surviving cases' exception types are.
+    observations = {
+        "a": observe_worker_died(),
+        "b": observe_worker_died(),
+        "c": {"outcome": "raised", "exc_type": "ValueError"},
+    }
+    assert _looks_like_infrastructure(observations) is True
+
+
 def test_does_not_look_like_infrastructure_when_most_cases_are_fine():
     observations = {
         "a": {"outcome": "returned"},
         "b": {"outcome": "returned"},
         "c": observe_worker_died(),
+    }
+    assert _looks_like_infrastructure(observations) is False
+
+
+def test_does_not_look_like_infrastructure_when_majority_raise_a_domain_exception():
+    # NoBudgetContextError is a genuine domain exception raised by real code
+    # paths on both backends, not a transport failure; a corpus family that
+    # deliberately probes operating outside a budget context could make a
+    # majority of its cases raise it legitimately.
+    observations = {
+        "a": {"outcome": "raised", "exc_type": "NoBudgetContextError"},
+        "b": {"outcome": "raised", "exc_type": "NoBudgetContextError"},
+        "c": {"outcome": "returned"},
+    }
+    assert _looks_like_infrastructure(observations) is False
+
+
+def test_looks_like_infrastructure_when_majority_share_one_transport_exception_type():
+    observations = {
+        "a": {"outcome": "raised", "exc_type": "ConnectionError"},
+        "b": {"outcome": "raised", "exc_type": "ConnectionError"},
+        "c": {"outcome": "returned"},
+    }
+    assert _looks_like_infrastructure(observations) is True
+
+
+def test_does_not_look_like_infrastructure_when_exception_types_are_a_mix():
+    # Half the cases raise ConnectionError and the other cases raise
+    # different, unrelated exceptions: no single exception type reaches a
+    # majority, so this is real per-case signal, not a broken backend.
+    observations = {
+        "a": {"outcome": "raised", "exc_type": "ConnectionError"},
+        "b": {"outcome": "raised", "exc_type": "ZMQError"},
+        "c": {"outcome": "raised", "exc_type": "ValueError"},
+        "d": {"outcome": "returned"},
     }
     assert _looks_like_infrastructure(observations) is False
 
@@ -91,7 +179,9 @@ def test_run_corpus_stops_the_server_on_the_infrastructure_early_return(monkeypa
     monkeypatch.setattr(runner, "start_server", lambda: sentinel)
     monkeypatch.setattr(runner, "stop_server", lambda proc: stopped.append(proc))
     monkeypatch.setattr(
-        runner, "_run_backend", lambda backend, cases: {"t/sum": observe_worker_died()}
+        runner,
+        "_run_backend",
+        lambda backend, cases: ({"t/sum": observe_worker_died()}, ""),
     )
 
     result = run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
@@ -99,6 +189,38 @@ def test_run_corpus_stops_the_server_on_the_infrastructure_early_return(monkeypa
     assert result.infrastructure_failure is not None
     assert result.divergences == []
     assert stopped == [sentinel]
+
+
+def test_run_corpus_surfaces_failing_backend_stderr_in_the_result(monkeypatch):
+    monkeypatch.setattr(runner, "start_server", lambda: object())
+    monkeypatch.setattr(runner, "stop_server", lambda proc: None)
+    monkeypatch.setattr(
+        runner,
+        "_run_backend",
+        lambda backend, cases: (
+            {"t/sum": observe_worker_died()},
+            f"{backend}: Traceback (most recent call last): boom",
+        ),
+    )
+
+    result = run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
+
+    assert result.infrastructure_failure is not None
+    assert "boom" in result.infrastructure_failure
+    assert result.stderr["inproc"] == "inproc: Traceback (most recent call last): boom"
+
+
+def test_run_corpus_on_an_empty_case_list_returns_a_clean_empty_result():
+    # A later stage that filters cases by tag can legitimately produce an
+    # empty list; this must not be reported as an infrastructure failure
+    # (`_looks_like_infrastructure({})` is `True` on its own, per the test
+    # above, but `run_corpus` short-circuits before ever calling it here).
+    # No server or backend fixtures are needed for this to be correct.
+    result = run_corpus([])
+    assert result.infrastructure_failure is None
+    assert result.divergences == []
+    assert result.flaky == []
+    assert result.observations == {}
 
 
 def test_worker_module_is_invocable_as_a_subprocess_with_no_cases():

--- a/tests/parity/test_runner_unit.py
+++ b/tests/parity/test_runner_unit.py
@@ -124,7 +124,9 @@ def test_run_backend_surfaces_worker_stderr_on_failure():
     assert restarts == 0
 
 
-@pytest.mark.parametrize("encode", [str, lambda s: s.encode("utf-8")], ids=["str", "bytes"])
+@pytest.mark.parametrize(
+    "encode", [str, lambda s: s.encode("utf-8")], ids=["str", "bytes"]
+)
 def test_run_backend_handles_a_subprocess_timeout(monkeypatch, encode):
     # `_run_backend`'s TimeoutExpired handler is exercised without a
     # genuinely hanging worker: `subprocess.run` is monkeypatched to raise it

--- a/tests/parity/test_runner_unit.py
+++ b/tests/parity/test_runner_unit.py
@@ -3,13 +3,18 @@
 `test_runner_integration.py` proves the happy path end to end against real
 backends and a real server, but that suite is slow to run repeatedly while
 iterating on failure handling. These tests isolate specific properties with
-fakes instead: a worker that dies mid-corpus does not lose the rest of the
-run, a majority-broken backend is reported as infrastructure rather than
-thousands of individual divergences (while a majority *domain* exception,
-like probing outside a budget context, is not), worker stderr reaches the
-result instead of being dropped, and the server is stopped even when a
-backend run raises partway through — none of which need a live server or a
-real worker subprocess to verify.
+fakes instead: a worker that dies mid-corpus costs only the one case that
+killed it (the cases before and after it are recorded normally, and a fresh
+worker resumes the rest), the restart count is visible and capped so a
+pathological corpus cannot loop forever, a majority-broken backend (or one
+needing a systemic number of restarts) is reported as infrastructure rather
+than thousands of individual divergences (while a majority *domain*
+exception, like probing outside a budget context, is not), worker stderr
+reaches the result instead of being dropped, and the server is stopped even
+when a backend run raises partway through — none of which need a live server
+to verify. `os._exit` stands in for a real segfault in these unit tests (both
+kill the worker without a catchable Python exception); the real segfault
+case is exercised separately in `test_runner_integration.py`.
 """
 
 from __future__ import annotations
@@ -28,25 +33,80 @@ from tests.parity.runner import _looks_like_infrastructure, _run_backend, run_co
 _ROOT = runner._ROOT
 
 
-def test_a_worker_that_dies_mid_corpus_backfills_the_rest_as_worker_died():
+def test_a_worker_that_dies_mid_corpus_costs_only_the_killing_case():
     # `setup` runs as an exec'd statement (unlike `source`, which is only an
     # expression), so it is the vehicle for actually killing the worker
-    # process, not just raising inside it.
+    # process, not just raising inside it. This is the point of the whole
+    # restart mechanism: the cases before and after the death must come back
+    # with real results, not be swept into `worker_died` along with it.
     cases = [
+        Case(id="t/before", source="1"),
         Case(id="t/kill", source="1", setup="import os; os._exit(1)"),
-        Case(id="t/never-reached", source="1"),
+        Case(id="t/after", source="fnp.sum(V)"),
     ]
-    observations, _stderr = _run_backend("inproc", cases)
-    assert set(observations) == {"t/kill", "t/never-reached"}
+    observations, _stderr, restarts = _run_backend("inproc", cases)
+    assert set(observations) == {"t/before", "t/kill", "t/after"}
+    assert observations["t/before"]["outcome"] == "returned"
     assert observations["t/kill"] == observe_worker_died()
-    assert observations["t/never-reached"] == observe_worker_died()
+    assert observations["t/after"]["outcome"] == "returned"
+    assert restarts == 1
+
+
+def test_run_backend_reports_the_number_of_restarts_it_needed():
+    # Two separate deaths in one run must cost two separate restarts, not
+    # one restart that happens to skip two cases: this pins the restart
+    # counter to the number of times the worker actually died, which is the
+    # figure that makes a 40-restart run "obviously different" on the
+    # result, per the module's docstring.
+    cases = [
+        Case(id="t/kill-a", source="1", setup="import os; os._exit(1)"),
+        Case(id="t/mid", source="1"),
+        Case(id="t/kill-b", source="1", setup="import os; os._exit(1)"),
+        Case(id="t/tail", source="fnp.sum(V)"),
+    ]
+    observations, _stderr, restarts = _run_backend("inproc", cases)
+    assert observations["t/kill-a"] == observe_worker_died()
+    assert observations["t/mid"]["outcome"] == "returned"
+    assert observations["t/kill-b"] == observe_worker_died()
+    assert observations["t/tail"]["outcome"] == "returned"
+    assert restarts == 2
+
+
+def test_run_backend_honours_the_restart_cap_and_does_not_hang(monkeypatch):
+    # A worker that dies on literally every case it is given (a broken
+    # import, say) must not restart forever. `_run_worker` is monkeypatched
+    # to a fake that never emits a single record, however many cases it is
+    # handed, so this proves termination without spending real time
+    # launching `_MAX_WORKER_RESTARTS` + 1 actual subprocesses.
+    calls: list[int] = []
+
+    def _always_dies_immediately(backend, cases):
+        calls.append(len(cases))
+        return {}, ""
+
+    monkeypatch.setattr(runner, "_run_worker", _always_dies_immediately)
+
+    cases = [
+        Case(id=f"t/case-{i}", source="1")
+        for i in range(runner._MAX_WORKER_RESTARTS + 5)
+    ]
+    observations, _stderr, restarts = _run_backend("inproc", cases)
+
+    assert restarts == runner._MAX_WORKER_RESTARTS
+    # One initial attempt plus one per restart, then the cap stops it from
+    # trying again — proof the loop actually terminates rather than relying
+    # on running out of cases.
+    assert len(calls) == runner._MAX_WORKER_RESTARTS + 1
+    assert len(observations) == len(cases)
+    assert all(obs == observe_worker_died() for obs in observations.values())
 
 
 def test_a_normal_run_is_unaffected_by_the_worker_died_fallback():
-    observations, _stderr = _run_backend(
+    observations, _stderr, restarts = _run_backend(
         "inproc", [Case(id="t/sum", source="fnp.sum(V)")]
     )
     assert observations["t/sum"]["outcome"] == "returned"
+    assert restarts == 0
 
 
 def test_run_backend_surfaces_worker_stderr_on_failure():
@@ -55,10 +115,13 @@ def test_run_backend_surfaces_worker_stderr_on_failure():
     # deterministically and fast, without needing a live server or a crafted
     # Case to provoke a real crash.
     cases = [Case(id="t/sum", source="fnp.sum(V)")]
-    observations, stderr_text = _run_backend("not-a-real-backend", cases)
+    observations, stderr_text, restarts = _run_backend("not-a-real-backend", cases)
     assert observations == {"t/sum": observe_worker_died()}
     assert stderr_text != ""
     assert "not-a-real-backend" in stderr_text
+    # Only one case existed and it was the one that "died"; there was nothing
+    # left to resume, so no restart was needed to reach that conclusion.
+    assert restarts == 0
 
 
 def test_run_backend_handles_a_subprocess_timeout(monkeypatch):
@@ -79,11 +142,14 @@ def test_run_backend_handles_a_subprocess_timeout(monkeypatch):
     monkeypatch.setattr(runner.subprocess, "run", _raise_timeout)
 
     cases = [Case(id="t/first", source="1"), Case(id="t/second", source="1")]
-    observations, stderr_text = _run_backend("inproc", cases)
+    observations, stderr_text, restarts = _run_backend("inproc", cases)
 
     assert observations["t/first"]["outcome"] == "returned"
     assert observations["t/second"] == observe_worker_died()
     assert stderr_text == "partial stderr"
+    # `t/second` is both the last case in the corpus and the one the
+    # timeout is attributed to, so there was nothing left to resume onto.
+    assert restarts == 0
 
 
 def test_looks_like_infrastructure_on_empty_observations():
@@ -154,6 +220,37 @@ def test_does_not_look_like_infrastructure_when_exception_types_are_a_mix():
     assert _looks_like_infrastructure(observations) is False
 
 
+def test_looks_like_infrastructure_when_restart_count_is_systemic():
+    # Only two of twenty-two cases actually show up as `worker_died` here —
+    # nowhere near a majority — but the backend needed
+    # `_SYSTEMIC_RESTART_THRESHOLD` restarts to get that far. That many
+    # separate worker deaths in one run is the backend dying over and over,
+    # not bad luck on a couple of cases, and must be flagged even though the
+    # old majority-of-cases rule alone would not catch it (this is exactly
+    # the 38%-of-8942-cases scenario that motivated this change, scaled
+    # down).
+    observations = {f"ok-{i}": {"outcome": "returned"} for i in range(20)}
+    observations["dead-1"] = observe_worker_died()
+    observations["dead-2"] = observe_worker_died()
+    assert (
+        _looks_like_infrastructure(
+            observations, restarts=runner._SYSTEMIC_RESTART_THRESHOLD
+        )
+        is True
+    )
+
+
+def test_does_not_look_like_infrastructure_with_a_couple_of_isolated_restarts():
+    # Same shape of observations as above, but only two restarts: this is
+    # the "handful of worker_died records is now normal and expected" case
+    # the new rule must NOT flag, now that a death costs only the one case
+    # that caused it.
+    observations = {f"ok-{i}": {"outcome": "returned"} for i in range(20)}
+    observations["dead-1"] = observe_worker_died()
+    observations["dead-2"] = observe_worker_died()
+    assert _looks_like_infrastructure(observations, restarts=2) is False
+
+
 def test_run_corpus_stops_the_server_even_when_a_backend_run_raises(monkeypatch):
     stopped = []
     sentinel = object()
@@ -181,7 +278,7 @@ def test_run_corpus_stops_the_server_on_the_infrastructure_early_return(monkeypa
     monkeypatch.setattr(
         runner,
         "_run_backend",
-        lambda backend, cases: ({"t/sum": observe_worker_died()}, ""),
+        lambda backend, cases: ({"t/sum": observe_worker_died()}, "", 0),
     )
 
     result = run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
@@ -189,6 +286,31 @@ def test_run_corpus_stops_the_server_on_the_infrastructure_early_return(monkeypa
     assert result.infrastructure_failure is not None
     assert result.divergences == []
     assert stopped == [sentinel]
+
+
+def test_run_corpus_reports_restart_count_and_flags_infrastructure_on_it(monkeypatch):
+    # Even with only ONE dead case in the observations (not remotely a
+    # majority), a run that needed a systemic number of restarts to produce
+    # it must still be flagged — and the restart count itself must land on
+    # the result, keyed by backend, so a 40-restart run is visibly different
+    # from a clean one.
+    monkeypatch.setattr(runner, "start_server", lambda: object())
+    monkeypatch.setattr(runner, "stop_server", lambda proc: None)
+    monkeypatch.setattr(
+        runner,
+        "_run_backend",
+        lambda backend, cases: (
+            {"t/sum": observe_worker_died()},
+            "",
+            runner._SYSTEMIC_RESTART_THRESHOLD,
+        ),
+    )
+
+    result = run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
+
+    assert result.infrastructure_failure is not None
+    assert str(runner._SYSTEMIC_RESTART_THRESHOLD) in result.infrastructure_failure
+    assert result.restarts["inproc"] == runner._SYSTEMIC_RESTART_THRESHOLD
 
 
 def test_run_corpus_surfaces_failing_backend_stderr_in_the_result(monkeypatch):
@@ -200,6 +322,7 @@ def test_run_corpus_surfaces_failing_backend_stderr_in_the_result(monkeypatch):
         lambda backend, cases: (
             {"t/sum": observe_worker_died()},
             f"{backend}: Traceback (most recent call last): boom",
+            0,
         ),
     )
 
@@ -221,6 +344,7 @@ def test_run_corpus_on_an_empty_case_list_returns_a_clean_empty_result():
     assert result.divergences == []
     assert result.flaky == []
     assert result.observations == {}
+    assert result.restarts == {}
 
 
 def test_worker_module_is_invocable_as_a_subprocess_with_no_cases():

--- a/tests/parity/test_runner_unit.py
+++ b/tests/parity/test_runner_unit.py
@@ -255,7 +255,7 @@ def test_run_corpus_stops_the_server_even_when_a_backend_run_raises(monkeypatch)
     stopped = []
     sentinel = object()
 
-    monkeypatch.setattr(runner, "start_server", lambda: sentinel)
+    monkeypatch.setattr(runner, "start_server", lambda base_port: sentinel)
     monkeypatch.setattr(runner, "stop_server", lambda proc: stopped.append(proc))
 
     def _boom(backend, cases):
@@ -273,7 +273,7 @@ def test_run_corpus_stops_the_server_on_the_infrastructure_early_return(monkeypa
     stopped = []
     sentinel = object()
 
-    monkeypatch.setattr(runner, "start_server", lambda: sentinel)
+    monkeypatch.setattr(runner, "start_server", lambda base_port: sentinel)
     monkeypatch.setattr(runner, "stop_server", lambda proc: stopped.append(proc))
     monkeypatch.setattr(
         runner,
@@ -294,7 +294,7 @@ def test_run_corpus_reports_restart_count_and_flags_infrastructure_on_it(monkeyp
     # it must still be flagged — and the restart count itself must land on
     # the result, keyed by backend, so a 40-restart run is visibly different
     # from a clean one.
-    monkeypatch.setattr(runner, "start_server", lambda: object())
+    monkeypatch.setattr(runner, "start_server", lambda base_port: object())
     monkeypatch.setattr(runner, "stop_server", lambda proc: None)
     monkeypatch.setattr(
         runner,
@@ -314,7 +314,7 @@ def test_run_corpus_reports_restart_count_and_flags_infrastructure_on_it(monkeyp
 
 
 def test_run_corpus_surfaces_failing_backend_stderr_in_the_result(monkeypatch):
-    monkeypatch.setattr(runner, "start_server", lambda: object())
+    monkeypatch.setattr(runner, "start_server", lambda base_port: object())
     monkeypatch.setattr(runner, "stop_server", lambda proc: None)
     monkeypatch.setattr(
         runner,

--- a/tests/parity/test_runner_unit.py
+++ b/tests/parity/test_runner_unit.py
@@ -1,0 +1,119 @@
+"""Fast unit coverage for `run_corpus`'s failure-handling edges.
+
+`test_runner_integration.py` proves the happy path end to end against real
+backends and a real server, but that suite is slow to run repeatedly while
+iterating on failure handling. These tests isolate three specific properties
+with fakes instead: a worker that dies mid-corpus does not lose the rest of
+the run, a majority-broken backend is reported as infrastructure rather than
+thousands of individual divergences, and the server is stopped even when a
+backend run raises partway through — none of which need a live server or a
+real worker subprocess to verify.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from tests.parity import runner
+from tests.parity.case import Case
+from tests.parity.observe import observe_worker_died
+from tests.parity.runner import _looks_like_infrastructure, _run_backend, run_corpus
+
+_ROOT = runner._ROOT
+
+
+def test_a_worker_that_dies_mid_corpus_backfills_the_rest_as_worker_died():
+    # `setup` runs as an exec'd statement (unlike `source`, which is only an
+    # expression), so it is the vehicle for actually killing the worker
+    # process, not just raising inside it.
+    cases = [
+        Case(id="t/kill", source="1", setup="import os; os._exit(1)"),
+        Case(id="t/never-reached", source="1"),
+    ]
+    observations = _run_backend("inproc", cases)
+    assert set(observations) == {"t/kill", "t/never-reached"}
+    assert observations["t/kill"] == observe_worker_died()
+    assert observations["t/never-reached"] == observe_worker_died()
+
+
+def test_a_normal_run_is_unaffected_by_the_worker_died_fallback():
+    observations = _run_backend("inproc", [Case(id="t/sum", source="fnp.sum(V)")])
+    assert observations["t/sum"]["outcome"] == "returned"
+
+
+def test_looks_like_infrastructure_on_empty_observations():
+    assert _looks_like_infrastructure({}) is True
+
+
+def test_looks_like_infrastructure_when_most_cases_died():
+    observations = {
+        "a": observe_worker_died(),
+        "b": observe_worker_died(),
+        "c": {"outcome": "returned"},
+    }
+    assert _looks_like_infrastructure(observations) is True
+
+
+def test_does_not_look_like_infrastructure_when_most_cases_are_fine():
+    observations = {
+        "a": {"outcome": "returned"},
+        "b": {"outcome": "returned"},
+        "c": observe_worker_died(),
+    }
+    assert _looks_like_infrastructure(observations) is False
+
+
+def test_run_corpus_stops_the_server_even_when_a_backend_run_raises(monkeypatch):
+    stopped = []
+    sentinel = object()
+
+    monkeypatch.setattr(runner, "start_server", lambda: sentinel)
+    monkeypatch.setattr(runner, "stop_server", lambda proc: stopped.append(proc))
+
+    def _boom(backend, cases):
+        raise RuntimeError("simulated worker-launch failure")
+
+    monkeypatch.setattr(runner, "_run_backend", _boom)
+
+    with pytest.raises(RuntimeError, match="simulated worker-launch failure"):
+        run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
+
+    assert stopped == [sentinel]
+
+
+def test_run_corpus_stops_the_server_on_the_infrastructure_early_return(monkeypatch):
+    stopped = []
+    sentinel = object()
+
+    monkeypatch.setattr(runner, "start_server", lambda: sentinel)
+    monkeypatch.setattr(runner, "stop_server", lambda proc: stopped.append(proc))
+    monkeypatch.setattr(
+        runner, "_run_backend", lambda backend, cases: {"t/sum": observe_worker_died()}
+    )
+
+    result = run_corpus([Case(id="t/sum", source="fnp.sum(V)")])
+
+    assert result.infrastructure_failure is not None
+    assert result.divergences == []
+    assert stopped == [sentinel]
+
+
+def test_worker_module_is_invocable_as_a_subprocess_with_no_cases():
+    # Sanity check on the exact invocation `_run_backend` uses: confirms
+    # `tests.parity.worker` imports cleanly as a namespace package (no
+    # `tests/__init__.py` needed) given cwd and PYTHONPATH set to the repo
+    # root, independent of any parity-runner logic.
+    proc = subprocess.run(
+        [sys.executable, "-m", "tests.parity.worker", "--backend=inproc"],
+        input="",
+        capture_output=True,
+        text=True,
+        cwd=_ROOT,
+        timeout=30,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == ""

--- a/tests/parity/test_server_port_isolation.py
+++ b/tests/parity/test_server_port_isolation.py
@@ -1,0 +1,59 @@
+"""Regression coverage for the parity harness's server-launch safety.
+
+This bug is invisible on a developer machine: a fresh checkout never has a
+leftover server sitting on the harness's port, so nothing here is caught by
+"it works locally". The failure only shows up when something else already
+holds the port at launch time (a leaked server from a prior suite, or a
+socket still lingering in Linux's longer TIME_WAIT window) — which is exactly
+what these tests simulate directly, without needing to actually race another
+test suite.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from tests.client_compat._server_fixture import (
+    ServerPortInUseError,
+    _worker_port,
+    start_server,
+)
+from tests.parity.runner import _PARITY_BASE_PORT
+
+
+def test_start_server_raises_instead_of_adopting_a_foreign_listener():
+    """Occupy the exact port the parity harness would use, then confirm
+    ``start_server`` fails loudly rather than handing back a subprocess that
+    is not actually the one listening on that port.
+
+    A plain TCP listener is enough to reproduce the failure class: the
+    launched server's own pre-bind probe (see ``start_server``) hits the same
+    "address already in use" condition regardless of whether the real
+    occupant is a raw socket or another flopscope-server with an open
+    session.
+    """
+    port = _worker_port(_PARITY_BASE_PORT)
+    foreign = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    foreign.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    foreign.bind(("127.0.0.1", port))
+    foreign.listen(1)
+    try:
+        with pytest.raises(ServerPortInUseError) as exc_info:
+            start_server(_PARITY_BASE_PORT)
+        message = str(exc_info.value)
+        assert str(port) in message
+        assert "already holds it" in message
+    finally:
+        foreign.close()
+
+
+def test_parity_and_client_compat_default_to_different_ports():
+    # The two harnesses import the SAME launch function; this pins the one
+    # fact that keeps them from colliding when run back-to-back in the same
+    # job — that they are configured with different port bases — so a future
+    # edit can't quietly re-merge the ranges.
+    from tests.client_compat._server_fixture import _BASE_PORT
+
+    assert _PARITY_BASE_PORT != _BASE_PORT

--- a/tests/parity/test_type_universe_unit.py
+++ b/tests/parity/test_type_universe_unit.py
@@ -11,11 +11,23 @@ def test_covers_every_position():
         "list-element",
         "index-key",
         "slice-bound",
+        "second-positional",
+        "dict-literal",
     } <= names
 
 
 def test_includes_the_seed_bug_value():
     assert "complex" in {name for name, _, _ in type_universe.VALUES}
+
+
+def test_includes_numpy_complex_scalars():
+    names = {name for name, _, _ in type_universe.VALUES}
+    assert {"np-complex64", "np-complex128"} <= names
+
+
+def test_includes_negative_integer_boundaries():
+    names = {name for name, _, _ in type_universe.VALUES}
+    assert {"int64-min", "int64-min-minus-one", "huge-negative-int"} <= names
 
 
 def test_numpy_values_are_tagged_so_they_can_be_skipped():
@@ -33,3 +45,8 @@ def test_builds_the_full_cross_product():
 def test_case_ids_encode_value_and_position():
     ids = {case.id for case in type_universe.build()}
     assert "types/complex::slice-bound" in ids
+
+
+def test_every_case_is_tagged_with_its_position():
+    for case in type_universe.build():
+        assert any(tag.startswith("position:") for tag in case.tags), case.id

--- a/tests/parity/test_type_universe_unit.py
+++ b/tests/parity/test_type_universe_unit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from tests.parity.corpus import type_universe
+
+
+def test_covers_every_position():
+    names = {name for name, _ in type_universe.POSITIONS}
+    assert {
+        "positional",
+        "keyword",
+        "list-element",
+        "index-key",
+        "slice-bound",
+    } <= names
+
+
+def test_includes_the_seed_bug_value():
+    assert "complex" in {name for name, _, _ in type_universe.VALUES}
+
+
+def test_numpy_values_are_tagged_so_they_can_be_skipped():
+    for name, _, tags in type_universe.VALUES:
+        if name.startswith("np-"):
+            assert "requires:numpy" in tags
+
+
+def test_builds_the_full_cross_product():
+    assert len(type_universe.build()) == len(type_universe.VALUES) * len(
+        type_universe.POSITIONS
+    )
+
+
+def test_case_ids_encode_value_and_position():
+    ids = {case.id for case in type_universe.build()}
+    assert "types/complex::slice-bound" in ids

--- a/tests/parity/test_worker_unit.py
+++ b/tests/parity/test_worker_unit.py
@@ -24,6 +24,41 @@ class _FakeCtx:
         self._i += 1
         return value
 
+    def summary(self):
+        # No-op stand-in for the real refresh call `run_case` now makes before
+        # every `flops_used` read (needed on the client backend; harmless
+        # here since the fake's counter doesn't need refreshing).
+        return ""
+
+
+class _FakeCachedCtx:
+    """Stands in for a BudgetContext whose `flops_used` is a CACHE that only
+    refreshes on an explicit `summary()` call — this is how the real client
+    backend behaves (`flopscope-client/src/flopscope/_budget.py`: the local
+    `_flops_used` cache is only updated from `__enter__`, `__exit__`, or a
+    `summary()` call, never automatically after an individual op dispatch).
+
+    Regression test double for the bug where `run_case` read `ctx.flops_used`
+    immediately after `eval()` without refreshing first: since the worker
+    holds one ambient context open for the whole corpus, that read always
+    landed on a stale cache, so the client backend reported a `flops` delta
+    of 0 for every single case, no matter what actually ran.
+    """
+
+    def __init__(self, true_values):
+        self._true_values = list(true_values)
+        self._true_i = 0
+        self._cached = 0
+
+    def summary(self):
+        self._cached = self._true_values[min(self._true_i, len(self._true_values) - 1)]
+        self._true_i += 1
+        return ""
+
+    @property
+    def flops_used(self):
+        return self._cached
+
 
 def _ns():
     # A tiny stand-in backend: enough for the worker's plumbing.
@@ -41,6 +76,22 @@ def test_records_an_exception_instead_of_propagating():
     obs = run_case(_ns(), Case(id="t/boom", source="V[99]"), _FakeCtx([0, 3]))
     assert obs["outcome"] == "raised"
     assert obs["exc_type"] == "IndexError"
+    assert obs["flops"] == 3
+
+
+def test_run_case_refreshes_the_flops_cache_before_reading_the_delta():
+    # Regression test for a per-case FLOP delta that was always 0 on the
+    # client backend: `run_case` must call `ctx.summary()` (or an equivalent
+    # refresh) before every `ctx.flops_used` read, not just read the
+    # property directly, or a cached-until-refreshed context reports every
+    # case as costing 0 FLOPs regardless of what actually ran.
+    obs = run_case(_ns(), Case(id="t/ok", source="V[0]"), _FakeCachedCtx([0, 5]))
+    assert obs["flops"] == 5
+
+
+def test_run_case_refreshes_the_flops_cache_on_the_exception_path_too():
+    obs = run_case(_ns(), Case(id="t/boom", source="V[99]"), _FakeCachedCtx([0, 3]))
+    assert obs["outcome"] == "raised"
     assert obs["flops"] == 3
 
 

--- a/tests/parity/test_worker_unit.py
+++ b/tests/parity/test_worker_unit.py
@@ -152,6 +152,53 @@ def test_run_stream_rebuilds_fixtures_so_one_case_cannot_contaminate_the_next():
     assert spy.call_count == 2
 
 
+#: A value whose `.shape` attribute RAISES when merely accessed (not just
+#: reports a wrong type) defeats `observe_result`'s own type-based defenses,
+#: exercising the backstop in `run_case` itself. This is the real-world
+#: shape: a registry operation returning a class rather than an instance
+#: leaves `.shape` as a descriptor that misbehaves when read.
+_HOSTILE_SETUP = """
+class Hostile:
+    @property
+    def shape(self):
+        raise RuntimeError("shape blew up")
+"""
+
+
+def test_run_case_records_a_result_that_fails_to_describe_instead_of_raising():
+    case = Case(id="t/hostile", source="Hostile()", setup=_HOSTILE_SETUP)
+    obs = run_case(_ns(), case, _FakeCtx([0, 0]))
+    assert obs["id"] == "t/hostile"
+    assert obs["outcome"] == "record_failed"
+    assert obs["exc_type"] == "RuntimeError"
+
+
+def test_run_stream_processes_the_next_case_after_a_record_failure():
+    # The important half of this regression test: a case that defeats
+    # `observe_result` must not cost the worker every case still queued
+    # behind it on stdin. This is the exact failure mode a real corpus run
+    # hit: an unhandled exception from recording (not from the expression
+    # itself) propagated out of `run_case`, out of `run_stream`, and killed
+    # the worker process mid-run.
+    bad = Case(id="t/hostile", source="Hostile()", setup=_HOSTILE_SETUP)
+    good = Case(id="t/after", source="1 + 1")
+    stdin = io.StringIO(
+        json.dumps(bad.to_json()) + "\n" + json.dumps(good.to_json()) + "\n"
+    )
+    stdout = io.StringIO()
+
+    run_stream(_FakeFnp(), _FakeCtx([0, 0]), stdin, stdout)
+
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert len(lines) == 2
+    assert lines[0]["id"] == "t/hostile"
+    assert lines[0]["outcome"] == "record_failed"
+    # The case queued behind the bad one still ran and was recorded: the
+    # worker did not die and did not skip it.
+    assert lines[1]["id"] == "t/after"
+    assert lines[1]["outcome"] == "returned"
+
+
 def test_run_stream_skips_malformed_lines_without_losing_queued_cases(capsys):
     good = Case(id="t/ok2", source="1 + 1")
     stdin = io.StringIO(

--- a/tests/parity/test_worker_unit.py
+++ b/tests/parity/test_worker_unit.py
@@ -112,12 +112,23 @@ def test_fixture_source_builds_every_documented_fixture():
         assert f"{name} = " in FIXTURE_SOURCE
 
 
+class _FakeRandom:
+    """Stands in for `flopscope.numpy.random`: only `seed()` is needed, since
+    `FIXTURE_SOURCE` calls it unconditionally as its first statement."""
+
+    @staticmethod
+    def seed(value=None):
+        pass
+
+
 class _FakeFnp:
     """Stands in for `flopscope.numpy`: `array()` returns a fresh, plain
     mutable `list` on every call (scalars pass through as-is, since a bare
     float has nothing mutable to protect), so a case that mutates a fixture
     in place can only ever corrupt the namespace it was handed, never a
     later case's."""
+
+    random = _FakeRandom()
 
     @staticmethod
     def array(values, dtype=None):

--- a/tests/parity/test_worker_unit.py
+++ b/tests/parity/test_worker_unit.py
@@ -1,0 +1,56 @@
+"""Worker unit tests that need no backend: namespace construction and dispatch."""
+
+from __future__ import annotations
+
+from tests.parity.case import Case
+from tests.parity.worker import FIXTURE_SOURCE, run_case
+
+
+class _FakeCtx:
+    """Stands in for a BudgetContext; returns a rising FLOP counter."""
+
+    def __init__(self, steps):
+        self._steps = list(steps)
+        self._i = 0
+
+    @property
+    def flops_used(self):
+        value = self._steps[min(self._i, len(self._steps) - 1)]
+        self._i += 1
+        return value
+
+
+def _ns():
+    # A tiny stand-in backend: enough for the worker's plumbing.
+    return {"fnp": None, "V": [1.0, 2.0, 3.0]}
+
+
+def test_runs_an_expression_and_records_the_result():
+    obs = run_case(_ns(), Case(id="t/ok", source="V[0]"), _FakeCtx([0, 5]))
+    assert obs["id"] == "t/ok"
+    assert obs["outcome"] == "returned"
+    assert obs["flops"] == 5
+
+
+def test_records_an_exception_instead_of_propagating():
+    obs = run_case(_ns(), Case(id="t/boom", source="V[99]"), _FakeCtx([0, 3]))
+    assert obs["outcome"] == "raised"
+    assert obs["exc_type"] == "IndexError"
+    assert obs["flops"] == 3
+
+
+def test_setup_statements_run_before_the_expression():
+    case = Case(id="t/setup", source="k", setup="k = V[1]")
+    obs = run_case(_ns(), case, _FakeCtx([0, 0]))
+    assert obs["outcome"] == "returned"
+
+
+def test_a_syntactically_invalid_case_is_recorded_not_crashed():
+    obs = run_case(_ns(), Case(id="t/bad", source="V["), _FakeCtx([0, 0]))
+    assert obs["outcome"] == "raised"
+    assert obs["exc_type"] == "SyntaxError"
+
+
+def test_fixture_source_builds_every_documented_fixture():
+    for name in ("A", "B", "V", "I", "M", "E", "S"):
+        assert f"{name} = " in FIXTURE_SOURCE

--- a/tests/parity/test_worker_unit.py
+++ b/tests/parity/test_worker_unit.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import io
+import json
+from unittest.mock import patch
+
 from tests.parity.case import Case
-from tests.parity.worker import FIXTURE_SOURCE, run_case
+from tests.parity.observe import fingerprint
+from tests.parity.worker import FIXTURE_SOURCE, build_namespace, run_case, run_stream
 
 
 class _FakeCtx:
@@ -54,3 +59,66 @@ def test_a_syntactically_invalid_case_is_recorded_not_crashed():
 def test_fixture_source_builds_every_documented_fixture():
     for name in ("A", "B", "V", "I", "M", "E", "S"):
         assert f"{name} = " in FIXTURE_SOURCE
+
+
+class _FakeFnp:
+    """Stands in for `flopscope.numpy`: `array()` returns a fresh, plain
+    mutable `list` on every call (scalars pass through as-is, since a bare
+    float has nothing mutable to protect), so a case that mutates a fixture
+    in place can only ever corrupt the namespace it was handed, never a
+    later case's."""
+
+    @staticmethod
+    def array(values, dtype=None):
+        if isinstance(values, (list, tuple)):
+            return list(values)
+        return values
+
+
+def test_run_stream_rebuilds_fixtures_so_one_case_cannot_contaminate_the_next():
+    # This is the regression test for the exact bug that discarded a prior
+    # measurement pass: an in-place mutation in one case leaking into the
+    # next via a fixture shared across cases. It only passes if `run_stream`
+    # calls `build_namespace(fnp)` fresh inside the loop, per case.
+    mutate = Case(id="t/mutate", source="V[0]", setup="V[0] = 999.0")
+    read = Case(id="t/read", source="V[0]")
+    stdin = io.StringIO(
+        json.dumps(mutate.to_json()) + "\n" + json.dumps(read.to_json()) + "\n"
+    )
+    stdout = io.StringIO()
+
+    with patch("tests.parity.worker.build_namespace", wraps=build_namespace) as spy:
+        run_stream(_FakeFnp(), _FakeCtx([0, 0]), stdin, stdout)
+
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert len(lines) == 2
+    assert lines[0]["id"] == "t/mutate"
+    assert lines[0]["value"] == fingerprint(999.0)
+    # The second case must see a pristine V, not the first case's mutation.
+    assert lines[1]["id"] == "t/read"
+    assert lines[1]["value"] == fingerprint(3.0)
+    # One fresh namespace per case, not one shared namespace for the run.
+    assert spy.call_count == 2
+
+
+def test_run_stream_skips_malformed_lines_without_losing_queued_cases(capsys):
+    good = Case(id="t/ok2", source="1 + 1")
+    stdin = io.StringIO(
+        "not json at all\n"
+        + json.dumps({"source": "1"})  # well-formed JSON, missing required "id"
+        + "\n"
+        + json.dumps(good.to_json())
+        + "\n"
+    )
+    stdout = io.StringIO()
+
+    run_stream(_FakeFnp(), _FakeCtx([0, 0]), stdin, stdout)
+
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert len(lines) == 1
+    assert lines[0]["id"] == "t/ok2"
+    assert lines[0]["outcome"] == "returned"
+    # Diagnostics go to stderr; stdout carries only clean observation JSON
+    # (already implied above by every stdout line parsing as JSON).
+    captured = capsys.readouterr()
+    assert "skipping malformed case line" in captured.err

--- a/tests/parity/worker.py
+++ b/tests/parity/worker.py
@@ -19,7 +19,11 @@ import os
 import sys
 
 from tests.parity.case import Case
-from tests.parity.observe import observe_exception, observe_result
+from tests.parity.observe import (
+    observe_exception,
+    observe_record_failure,
+    observe_result,
+)
 
 #: Fixtures are rebuilt per case: an audit pass was discarded to in-place-op
 #: contamination, so shared mutable fixtures are a known failure mode.
@@ -68,7 +72,17 @@ def run_case(namespace: dict, case: Case, ctx) -> dict:
         ctx.summary()
         return {"id": case.id, **observe_exception(exc, ctx.flops_used - before)}
     ctx.summary()
-    return {"id": case.id, **observe_result(value, ctx.flops_used - before)}
+    delta = ctx.flops_used - before
+    try:
+        result = observe_result(value, delta)
+    except Exception as exc:  # noqa: BLE001 - recording, not handling
+        # observe_result describing an arbitrary returned value is itself
+        # fallible (e.g. a registry op handing back a class instead of an
+        # instance, whose attributes lie about their own shape). A failure
+        # here must be recorded like any other outcome, not propagate and
+        # kill the worker mid-stream, discarding every case still queued.
+        result = observe_record_failure(exc, delta)
+    return {"id": case.id, **result}
 
 
 def _import_backend(backend: str):

--- a/tests/parity/worker.py
+++ b/tests/parity/worker.py
@@ -1,0 +1,97 @@
+"""Execute the parity corpus against exactly ONE backend.
+
+Run as::
+
+    python -m tests.parity.worker --backend=inproc
+    python -m tests.parity.worker --backend=client
+
+Reads one JSON-encoded Case per line on stdin; writes one JSON observation per
+line on stdout. The two backends install under the same import name
+(``flopscope``) and cannot coexist in one interpreter, which is why this is a
+separate process rather than a function call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from tests.parity.case import Case
+from tests.parity.observe import observe_exception, observe_result
+
+#: Fixtures are rebuilt per case: an audit pass was discarded to in-place-op
+#: contamination, so shared mutable fixtures are a known failure mode.
+FIXTURE_SOURCE = """
+A = fnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
+B = fnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype="float32")
+V = fnp.array([3.0, 1.0, 4.0, 1.0, 5.0, 9.0], dtype="float32")
+I = fnp.array([3, 1, 4, 1, 5, 9], dtype="int64")
+M = fnp.array([True, False, True, False, True, False], dtype="bool")
+E = fnp.array([], dtype="float32")
+S = fnp.array(2.0, dtype="float32")
+"""
+
+_BUDGET = 10**15
+
+
+def build_namespace(fnp) -> dict:
+    """Return a fresh namespace with `fnp` bound and the fixtures rebuilt."""
+    namespace: dict = {"fnp": fnp}
+    exec(FIXTURE_SOURCE, namespace)  # noqa: S102 - fixtures are ours, not input
+    return namespace
+
+
+def run_case(namespace: dict, case: Case, ctx) -> dict:
+    """Execute one case in *namespace*, recording the outcome and FLOP delta."""
+    local = dict(namespace)
+    before = ctx.flops_used
+    try:
+        if case.setup:
+            exec(case.setup, local)  # noqa: S102 - corpus is ours, not user input
+        value = eval(case.source, local)  # noqa: S307 - corpus is ours
+    except BaseException as exc:  # noqa: BLE001 - recording, not handling
+        return {"id": case.id, **observe_exception(exc, ctx.flops_used - before)}
+    return {"id": case.id, **observe_result(value, ctx.flops_used - before)}
+
+
+def _import_backend(backend: str):
+    """Import exactly one backend and return its numpy-shaped module."""
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    if backend == "client":
+        sys.path.insert(0, os.path.join(root, "flopscope-client", "src"))
+    else:
+        sys.path.insert(0, os.path.join(root, "src"))
+    import flopscope
+    import flopscope.numpy as fnp
+
+    return flopscope, fnp
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=("inproc", "client"), required=True)
+    args = parser.parse_args(argv)
+
+    flopscope, fnp = _import_backend(args.backend)
+
+    # ONE ambient context for the whole run: the client rejects nested contexts.
+    ctx = flopscope.BudgetContext(flop_budget=_BUDGET, quiet=True)
+    ctx.__enter__()
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            case = Case.from_json(json.loads(line))
+            observation = run_case(build_namespace(fnp), case, ctx)
+            sys.stdout.write(json.dumps(observation) + "\n")
+            sys.stdout.flush()
+    finally:
+        ctx.__exit__(None, None, None)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/parity/worker.py
+++ b/tests/parity/worker.py
@@ -44,15 +44,30 @@ def build_namespace(fnp) -> dict:
 
 
 def run_case(namespace: dict, case: Case, ctx) -> dict:
-    """Execute one case in *namespace*, recording the outcome and FLOP delta."""
+    """Execute one case in *namespace*, recording the outcome and FLOP delta.
+
+    ``ctx.summary()`` is called before every ``flops_used`` read, including
+    ``before``. The client backend's ``flops_used`` is a local cache that is
+    only refreshed on context enter/exit or an explicit ``summary()`` call —
+    never automatically after an op dispatch — and this worker holds one
+    ambient context open for the whole corpus rather than one per case, so
+    without this the client's per-case delta would read as 0 for every case.
+    ``summary()`` is a read-only status query on both backends (confirmed: it
+    prints nothing and bills no FLOPs itself), so this is safe to call
+    unconditionally, including on the in-process backend where it is a no-op
+    refresh.
+    """
     local = dict(namespace)
+    ctx.summary()
     before = ctx.flops_used
     try:
         if case.setup:
             exec(case.setup, local)  # noqa: S102 - corpus is ours, not user input
         value = eval(case.source, local)  # noqa: S307 - corpus is ours
     except Exception as exc:  # noqa: BLE001 - recording, not handling
+        ctx.summary()
         return {"id": case.id, **observe_exception(exc, ctx.flops_used - before)}
+    ctx.summary()
     return {"id": case.id, **observe_result(value, ctx.flops_used - before)}
 
 

--- a/tests/parity/worker.py
+++ b/tests/parity/worker.py
@@ -51,7 +51,7 @@ def run_case(namespace: dict, case: Case, ctx) -> dict:
         if case.setup:
             exec(case.setup, local)  # noqa: S102 - corpus is ours, not user input
         value = eval(case.source, local)  # noqa: S307 - corpus is ours
-    except BaseException as exc:  # noqa: BLE001 - recording, not handling
+    except Exception as exc:  # noqa: BLE001 - recording, not handling
         return {"id": case.id, **observe_exception(exc, ctx.flops_used - before)}
     return {"id": case.id, **observe_result(value, ctx.flops_used - before)}
 
@@ -69,6 +69,30 @@ def _import_backend(backend: str):
     return flopscope, fnp
 
 
+def run_stream(fnp, ctx, stdin, stdout) -> None:
+    """Read cases from *stdin*, write one observation line per case to *stdout*.
+
+    Fixtures are rebuilt fresh for every case (`build_namespace` is called
+    inside this loop, not hoisted above it): a prior measurement pass had to
+    be discarded because an in-place operation in one case contaminated a
+    later one via a shared fixture object.
+    """
+    for line in stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            case = Case.from_json(json.loads(line))
+        except Exception as exc:  # noqa: BLE001 - a bad line must not kill the worker
+            # Never write diagnostics to stdout: it carries the observation
+            # records and the parent parses it line-by-line as JSON.
+            print(f"worker: skipping malformed case line: {exc}", file=sys.stderr)
+            continue
+        observation = run_case(build_namespace(fnp), case, ctx)
+        stdout.write(json.dumps(observation) + "\n")
+        stdout.flush()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", choices=("inproc", "client"), required=True)
@@ -80,14 +104,7 @@ def main(argv: list[str] | None = None) -> int:
     ctx = flopscope.BudgetContext(flop_budget=_BUDGET, quiet=True)
     ctx.__enter__()
     try:
-        for line in sys.stdin:
-            line = line.strip()
-            if not line:
-                continue
-            case = Case.from_json(json.loads(line))
-            observation = run_case(build_namespace(fnp), case, ctx)
-            sys.stdout.write(json.dumps(observation) + "\n")
-            sys.stdout.flush()
+        run_stream(fnp, ctx, sys.stdin, sys.stdout)
     finally:
         ctx.__exit__(None, None, None)
     return 0

--- a/tests/parity/worker.py
+++ b/tests/parity/worker.py
@@ -27,7 +27,24 @@ from tests.parity.observe import (
 
 #: Fixtures are rebuilt per case: an audit pass was discarded to in-place-op
 #: contamination, so shared mutable fixtures are a known failure mode.
+#:
+#: The fixed seed below (an arbitrary but memorable constant, not derived
+#: from anything) reseeds the global RNG identically on both backends before
+#: every case. Without it, a case that draws from `fnp.random.*` compares two
+#: independently-seeded streams, so the two backends only agree by chance
+#: (e.g. 1-in-6 for a 6-element `random.choice`) - a coin flip, not a
+#: comparison. Confirmed by direct measurement (not just assumed) that a
+#: seeded draw is bit-identical between the two backends: `fnp.random.seed
+#: (1234); fnp.random.choice(V)` returns `1.0` on both, and `fnp.random.seed
+#: (1234); fnp.random.rand(3)` returns the same three float64 values to the
+#: last bit. This call costs 0 FLOPs on both backends (`random.seed` is a
+#: free/configuration op, not a sampler), and even if it billed something,
+#: this line runs as part of fixture construction in `build_namespace`,
+#: which executes (and is fully accounted for) before `run_case` takes its
+#: `before` FLOP snapshot - so it can never leak into a case's measured
+#: delta either way.
 FIXTURE_SOURCE = """
+fnp.random.seed(1234)
 A = fnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
 B = fnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype="float32")
 V = fnp.array([3.0, 1.0, 4.0, 1.0, 5.0, 9.0], dtype="float32")


### PR DESCRIPTION
## What

Adds `tests/parity/`, a differential test harness that runs identical expressions
against both flopscope backends -- the in-process numpy-backed one under `src/`
and the client/server one under `flopscope-client/` -- and fails when they
disagree.

The repository already tests two edges of a triangle: `tests/numpy_compat/`
covers in-process versus NumPy, and `tests/client_compat/` covers client versus
NumPy. This adds the missing edge, client versus in-process, which is the only
pair that has to agree exactly.

## Why the existing harness could not cover this

`tests/client_compat/` runs NumPy's own suite against the client, and its design
makes a specific class of difference invisible rather than merely untested:

- `_patch_client._to_client_arg` converts `ndarray` to a list and numpy scalars
  to Python scalars *before* the call reaches the client, so argument-encoding
  differences cannot arise there.
- `_coerce._CoercingConstructor` materialises every `RemoteArray` via `.tolist()`
  before `np.testing.assert_*` sees it, which discards dtype and container type.
- `array`, `asarray` and `arange` are in `_SKIP`, so the client's own
  constructors are never exercised.
- NumPy's tests are written from NumPy's perspective and cannot express a remote
  value flowing back into a remote call.

Each of those choices is locally correct and necessary for that harness to run.
Together they mean no amount of additional tests written inside it would find
this class. `xfails_client.py` is deliberately empty, so this is not suppression
-- it is the harness's shape.

Nothing anywhere compared FLOP cost between the backends.

## How it works

A parent process owns a corpus of serialisable cases and imports neither
backend. It spawns two worker subprocesses, one per backend -- both packages
install under the import name `flopscope` and cannot coexist in one interpreter.
Workers record what they observe and never normalise; what counts as equal is
decided downstream in the comparator, where it is visible and reviewable.

Nine dimensions are compared independently: outcome, exception class, exception
ancestry, value, dtype, shape, container, Python type, and FLOPs billed. Values
compare bit-exactly rather than approximately. Exceptions compare on class and
builtin ancestry, never on message text.

The corpus comes from three orthogonal sources: a mechanical grid over every
registered op crossed with argument patterns, a sweep of argument values crossed
with argument position, and a small hand-written set of realistic idioms.

## Known differences

Current differences are recorded in a reasoned allowlist. It is strict in both
directions: an unexplained difference fails, and an entry that no longer matches
anything also fails and must be deleted. Fixing something therefore forces
removal of its entry in the same change, so the list cannot accumulate dead
weight. Entries may be globs, and each entry's match count is reported so a
broad one is visible in review.

Twenty-six cases are excluded and reported as undriven rather than silently
dropped: seventeen crash the interpreter outright and nine return uninitialised
memory, so neither can be compared.

## CI

- `make test-parity-fast` -- blocking on every pull request, about 2 seconds.
- `make test-parity-full` -- reports on pull requests, blocks pushes to main and
  manual dispatch, about 4.6 minutes.

Note that `tests/parity` is excluded from the default pytest run via `addopts`,
so any invocation must name the path explicitly.

## Scope

Test-only. No production code under `src/`, `flopscope-client/` or
`flopscope-server/` is modified. 129 unit tests, pyright clean, ruff clean.

The five pre-existing failures in the main suite (docs-generation tests that
require `scripts/generate_api_docs.py` to have run) are unrelated and reproduce
identically on the base commit.