### PR TITLE
fix(server): stop charging for results the server cannot deliver

### DIFF
--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -313,6 +313,15 @@ class RequestHandler:
                 "error_type": "ValueError",
                 "message": f"array too large: {len(data)} bytes exceeds {MAX_ARRAY_BYTES} byte limit",
             }
+        if dtype not in _CLIENT_DECODABLE_DTYPES:
+            return {
+                "status": "error",
+                "error_type": "UnsupportedDtypeError",
+                "message": (
+                    f"dtype {dtype!r} is not supported; arrays must use a dtype "
+                    f"the client can decode"
+                ),
+            }
         arr = np.frombuffer(data, dtype=dtype).reshape(shape).copy()
         handle = self._session.store_array(arr)
         meta = self._session.array_metadata(handle)
@@ -585,6 +594,15 @@ class RequestHandler:
                     "error_type": "ValueError",
                     "message": f"result array too large: {result.nbytes} bytes exceeds {MAX_ARRAY_BYTES} byte limit",
                 }
+            dtype_str = str(result.dtype)
+            if dtype_str not in _CLIENT_DECODABLE_DTYPES:
+                return {
+                    "status": "error",
+                    "error_type": "UnsupportedReturnType",
+                    "message": (
+                        f"result dtype {dtype_str!r} cannot be delivered to the client"
+                    ),
+                }
             handle = self._session.store_array(result)
             meta = self._session.array_metadata(handle)
             return {"status": "ok", "result": meta, "budget": budget}
@@ -595,17 +613,23 @@ class RequestHandler:
             # (array or 0-d scalar) stranded in the store. Refused means
             # refused for the whole result, not a partial one.
             for r in result:
+                undecodable_dtype = None
                 if isinstance(r, np.generic) and not _is_msgpack_native(r.item()):
-                    dtype_str = str(r.dtype)
-                    if dtype_str not in _CLIENT_DECODABLE_DTYPES:
-                        return {
-                            "status": "error",
-                            "error_type": "UnsupportedReturnType",
-                            "message": (
-                                f"result dtype {dtype_str!r} cannot be "
-                                f"delivered to the client"
-                            ),
-                        }
+                    undecodable_dtype = str(r.dtype)
+                elif isinstance(r, np.ndarray):
+                    undecodable_dtype = str(r.dtype)
+                if (
+                    undecodable_dtype is not None
+                    and undecodable_dtype not in _CLIENT_DECODABLE_DTYPES
+                ):
+                    return {
+                        "status": "error",
+                        "error_type": "UnsupportedReturnType",
+                        "message": (
+                            f"result dtype {undecodable_dtype!r} cannot be "
+                            f"delivered to the client"
+                        ),
+                    }
 
             items = []
             for r in result:

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -590,13 +590,38 @@ class RequestHandler:
             return {"status": "ok", "result": meta, "budget": budget}
 
         if isinstance(result, (tuple, list)):
+            # Validate every element before storing anything: a later element
+            # failing decodability must not leave an earlier element's handle
+            # (array or 0-d scalar) stranded in the store. Refused means
+            # refused for the whole result, not a partial one.
+            for r in result:
+                if isinstance(r, np.generic) and not _is_msgpack_native(r.item()):
+                    dtype_str = str(r.dtype)
+                    if dtype_str not in _CLIENT_DECODABLE_DTYPES:
+                        return {
+                            "status": "error",
+                            "error_type": "UnsupportedReturnType",
+                            "message": (
+                                f"result dtype {dtype_str!r} cannot be "
+                                f"delivered to the client"
+                            ),
+                        }
+
             items = []
             for r in result:
                 if isinstance(r, np.ndarray):
                     handle = self._session.store_array(r)
                     items.append(self._session.array_metadata(handle))
                 elif isinstance(r, np.generic):
-                    items.append({"value": r.item(), "dtype": str(r.dtype)})
+                    item = r.item()
+                    if not _is_msgpack_native(item):
+                        # Not encodable by value, but decodability was already
+                        # confirmed above. Deliver it the way a 0-d array
+                        # result is already delivered.
+                        handle = self._session.store_array(np.asarray(r))
+                        items.append(self._session.array_metadata(handle))
+                    else:
+                        items.append({"value": item, "dtype": str(r.dtype)})
                 elif isinstance(r, (int, float)):
                     dtype_str = "float64" if isinstance(r, float) else "int64"
                     items.append({"value": r, "dtype": dtype_str})
@@ -614,9 +639,19 @@ class RequestHandler:
             dtype_str = str(result.dtype)
             item = result.item()
             if not _is_msgpack_native(item):
-                # Not encodable by value. Deliver it the way a 0-d array
-                # result is already delivered, rather than failing after the
-                # caller has been charged for computing it.
+                if dtype_str not in _CLIENT_DECODABLE_DTYPES:
+                    return {
+                        "status": "error",
+                        "error_type": "UnsupportedReturnType",
+                        "message": (
+                            f"result dtype {dtype_str!r} cannot be delivered "
+                            f"to the client"
+                        ),
+                    }
+                # Not encodable by value, but the dtype is one the client can
+                # decode. Deliver it the way a 0-d array result is already
+                # delivered, rather than failing after the caller has been
+                # charged for computing it.
                 handle = self._session.store_array(np.asarray(result))
                 meta = self._session.array_metadata(handle)
                 return {"status": "ok", "result": meta, "budget": budget}
@@ -672,12 +707,16 @@ class RequestHandler:
         # conformance test (tests/test_registry_conformance.py) catches any op
         # whose return type lands here.
         serializable = _make_serializable(result)
-        if _is_msgpack_native(serializable):
-            return {"status": "ok", "result": {"value": serializable}, "budget": budget}
-        raise flops.UnsupportedReturnType(
-            f"{type(result).__name__} is not serializable across the "
-            f"client/server boundary"
-        )
+        if not _is_msgpack_native(serializable):
+            return {
+                "status": "error",
+                "error_type": "UnsupportedReturnType",
+                "message": (
+                    f"result of type {type(result).__name__!r} cannot be "
+                    f"encoded for delivery to the client"
+                ),
+            }
+        return {"status": "ok", "result": {"value": serializable}, "budget": budget}
 
 
 # ---------------------------------------------------------------------------

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -11,6 +11,7 @@ import numpy as np
 
 import flopscope as flops
 from flopscope._perm_group import SymmetryGroup, _Permutation
+from flopscope_server import _array_store
 from flopscope_server._session import Session
 
 _HANDLE_RE = re.compile(r"^a\d+$")
@@ -189,6 +190,21 @@ class RequestHandler:
                 return self._handle_free(request)
             if op == "budget_status":
                 return self._handle_budget_status()
+
+            # Capacity is checked before dispatch, on purpose: ArrayStore.put
+            # raises only at store time, which for every op below is after
+            # the op has already run and been charged. Refusing here instead
+            # means an over-capacity request costs the caller nothing.
+            if self._session.array_count >= _array_store.MAX_ARRAY_COUNT:
+                return {
+                    "status": "error",
+                    "error_type": "MemoryError",
+                    "message": (
+                        f"array store limit reached: "
+                        f"{_array_store.MAX_ARRAY_COUNT} arrays"
+                    ),
+                }
+
             if op == "create_from_data":
                 return self._handle_create_from_data(request)
             if op == "__getitem__":

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -59,6 +59,46 @@ def _allowed_rs_methods() -> frozenset:
 
 _ALLOWED_RS_METHODS = _allowed_rs_methods()
 
+# Ops whose result can store more than one array/scalar handle. The
+# per-request capacity gate in RequestHandler.handle() must know this BEFORE
+# dispatch: flopscope charges FLOPs synchronously as part of running an op
+# (BudgetContext.deduct charges before the numpy kernel is even invoked —
+# see flopscope._budget), so once dispatch begins the charge is permanent.
+# A refusal decided only after the op has already run would no longer be
+# free. Values are a conservative upper bound on the number of handles a
+# single call can produce, keyed by dotted op name.
+_FIXED_MULTI_HANDLE_COUNTS: dict[str, int] = {
+    "linalg.eig": 2,
+    "linalg.eigh": 2,
+    "linalg.qr": 2,
+    "linalg.svd": 3,
+    "linalg.slogdet": 2,
+    "linalg.lstsq": 4,
+    "modf": 2,
+    "frexp": 2,
+    "divmod": 2,
+    "polydiv": 2,
+    "histogram": 2,
+    "histogram2d": 3,
+}
+
+# Ops that return one output array per array argument, i.e. arity equals the
+# number of array handles in the request rather than a fixed constant.
+_PER_ARG_MULTI_HANDLE_OPS = frozenset({"meshgrid", "broadcast_arrays", "ix_"})
+
+
+def _prospective_handle_count(op: str, raw_args: list) -> int:
+    """Upper bound on array/scalar handles *op* could store, without dispatching it.
+
+    Used by the pre-dispatch capacity gate in :meth:`RequestHandler.handle`
+    so a capacity refusal never depends on having already run (and therefore
+    already charged) the operation. Defaults to 1 -- a single array or 0-d
+    scalar handle -- which covers every op not listed above.
+    """
+    if op in _PER_ARG_MULTI_HANDLE_OPS:
+        return max(len(raw_args), 1)
+    return _FIXED_MULTI_HANDLE_COUNTS.get(op, 1)
+
 
 def _make_serializable(obj):
     """Convert a nested structure to be msgpack-safe (no numpy types)."""
@@ -194,8 +234,14 @@ class RequestHandler:
             # Capacity is checked before dispatch, on purpose: ArrayStore.put
             # raises only at store time, which for every op below is after
             # the op has already run and been charged. Refusing here instead
-            # means an over-capacity request costs the caller nothing.
-            if self._session.array_count >= _array_store.MAX_ARRAY_COUNT:
+            # means an over-capacity request costs the caller nothing. Some
+            # ops (linalg.eig/eigh/qr/svd, meshgrid, ...) can store more than
+            # one handle for a single call, so the gate reserves that many
+            # slots up front -- checking only for one free slot would let
+            # such a call pass, run, get charged, and then fail partway
+            # through storing its own result.
+            needed = _prospective_handle_count(op, request.get("args") or [])
+            if self._session.array_count + needed > _array_store.MAX_ARRAY_COUNT:
                 return {
                     "status": "error",
                     "error_type": "MemoryError",
@@ -656,6 +702,26 @@ class RequestHandler:
                         "message": (
                             f"result dtype {undecodable_dtype!r} cannot be "
                             f"delivered to the client"
+                        ),
+                    }
+
+            # Any element that is neither a numpy array/scalar (checked
+            # above) nor msgpack-encodable by value -- including one buried
+            # inside a nested list/tuple -- would otherwise fall through to
+            # the storing loop below and only fail once msgpack.packb() runs
+            # on the assembled response, after earlier elements' handles have
+            # already been minted. Refused means refused for the whole
+            # result, so this must be checked before storing anything.
+            for r in result:
+                if isinstance(r, (np.ndarray, np.generic)):
+                    continue
+                if not _is_msgpack_native(_make_serializable(r)):
+                    return {
+                        "status": "error",
+                        "error_type": "UnsupportedReturnType",
+                        "message": (
+                            f"result element of type {type(r).__name__!r} "
+                            f"cannot be encoded for delivery to the client"
                         ),
                     }
 

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -102,6 +102,31 @@ _FIXED_MULTI_HANDLE_COUNTS: dict[str, int] = {
 # number of array handles in the request rather than a fixed constant.
 _PER_ARG_MULTI_HANDLE_OPS = frozenset({"meshgrid", "broadcast_arrays", "ix_"})
 
+# Ops that mint no array handle whatever their arguments, so reserving an
+# array slot for them would refuse a request the server can in fact deliver.
+# `save`/`savez`/`savez_compressed` route to _handle_save, which bills egress
+# and returns None; the RNG constructors return a Generator/RandomState/
+# SeedSequence, which _pack_result puts in the connection's separate
+# generator store (Session.store_generator), never in the array store.
+#
+# Only ops whose zero-handle result is unconditional belong here. A reduction
+# like `sum` does not qualify even though `sum(V)` returns a msgpack-native
+# scalar and stores nothing: `sum(V, axis=0)` returns an array and does store
+# one, and which of the two a call is cannot be read off the op name. Those
+# stay on the conservative default of 1 -- refused free at full capacity,
+# never charged -- with the exact, table-independent gate in _pack_result as
+# the guarantee against a stranded handle.
+_ZERO_ARRAY_HANDLE_OPS = frozenset(
+    {
+        "save",
+        "savez",
+        "savez_compressed",
+        "random.default_rng",
+        "random.SeedSequence",
+        "random.RandomState",
+    }
+)
+
 
 def _prospective_handle_count(op: str, raw_args: list) -> int:
     """Upper bound on array/scalar handles *op* could store, without dispatching it.
@@ -111,6 +136,8 @@ def _prospective_handle_count(op: str, raw_args: list) -> int:
     already charged) the operation. Defaults to 1 -- a single array or 0-d
     scalar handle -- which covers every op not listed above.
     """
+    if op in _ZERO_ARRAY_HANDLE_OPS:
+        return 0
     if op in _PER_ARG_MULTI_HANDLE_OPS:
         return max(len(raw_args), 1)
     return _FIXED_MULTI_HANDLE_COUNTS.get(op, 1)
@@ -127,6 +154,33 @@ def _make_serializable(obj):
     if isinstance(obj, dict):
         return {k: _make_serializable(v) for k, v in obj.items()}
     return obj
+
+
+def _unresolvable_operand(value) -> str | None:
+    """Name the type of an operand the protocol can never turn into a value.
+
+    msgpack delivers only ``None``/bool/int/float/str/bytes/list/dict, and
+    :meth:`RequestHandler._resolve_arg` converts every dict shape the protocol
+    defines -- array handle, generator handle, symmetry group -- into the
+    object it names. A dict that survives resolution therefore names nothing:
+    NumPy can only coerce it to an ``object`` array, and ``object`` is not a
+    dtype the client can decode, so the response is undeliverable however the
+    kernel runs.
+
+    Refusing it here, before dispatch, keeps the refusal free. The alternative
+    is to run the kernel, charge the caller for it, and only discover at pack
+    time that nothing can be sent back -- a charge with no result, which is
+    the exact outcome this module exists to prevent. Returns the offending
+    type's name, or ``None`` if every operand is representable.
+    """
+    if isinstance(value, dict):
+        return type(value).__name__
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            found = _unresolvable_operand(item)
+            if found is not None:
+                return found
+    return None
 
 
 _MSGPACK_SCALARS = (type(None), bool, int, float, str, bytes)
@@ -553,6 +607,18 @@ class RequestHandler:
         func = _get_flopscope_func(op)
         resolved_args = [self._resolve_arg(a) for a in raw_args]
         resolved_kwargs = {k: self._resolve_arg(v) for k, v in kwargs.items()}
+
+        for operand in (*resolved_args, *resolved_kwargs.values()):
+            bad_type = _unresolvable_operand(operand)
+            if bad_type is not None:
+                return {
+                    "status": "error",
+                    "error_type": "TypeError",
+                    "message": (
+                        f"{op}() received an argument of type {bad_type!r}, "
+                        f"which cannot be used as an array operand"
+                    ),
+                }
 
         result = self._run_kernel(func, *resolved_args, **resolved_kwargs)
 

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -59,14 +59,30 @@ def _allowed_rs_methods() -> frozenset:
 
 _ALLOWED_RS_METHODS = _allowed_rs_methods()
 
-# Ops whose result can store more than one array/scalar handle. The
-# per-request capacity gate in RequestHandler.handle() must know this BEFORE
-# dispatch: flopscope charges FLOPs synchronously as part of running an op
-# (BudgetContext.deduct charges before the numpy kernel is even invoked —
-# see flopscope._budget), so once dispatch begins the charge is permanent.
-# A refusal decided only after the op has already run would no longer be
-# free. Values are a conservative upper bound on the number of handles a
-# single call can produce, keyed by dotted op name.
+# Capacity is enforced in two layers; this table is the first, not the only
+# one:
+#
+#   1. This table + the pre-dispatch gate in RequestHandler.handle() (below,
+#      around _prospective_handle_count). A best-effort OPTIMISATION: when an
+#      op's arity is listed here, a capacity refusal happens before dispatch,
+#      so nothing was computed or charged -- the refusal is free. flopscope
+#      charges FLOPs synchronously as part of running an op
+#      (BudgetContext.deduct charges before the numpy kernel is even invoked
+#      -- see flopscope._budget), so once dispatch begins the charge is
+#      permanent; this table exists to decide BEFORE that point. It is
+#      allowed to be incomplete -- ops with shape-dependent arity (e.g.
+#      nonzero, which returns one array per dimension) are intentionally not
+#      enumerated here.
+#   2. The exact handle count computed in _pack_result, from the actual
+#      result, before its first store. That layer is the GUARANTEE: it is
+#      table-independent and universal, so no operation -- listed here or
+#      not -- can ever strand a handle. It is not free (the op has already
+#      run and been charged by then), only leak-proof.
+#
+# Do not "complete" this table for more ops. Its job is to make the common
+# multi-handle ops free to refuse; the second layer is what makes refusal
+# safe for everything else. Values are a conservative upper bound on the
+# number of handles a single call can produce, keyed by dotted op name.
 _FIXED_MULTI_HANDLE_COUNTS: dict[str, int] = {
     "linalg.eig": 2,
     "linalg.eigh": 2,
@@ -724,6 +740,46 @@ class RequestHandler:
                             f"cannot be encoded for delivery to the client"
                         ),
                     }
+
+            # Second capacity layer, table-independent and exact: the
+            # pre-dispatch gate in RequestHandler.handle() (see
+            # _prospective_handle_count) is a best-effort table of known
+            # multi-handle ops, so a refusal there is free -- the op never
+            # ran. But an op with shape-dependent arity (e.g. nonzero, which
+            # returns one array per dimension) can strand a handle if it is
+            # missing from that table: with one free slot, the loop below
+            # would store its first element, then hit MemoryError storing
+            # its second, leaving the first stranded with no id ever
+            # delivered to the caller to free it.
+            #
+            # By this point in _pack_result the result already exists, so
+            # the number of handles it will actually store is known exactly
+            # -- no table, no guessing. Refusing here closes that gap
+            # universally, for every op, regardless of whether anyone
+            # remembered to list it. The trade-off: the op has already run
+            # and been charged (see the module comment above
+            # _FIXED_MULTI_HANDLE_COUNTS), so unlike the pre-dispatch gate,
+            # this refusal is NOT free for an op the table doesn't cover --
+            # it only guarantees nothing is stranded, and stores nothing
+            # itself.
+            handles_needed = sum(
+                1
+                for r in result
+                if isinstance(r, np.ndarray)
+                or (isinstance(r, np.generic) and not _is_msgpack_native(r.item()))
+            )
+            if (
+                self._session.array_count + handles_needed
+                > _array_store.MAX_ARRAY_COUNT
+            ):
+                return {
+                    "status": "error",
+                    "error_type": "MemoryError",
+                    "message": (
+                        f"array store limit reached: "
+                        f"{_array_store.MAX_ARRAY_COUNT} arrays"
+                    ),
+                }
 
             items = []
             for r in result:

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -97,6 +97,28 @@ def _is_msgpack_native(obj) -> bool:
 #: Maximum allowed array size in bytes (configurable via environment variable).
 MAX_ARRAY_BYTES = int(os.environ.get("FLOPSCOPE_MAX_ARRAY_BYTES", 100 * 1024 * 1024))
 
+#: Dtypes the client knows how to decode off the wire. Mirrors the client's
+#: own table; a handle minted with any other dtype would be unreadable, so a
+#: result carrying one is refused rather than stored.
+_CLIENT_DECODABLE_DTYPES: frozenset[str] = frozenset(
+    {
+        "bool",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float16",
+        "float32",
+        "float64",
+        "complex64",
+        "complex128",
+    }
+)
+
 
 class RequestHandler:
     """Dispatch decoded request dicts to real flopscope functions.
@@ -590,9 +612,17 @@ class RequestHandler:
         # Scalar or other value
         if isinstance(result, np.generic):
             dtype_str = str(result.dtype)
+            item = result.item()
+            if not _is_msgpack_native(item):
+                # Not encodable by value. Deliver it the way a 0-d array
+                # result is already delivered, rather than failing after the
+                # caller has been charged for computing it.
+                handle = self._session.store_array(np.asarray(result))
+                meta = self._session.array_metadata(handle)
+                return {"status": "ok", "result": meta, "budget": budget}
             return {
                 "status": "ok",
-                "result": {"value": result.item(), "dtype": dtype_str},
+                "result": {"value": item, "dtype": dtype_str},
                 "budget": budget,
             }
         if isinstance(result, bool):

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -625,9 +625,21 @@ class RequestHandler:
 
         if isinstance(result, (tuple, list)):
             # Validate every element before storing anything: a later element
-            # failing decodability must not leave an earlier element's handle
-            # (array or 0-d scalar) stranded in the store. Refused means
-            # refused for the whole result, not a partial one.
+            # failing the size or decodability check must not leave an
+            # earlier element's handle (array or 0-d scalar) stranded in the
+            # store. Refused means refused for the whole result, not a
+            # partial one.
+            for r in result:
+                if isinstance(r, np.ndarray) and r.nbytes > MAX_ARRAY_BYTES:
+                    return {
+                        "status": "error",
+                        "error_type": "ValueError",
+                        "message": (
+                            f"result array too large: {r.nbytes} bytes "
+                            f"exceeds {MAX_ARRAY_BYTES} byte limit"
+                        ),
+                    }
+
             for r in result:
                 undecodable_dtype = None
                 if isinstance(r, np.generic) and not _is_msgpack_native(r.item()):

--- a/flopscope-server/src/flopscope_server/_session.py
+++ b/flopscope-server/src/flopscope_server/_session.py
@@ -111,6 +111,16 @@ class Session:
         """Return the array for *handle*. Delegates to the connection store."""
         return self._conn.arrays.get(handle)
 
+    @property
+    def array_count(self) -> int:
+        """Number of arrays currently held in the array store.
+
+        Lets callers check remaining capacity before minting a new handle,
+        instead of discovering the store is full only once ``store_array``
+        raises ``MemoryError``.
+        """
+        return self._conn.arrays.count
+
     def array_metadata(self, handle: str) -> dict:
         """Return metadata dict for *handle*. Delegates to the connection store."""
         return self._conn.arrays.metadata(handle)

--- a/flopscope-server/tests/test_budget_monotonicity.py
+++ b/flopscope-server/tests/test_budget_monotonicity.py
@@ -159,3 +159,94 @@ def test_no_op_record_carries_a_negative_flop_cost(session, monkeypatch):
     assert all(record.flop_cost >= 0 for record in op_log), (
         f"a negative flop_cost slipped into the op log: {op_log}"
     )
+
+
+def test_a_full_store_still_serves_ops_that_mint_no_array_handle(session, monkeypatch):
+    # The pre-dispatch gate reserves a slot per prospective handle, which
+    # would refuse an op that needs none. `random.default_rng` returns a
+    # Generator, and _pack_result puts that in the connection's separate
+    # generator store -- the array store being full says nothing about
+    # whether this response can be delivered, so it must not be refused.
+    session.store_array(np.ones(4, dtype="float64"))
+    monkeypatch.setattr(_array_store, "MAX_ARRAY_COUNT", 1)
+
+    response = RequestHandler(session).handle(
+        {"op": "random.default_rng", "args": [7], "kwargs": {}}
+    )
+
+    assert response["status"] == "ok", response.get("message")
+    assert "gen_id" in response["result"]
+
+
+def test_a_full_store_refuses_an_op_whose_handle_count_is_argument_dependent(
+    session, monkeypatch
+):
+    # The other side of the exemption: `sum` is NOT exempt, because its
+    # handle count cannot be read off the op name. `sum(a)` returns a
+    # msgpack-native scalar and stores nothing, but `sum(a, axis=0)` returns
+    # an array and stores one, so the gate stays conservative for it. The
+    # cost of that conservatism is a refusal the server could have served --
+    # but the refusal is free, which is the property being protected here.
+    a = session.store_array(np.ones((4, 4), dtype="float64"))
+    monkeypatch.setattr(_array_store, "MAX_ARRAY_COUNT", 1)
+    before = session.budget_context.flops_used
+
+    response = RequestHandler(session).handle(
+        {"op": "sum", "args": [{"__handle__": a}], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert response["error_type"] == "MemoryError"
+    assert session.budget_context.flops_used == before
+
+
+def test_an_unrepresentable_operand_is_refused_before_any_charge(session):
+    # A dict that survives _resolve_arg names nothing the protocol defines,
+    # so NumPy can only coerce it to an `object` array -- a dtype the client
+    # has no decoder for. Running the kernel would charge for a result that
+    # could never be sent back, so the refusal has to happen before dispatch.
+    handler = RequestHandler(session)
+    v = session.store_array(np.array([True, False, True]))
+    before = session.budget_context.flops_used
+
+    response = handler.handle(
+        {"op": "where", "args": [{"__handle__": v}, {"k": 1}, 0.0], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert response["error_type"] == "TypeError"
+    assert "dict" in response["message"]
+    assert session.budget_context.flops_used == before, (
+        "an undeliverable operand must cost the caller nothing"
+    )
+
+
+def test_an_unrepresentable_operand_is_found_inside_a_sequence(session):
+    # concatenate([a, {...}]) hides the dict one level down, where
+    # _resolve_arg recurses -- so the check has to recurse too, or the
+    # nested case falls through to the kernel and gets charged.
+    handler = RequestHandler(session)
+    a = session.store_array(np.ones(3, dtype="float64"))
+    before = session.budget_context.flops_used
+
+    response = handler.handle(
+        {"op": "concatenate", "args": [[{"__handle__": a}, {"k": 1}]], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert response["error_type"] == "TypeError"
+    assert session.budget_context.flops_used == before
+
+
+def test_handle_envelopes_are_not_mistaken_for_unrepresentable_operands(session):
+    # The check runs on *resolved* arguments precisely so that the protocol's
+    # own dict envelopes -- which arrive as dicts and leave as arrays -- are
+    # never caught by it. Without that ordering this refuses every op.
+    handler = RequestHandler(session)
+    a = session.store_array(np.ones((4, 4), dtype="float64"))
+
+    response = handler.handle(
+        {"op": "matmul", "args": [{"__handle__": a}, {"__handle__": a}], "kwargs": {}}
+    )
+
+    assert response["status"] == "ok", response.get("message")

--- a/flopscope-server/tests/test_budget_monotonicity.py
+++ b/flopscope-server/tests/test_budget_monotonicity.py
@@ -63,6 +63,48 @@ def test_a_multi_array_result_refuses_before_charging(session, monkeypatch):
     )
 
 
+def test_a_shape_dependent_arity_op_is_charged_but_never_strands_a_handle(
+    session, monkeypatch
+):
+    """nonzero returns one array per dimension of its input -- an arity the
+    static _FIXED_MULTI_HANDLE_COUNTS table does not (and by design should
+    not) enumerate, since it depends on the input's ndim rather than the op
+    name alone. The pre-dispatch gate therefore reserves only 1 slot for it,
+    same as any untabulated op.
+
+    With exactly one free slot, dispatch proceeds, the op runs and is
+    charged, and a 2-D input needs 2 handles. The exact count computed in
+    _pack_result before the first store must still refuse and leave the
+    store untouched -- the second, table-independent layer is what prevents
+    the first handle from being stranded here, not the pre-dispatch table.
+    Unlike the free pre-dispatch refusal, this one is NOT free: the op
+    already ran, so it is still charged. That charge is the accepted
+    trade-off, not a bug -- assert it explicitly so it stays pinned.
+    """
+    handler = RequestHandler(session)
+    a = session.store_array(np.array([[0, 1], [1, 0]], dtype="float64"))
+    # array_count is now 1; MAX_ARRAY_COUNT=2 means exactly one slot free.
+    monkeypatch.setattr(_array_store, "MAX_ARRAY_COUNT", 2)
+    before_flops = session.budget_context.flops_used
+    before_count = session.array_count
+
+    response = handler.handle(
+        {"op": "nonzero", "args": [{"__handle__": a}], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert session.array_count == before_count, (
+        "the exact-count check in _pack_result must refuse before storing "
+        "anything, leaving no handle stranded"
+    )
+    assert session.budget_context.flops_used > before_flops, (
+        "this refusal is not free: the op already ran and was charged "
+        "before _pack_result could know its exact handle count -- only the "
+        "pre-dispatch table (which does not cover shape-dependent arity "
+        "ops like nonzero) can make a refusal free"
+    )
+
+
 def test_a_genuine_failure_is_still_charged(session):
     handler = RequestHandler(session)
     singular = session.store_array(np.zeros((64, 64), dtype="float64"))

--- a/flopscope-server/tests/test_budget_monotonicity.py
+++ b/flopscope-server/tests/test_budget_monotonicity.py
@@ -37,6 +37,32 @@ def test_a_full_store_refuses_before_charging(session, monkeypatch):
     )
 
 
+def test_a_multi_array_result_refuses_before_charging(session, monkeypatch):
+    """linalg.eigh stores two handles (eigenvalues + eigenvectors) for one
+    call. With only one array-store slot free, the whole request must be
+    refused before dispatch -- not run, charged, and left with one handle
+    stranded when the second store hits the limit mid-loop.
+    """
+    handler = RequestHandler(session)
+    a = session.store_array(np.eye(32, dtype="float64"))
+    # array_count is now 1; MAX_ARRAY_COUNT=2 means exactly one slot free.
+    monkeypatch.setattr(_array_store, "MAX_ARRAY_COUNT", 2)
+    before_flops = session.budget_context.flops_used
+    before_count = session.array_count
+
+    response = handler.handle(
+        {"op": "linalg.eigh", "args": [{"__handle__": a}], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert session.budget_context.flops_used == before_flops, (
+        "a refusal must be free even when the result needs multiple handles"
+    )
+    assert session.array_count == before_count, (
+        "a refusal must leave nothing behind, including a partial multi-array store"
+    )
+
+
 def test_a_genuine_failure_is_still_charged(session):
     handler = RequestHandler(session)
     singular = session.store_array(np.zeros((64, 64), dtype="float64"))
@@ -63,3 +89,31 @@ def test_flops_used_never_decreases(session):
         handler.handle({"op": op, "args": args, "kwargs": {}})
         seen.append(session.budget_context.flops_used)
     assert seen == sorted(seen), f"budget decreased somewhere: {seen}"
+
+
+def test_no_op_record_carries_a_negative_flop_cost(session, monkeypatch):
+    """The aggregate flops_used never decreasing is not the same guarantee as
+    no individual record being negative -- a previously-shipped bug billed
+    zero-sized contractions a negative flop_cost that still summed to a
+    monotonic total. Pin the per-record shape directly, across a sequence
+    that includes a capacity refusal.
+    """
+    handler = RequestHandler(session)
+    a = session.store_array(np.ones((32, 32), dtype="complex128"))
+    for op in ("linalg.det", "trace", "matmul", "linalg.inv", "sum"):
+        args = [{"__handle__": a}]
+        if op == "matmul":
+            args.append({"__handle__": a})
+        handler.handle({"op": op, "args": args, "kwargs": {}})
+
+    # A refusal in the mix: it must not append a negative (or any) record.
+    monkeypatch.setattr(_array_store, "MAX_ARRAY_COUNT", session.array_count)
+    handler.handle(
+        {"op": "matmul", "args": [{"__handle__": a}, {"__handle__": a}], "kwargs": {}}
+    )
+
+    op_log = session.budget_context.op_log
+    assert op_log, "expected at least one recorded op"
+    assert all(record.flop_cost >= 0 for record in op_log), (
+        f"a negative flop_cost slipped into the op log: {op_log}"
+    )

--- a/flopscope-server/tests/test_budget_monotonicity.py
+++ b/flopscope-server/tests/test_budget_monotonicity.py
@@ -1,0 +1,65 @@
+"""The security invariant: nothing may give FLOP budget back.
+
+A charged-then-undeliverable result is fixed by not doing the work, never by
+crediting the caller. These tests pin that a refusal is free and that a genuine
+computation failure is still charged exactly as before.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from flopscope_server import _array_store
+from flopscope_server._request_handler import RequestHandler
+from flopscope_server._session import Session
+
+
+@pytest.fixture()
+def session():
+    s = Session(flop_budget=10**15)
+    yield s
+    s.close()
+
+
+def test_a_full_store_refuses_before_charging(session, monkeypatch):
+    handler = RequestHandler(session)
+    a = session.store_array(np.ones((256, 256), dtype="float64"))
+    monkeypatch.setattr(_array_store, "MAX_ARRAY_COUNT", 1)
+    before = session.budget_context.flops_used
+
+    response = handler.handle(
+        {"op": "matmul", "args": [{"__handle__": a}, {"__handle__": a}], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert session.budget_context.flops_used == before, (
+        "a refusal must be free: the work was never delivered"
+    )
+
+
+def test_a_genuine_failure_is_still_charged(session):
+    handler = RequestHandler(session)
+    singular = session.store_array(np.zeros((64, 64), dtype="float64"))
+    before = session.budget_context.flops_used
+
+    response = handler.handle(
+        {"op": "linalg.inv", "args": [{"__handle__": singular}], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert session.budget_context.flops_used > before, (
+        "genuine computation failures are charged, unchanged by this work"
+    )
+
+
+def test_flops_used_never_decreases(session):
+    handler = RequestHandler(session)
+    a = session.store_array(np.ones((32, 32), dtype="complex128"))
+    seen = [session.budget_context.flops_used]
+    for op in ("linalg.det", "trace", "matmul", "linalg.inv", "sum"):
+        args = [{"__handle__": a}]
+        if op == "matmul":
+            args.append({"__handle__": a})
+        handler.handle({"op": op, "args": args, "kwargs": {}})
+        seen.append(session.budget_context.flops_used)
+    assert seen == sorted(seen), f"budget decreased somewhere: {seen}"

--- a/flopscope-server/tests/test_pack_result_delivery.py
+++ b/flopscope-server/tests/test_pack_result_delivery.py
@@ -95,3 +95,60 @@ def test_tuple_with_array_then_undecodable_element_leaks_no_handle(handler):
     assert packed["status"] == "error"
     assert packed["error_type"] == "UnsupportedReturnType"
     assert len(handler._session._conn.arrays._arrays) == before
+
+
+def test_array_result_with_undecodable_dtype_is_refused_not_stored(handler):
+    # An array result (not a 0-d scalar) of an undecodable dtype must be
+    # refused at the top-level np.ndarray branch, not stored as a handle the
+    # client would fail to fetch later.
+    before = len(handler._session._conn.arrays._arrays)
+    arr = np.array(["2024-01-01", "2024-01-02"], dtype="datetime64[D]")
+    packed = handler._pack_result(arr)
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    assert len(handler._session._conn.arrays._arrays) == before
+
+
+def test_tuple_with_undecodable_array_element_is_refused_not_stored(handler):
+    before = len(handler._session._conn.arrays._arrays)
+    arr = np.array(["2024-01-01"], dtype="datetime64[D]")
+    packed = handler._pack_result((arr, np.float64(1.0)))
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    assert len(handler._session._conn.arrays._arrays) == before
+
+
+def test_tuple_with_array_then_undecodable_array_element_leaks_no_handle(handler):
+    # The first (decodable) array element would normally be stored before the
+    # later element is even inspected; the whole result must still be refused
+    # with no handle left over from the first array.
+    before = len(handler._session._conn.arrays._arrays)
+    arr1 = np.arange(3.0)
+    arr2 = np.array(["2024-01-01"], dtype="datetime64[D]")
+    packed = handler._pack_result((arr1, arr2))
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    assert len(handler._session._conn.arrays._arrays) == before
+
+
+def test_create_from_data_refuses_an_undecodable_dtype(handler):
+    response = handler.handle(
+        {
+            "op": "create_from_data",
+            "args": [b"\x00" * 16, [2], "datetime64[D]"],
+            "kwargs": {},
+        }
+    )
+    assert response["status"] == "error"
+    assert "datetime64[D]" in response["message"]
+
+
+def test_create_from_data_still_accepts_a_normal_dtype(handler):
+    response = handler.handle(
+        {
+            "op": "create_from_data",
+            "args": [np.arange(3, dtype="float32").tobytes(), [3], "float32"],
+            "kwargs": {},
+        }
+    )
+    assert response["status"] == "ok"

--- a/flopscope-server/tests/test_pack_result_delivery.py
+++ b/flopscope-server/tests/test_pack_result_delivery.py
@@ -152,3 +152,19 @@ def test_create_from_data_still_accepts_a_normal_dtype(handler):
         }
     )
     assert response["status"] == "ok"
+
+
+def test_oversize_element_of_a_multi_result_is_refused(handler, monkeypatch):
+    import flopscope_server._request_handler as rh
+
+    monkeypatch.setattr(rh, "MAX_ARRAY_BYTES", 1024)
+    big = np.zeros(4096, dtype="float64")  # 32768 bytes
+    before = len(handler._session._conn.arrays._arrays)
+
+    packed = handler._pack_result((np.zeros(2), big))
+
+    assert packed["status"] == "error"
+    assert "too large" in packed["message"]
+    assert len(handler._session._conn.arrays._arrays) == before, (
+        "a refused multi-result must not leave partial handles behind"
+    )

--- a/flopscope-server/tests/test_pack_result_delivery.py
+++ b/flopscope-server/tests/test_pack_result_delivery.py
@@ -154,6 +154,20 @@ def test_create_from_data_still_accepts_a_normal_dtype(handler):
     assert response["status"] == "ok"
 
 
+def test_tuple_with_raw_non_numpy_element_is_refused_not_stored(handler):
+    # A plain Python object that is neither a numpy array/scalar nor
+    # msgpack-native (e.g. a raw `complex`) must be caught during
+    # prevalidation, before the array element ahead of it is stored --
+    # otherwise it reaches msgpack.packb() unconverted and fails there with
+    # an opaque error, after the first element's handle has already been
+    # minted.
+    before = len(handler._session._conn.arrays._arrays)
+    packed = handler._pack_result((np.arange(3.0), complex(1, 2)))
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    assert len(handler._session._conn.arrays._arrays) == before
+
+
 def test_oversize_element_of_a_multi_result_is_refused(handler, monkeypatch):
     import flopscope_server._request_handler as rh
 

--- a/flopscope-server/tests/test_pack_result_delivery.py
+++ b/flopscope-server/tests/test_pack_result_delivery.py
@@ -1,0 +1,42 @@
+"""A result the server cannot deliver must not be charged for.
+
+The server pre-charges an operation and then executes it, so any result it
+cannot describe has already cost the caller. These tests pin the two ways that
+is avoided: making the result deliverable, and refusing it before dispatch.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from flopscope_server._request_handler import RequestHandler
+from flopscope_server._session import Session
+
+
+@pytest.fixture()
+def handler():
+    session = Session(flop_budget=10**15)
+    yield RequestHandler(session)
+    session.close()
+
+
+def test_complex_scalar_is_delivered_as_a_handle(handler):
+    packed = handler._pack_result(np.complex128(1 + 2j))
+    assert packed["status"] == "ok"
+    assert "id" in packed["result"], packed
+    assert packed["result"]["dtype"] == "complex128"
+    assert packed["result"]["shape"] == []
+
+
+def test_complex_scalar_handle_holds_the_right_value(handler):
+    packed = handler._pack_result(np.complex64(3 - 4j))
+    stored = handler._session.get_array(packed["result"]["id"])
+    assert stored.dtype == np.complex64
+    assert stored.shape == ()
+    assert stored == np.complex64(3 - 4j)
+
+
+def test_native_scalars_still_come_back_by_value(handler):
+    packed = handler._pack_result(np.float64(2.5))
+    assert packed["result"] == {"value": 2.5, "dtype": "float64"}
+    assert "id" not in packed["result"]

--- a/flopscope-server/tests/test_pack_result_delivery.py
+++ b/flopscope-server/tests/test_pack_result_delivery.py
@@ -40,3 +40,58 @@ def test_native_scalars_still_come_back_by_value(handler):
     packed = handler._pack_result(np.float64(2.5))
     assert packed["result"] == {"value": 2.5, "dtype": "float64"}
     assert "id" not in packed["result"]
+
+
+def test_unencodable_result_is_refused_with_a_named_error(handler):
+    class Opaque:
+        pass
+
+    packed = handler._pack_result(Opaque())
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    assert "Opaque" in packed["message"]
+
+
+def test_undecodable_dtype_is_refused_not_stored(handler):
+    # np.longdouble is not usable here: on some platforms (e.g. Apple Silicon)
+    # it has no extended precision and reports dtype "float64", which IS
+    # client-decodable, so it wouldn't exercise the refusal path at all.
+    # datetime64 has no client-side decoder on any platform, so it reliably
+    # takes the refusal branch everywhere.
+    before = len(handler._session._conn.arrays._arrays)
+    packed = handler._pack_result(np.datetime64("2024-01-01"))
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    # Refused means refused: nothing was minted for the caller to fetch.
+    assert len(handler._session._conn.arrays._arrays) == before
+
+
+def test_tuple_with_complex_elements_are_delivered_as_handles(handler):
+    packed = handler._pack_result((np.complex128(1 + 2j), np.float64(3.5)))
+    assert packed["status"] == "ok"
+    items = packed["result"]["multi"]
+    assert "id" in items[0]
+    assert items[0]["dtype"] == "complex128"
+    assert items[0]["shape"] == []
+    stored = handler._session.get_array(items[0]["id"])
+    assert stored == np.complex128(1 + 2j)
+    assert items[1] == {"value": 3.5, "dtype": "float64"}
+
+
+def test_tuple_with_undecodable_element_is_refused_not_stored(handler):
+    before = len(handler._session._conn.arrays._arrays)
+    packed = handler._pack_result((np.datetime64("2024-01-01"), np.float64(1.0)))
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    assert len(handler._session._conn.arrays._arrays) == before
+
+
+def test_tuple_with_array_then_undecodable_element_leaks_no_handle(handler):
+    # The array element would normally be stored before the later element is
+    # even inspected; the whole result must still be refused with no handle
+    # left over from the array.
+    before = len(handler._session._conn.arrays._arrays)
+    packed = handler._pack_result((np.arange(3.0), np.datetime64("2024-01-01")))
+    assert packed["status"] == "error"
+    assert packed["error_type"] == "UnsupportedReturnType"
+    assert len(handler._session._conn.arrays._arrays) == before

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -5227,14 +5227,17 @@ ENTRIES: tuple[Entry, ...] = (
     ),
     Entry(
         case_id="idiom/complex-element-read",
-        dimension="outcome",
-        category=Category.KNOWN_BUG,
+        dimension="pytype",
+        category=Category.ACCEPTED_DIVERGENCE,
         reason=(
-            "`fnp.full((2,), 1.0, dtype='complex128')[0]` returns a bare complex"
-            " scalar in-process but raises on the client, which cannot pack a complex"
-            " scalar into its response."
+            "`fnp.full((2,), 1.0, dtype='complex128')[0]` now returns on both"
+            " backends: in-process as a bare `complex128` scalar, and on the client"
+            " as a 0-d array-wrapper handle. A complex scalar has no encodable"
+            " bare-value wire form, so the client necessarily wraps a"
+            " handle-delivered result rather than unwrapping it - the same shape"
+            " as the accepted `idiom/ndim-returns-int` `pytype` divergence."
         ),
-        issue="INTERNAL-P2-family-5",
+        issue="INTERNAL-P5-scalar-wrapper",
     ),
     Entry(
         case_id="idiom/tuple-axis-sum",
@@ -5544,6 +5547,58 @@ ENTRIES: tuple[Entry, ...] = (
             " anything (0 FLOPs)."
         ),
         issue="INTERNAL-P2-family-4",
+    ),
+    Entry(
+        case_id="types/bytes::constructor",
+        dimension="outcome",
+        category=Category.ACCEPTED_DIVERGENCE,
+        reason=(
+            "`fnp.asarray(b'\\x01\\x02')` produces an in-process array with a"
+            " byte-string dtype (`|S2`). The client has no decodable"
+            " representation for string/byte-string dtypes, so the server refuses"
+            " to mint a handle for it rather than returning one the client could"
+            " not read back - a deliberate choice, consistent with the client's"
+            " own `array()` already rejecting `bytes`/`str` inputs outright."
+        ),
+        issue="INTERNAL-P5-dtype-representation",
+    ),
+    Entry(
+        case_id="types/dict::constructor",
+        dimension="outcome",
+        category=Category.ACCEPTED_DIVERGENCE,
+        reason=(
+            "`fnp.asarray({'k': 1})` produces an in-process array with `object`"
+            " dtype. The client has no decodable representation for `object`"
+            " dtype, so the server refuses to mint a handle for it rather than"
+            " returning one the client could not read back - a deliberate choice."
+        ),
+        issue="INTERNAL-P5-dtype-representation",
+    ),
+    Entry(
+        case_id="types/dict::second-positional",
+        dimension="outcome",
+        category=Category.ACCEPTED_DIVERGENCE,
+        reason=(
+            "`fnp.where(M, {'k': 1}, 0.0)` produces an in-process array with"
+            " `object` dtype (from mixing a `dict` operand into the result). The"
+            " client has no decodable representation for `object` dtype, so the"
+            " server refuses to mint a handle for it rather than returning one the"
+            " client could not read back - a deliberate choice."
+        ),
+        issue="INTERNAL-P5-dtype-representation",
+    ),
+    Entry(
+        case_id="grid/where::scalar-operand",
+        dimension="outcome",
+        category=Category.ACCEPTED_DIVERGENCE,
+        reason=(
+            "`fnp.where(V, 2.0)` (the two-argument, condition-only form) produces"
+            " an in-process array with `object` dtype. The client has no decodable"
+            " representation for `object` dtype, so the server refuses to mint a"
+            " handle for it rather than returning one the client could not read"
+            " back - a deliberate choice."
+        ),
+        issue="INTERNAL-P5-dtype-representation",
     ),
 )
 

--- a/tests/parity/allowlist.py
+++ b/tests/parity/allowlist.py
@@ -3864,6 +3864,32 @@ ENTRIES: tuple[Entry, ...] = (
     ),
     Entry(
         case_id="types/dict::*",
+        dimension="flops",
+        category=Category.ACCEPTED_DIVERGENCE,
+        reason=(
+            "In-process numpy coerces a `dict` operand to an `object` array and runs"
+            " the kernel, charging for it, before anything notices the result is"
+            " unusable. The server cannot deliver an `object` array to the client at"
+            " all, so it refuses the operand before dispatch and charges nothing."
+            " Charging for a result that provably cannot be returned is the worse"
+            " behaviour of the two, so the client stays at zero here deliberately."
+        ),
+        issue="INTERNAL-P3-refuse-before-charging",
+    ),
+    Entry(
+        case_id="types/*::dict-literal",
+        dimension="flops",
+        category=Category.ACCEPTED_DIVERGENCE,
+        reason=(
+            "Same deliberate choice as the `types/dict::*` flops entry, reached from"
+            " the other direction: the dict-literal position wraps every value family"
+            " in a `dict`, so whatever the value is, the operand is one the server"
+            " refuses before dispatch while in-process numpy runs and charges for it."
+        ),
+        issue="INTERNAL-P3-refuse-before-charging",
+    ),
+    Entry(
+        case_id="types/dict::*",
         dimension="exc_type",
         category=Category.KNOWN_BUG,
         reason=(


### PR DESCRIPTION
Stacked on #152 (the parity harness), which is its acceptance gate. Review that
one first; this PR's diff is server-only plus five allowlist entries.

## Problem

The server charges an operation's cost and then executes it, so a result it
afterwards cannot deliver has already cost the caller something they never
receive. The error surfaces as a generic serialization failure, which reads like
infrastructure breakage, so retrying looks like the sensible response — and each
retry costs the same again.

Measured before this change: 25 attempts at a complex-valued `linalg.det` on a
40x40 matrix consumed 2,733,184 FLOPs and returned nothing. The same call at
n=1024 costs 5,726,631,248.

## Approach: make the result deliverable, or refuse before the cost is spent

Deliberately **not** a refund. Nothing here decreases a budget; there is no
rollback, credit, or negative cost anywhere. Refunding was considered and
rejected: giving budget back after work has run is a much harder property to
make safe than not spending it in the first place, and this repository has
previously shipped a bug where an accidental negative cost credited budget.

Three changes:

1. **Non-encodable scalars are returned as 0-d array handles**, the way `sum`,
   `mean` and `einsum` results already are. `_pack_result`'s scalar branch called
   `.item()` with no check that the value could be encoded, which is the only
   reason `trace`, `det`, `vdot` and element access failed on a complex array
   while `sum` on the same array worked. This alone removes the expensive failure
   family. Applied to multi-output results too, so `slogdet`'s complex sign works.

2. **One dtype whitelist, enforced at both ends.** `create_from_data` passed the
   wire dtype string straight to `np.frombuffer`, so an array could be created
   with a dtype the client cannot decode; and results were stored without
   checking. Both now refuse with a typed error rather than minting a handle that
   fails on first read. The whitelist matches the client's own decoder table
   exactly.

3. **Capacity is checked before dispatch.** A full array store and an oversize
   multi-output result were both detected only at store time, after the work had
   run. Two layers now: a per-operation arity estimate before dispatch makes the
   refusal free where the arity is predictable, and an exact count before the
   first store guarantees — independently of that estimate — that a refusal never
   leaves a handle behind. The second layer is the guarantee; the first is an
   optimisation and is allowed to be incomplete.

Residual exposure drops from 2,733,184 FLOPs to approximately 1.

## Testing

`flopscope-server/tests/test_budget_monotonicity.py` pins the property that
matters: a refusal charges nothing, a genuine computation failure is still
charged exactly as before, `flops_used` never decreases across a sequence, and no
individual operation record carries a negative cost.

The differential parity harness from #152 is the acceptance gate. It compares
this backend against the in-process one across ~8,900 expressions and fails on
any difference that is not explained — including one that has been *fixed*, which
it reports as a stale entry. This change made one entry stale and introduced five
new accepted differences, all cases where the server now refuses a dtype the
client has no representation for instead of returning a handle that fails on
first read.

287 server tests pass; the full sweep is clean.

## Not included

`out=` hardening, which is a correctness and crash issue in its own right rather
than a budget one, is filed separately.