### PR TITLE
fix(server): reject unbound method ops that segfault the grading process

### DIFF
--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -677,11 +677,30 @@ def _get_flopscope_func(op_name: str):
     parts = op_name.split(".")
     for base in (fnp, flops):
         obj = base
+        through_class = False
         try:
             for part in parts:
+                # Resolving an attribute OFF a class (e.g. the ``seed`` in
+                # ``random.RandomState.seed``) yields an unbound method that
+                # requires an instance. Calling one with a participant-supplied
+                # array as ``self`` reaches numpy C code that does not
+                # type-check ``self`` and segfaults the whole process. These
+                # fully-qualified names exist in the registry as a billing
+                # catalog only; the supported way to call a generator method is
+                # the client's un-prefixed ``Generator.<method>`` form, routed
+                # onto a real instance well before this function. So a
+                # resolution that crosses a class is always a misuse -- refuse
+                # it with a typed error rather than dispatch an unbound method.
+                if isinstance(obj, type):
+                    through_class = True
                 obj = getattr(obj, part)
         except AttributeError:
             continue
+        if through_class:
+            raise flops.UnsupportedFunctionError(
+                f"{op_name!r} names a method that requires an instance and "
+                f"cannot be called as a standalone operation"
+            )
         return obj
     raise AttributeError(f"flopscope does not provide {op_name!r}")
 

--- a/flopscope-server/tests/test_unbound_method_rejection.py
+++ b/flopscope-server/tests/test_unbound_method_rejection.py
@@ -1,0 +1,89 @@
+"""Fully-qualified ``random.RandomState.*`` / ``random.Generator.*`` op names
+resolve to numpy methods that require an instance. numpy's C implementations do
+not type-check ``self``, so calling one unbound with an arbitrary array
+segfaults the interpreter (verified against plain numpy 2.2.x — an upstream
+defect). The server dispatches such an op by walking the dotted attribute chain
+and calling the resolved object with the request's arguments, so an unguarded
+dispatch crashes the whole server process, not just the request.
+
+The server must refuse these names with a typed error instead. The legitimate
+way to call a generator method — the client's un-prefixed ``Generator.<method>``
+form, routed onto a real instance — is unaffected and covered elsewhere.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+from flopscope_server._request_handler import _get_flopscope_func
+
+# Names that resolve THROUGH a class object, i.e. unbound methods. The rule is
+# structural (traversal crosses a ``type``), so this list is illustrative, not
+# the enforcement mechanism.
+_UNBOUND = [
+    "random.RandomState.seed",
+    "random.RandomState.get_state",
+    "random.Generator.spawn",
+    "random.Generator.random",
+]
+
+# Genuine module-level functions and constructors that must keep resolving.
+_LEGITIMATE = [
+    "random.random",
+    "random.default_rng",
+    "linalg.svd",
+    "sum",
+    "stats.norm.pdf",
+]
+
+
+@pytest.mark.parametrize("op", _UNBOUND)
+def test_unbound_method_names_are_rejected_not_resolved(op):
+    from flopscope import UnsupportedFunctionError
+
+    with pytest.raises(UnsupportedFunctionError):
+        _get_flopscope_func(op)
+
+
+@pytest.mark.parametrize("op", _LEGITIMATE)
+def test_legitimate_ops_still_resolve(op):
+    assert callable(_get_flopscope_func(op))
+
+
+def test_server_survives_an_unbound_method_request():
+    """End to end, in a subprocess, because a SIGSEGV cannot be caught in-process.
+
+    Drives a real in-process ``RequestHandler`` exactly as the server does, sends
+    the crashing op, and asserts the process exits cleanly with a typed error
+    rather than dying on signal 11. Before the fix this child exits -11.
+    """
+    child = """
+import sys
+import numpy as np
+from flopscope_server._request_handler import RequestHandler
+from flopscope_server._session import Session
+
+session = Session(flop_budget=10**15)
+handler = RequestHandler(session)
+handle = session.store_array(np.array([1.0, 2.0, 3.0], dtype="float32"))
+resp = handler.handle(
+    {"op": "random.RandomState.seed", "args": [{"__handle__": handle}], "kwargs": {}}
+)
+assert resp["status"] == "error", resp
+assert resp["error_type"] == "UnsupportedFunctionError", resp
+session.close()
+print("SURVIVED")
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", child],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"server process exited {proc.returncode} "
+        f"(-11/139 == SIGSEGV); stderr:\n{proc.stderr[-500:]}"
+    )
+    assert "SURVIVED" in proc.stdout


### PR DESCRIPTION
## Summary

Certain registry op names resolve to numpy methods that require an instance.
Dispatched as standalone ops with an array argument, they reach numpy C code
that does not type-check `self` and **segfault the whole server process** — a
denial-of-service on the grading process, since participant code runs against
this backend.

## Root cause

This is an **upstream numpy defect**, reproducible with no flopscope involved
(numpy 2.2.6):

```
python -c "import numpy as np; np.random.Generator.spawn(np.array([1.0,2.0]), 2.0)"
# exits 139 (SIGSEGV)
```

The 94 fully-qualified `random.RandomState.*` and `random.Generator.*` names
live in the registry as a billing catalog, so they pass the request whitelist.
As standalone ops they miss the instance-routing branches (which match the
client's un-prefixed `Generator.<method>` form) and reach `_get_flopscope_func`,
which returns the unbound method; the server then calls it with the request's
first argument as `self`.

## Fix

`_get_flopscope_func` refuses any op whose resolution crosses a class attribute —
an unbound method — with a typed `UnsupportedFunctionError`. The rule is
structural rather than a name list, so every current and future
`random.<Class>.<method>` name is covered. Verified mechanically: all 94
affected names cross a class, and no legitimate op does — module functions and
constructors (`random.default_rng`, `random.SeedSequence`) still resolve.

The supported path for calling a generator method — the client's un-prefixed
`Generator.<method>` form, routed onto a real instance — is handled before this
point and is unchanged.

## Tests

A subprocess regression test drives a real `RequestHandler` with the crashing op
and asserts the process exits cleanly rather than on signal 11 (before the fix
the child exits -11). Plus unit tests that the affected names are rejected while
genuine functions and constructors still resolve. 276 server tests pass.

## Not included, and worth a decision

- **Report upstream to numpy.** The segfault is theirs; the minimal repro above
  has no flopscope in it.
- **The in-process backend still segfaults** on a direct `fnp.random.Generator.spawn(...)`
  call — this PR hardens the server dispatch only. Fixing the in-process/registry
  layer would also let the differential parity harness stop excluding these cases,
  but it touches the billing catalog, so it belongs in a separate change.
- **Sandbox reachability from a real submission is unverified here.** Through the
  normal client surface these ops raise `AttributeError` and never reach the
  server. The server-killing path needs a raw request that bypasses the client
  surface; whether the graded sandbox permits the private imports that would allow
  that should be checked against the real evaluation image. The fix is correct
  either way — defense in depth at worst, DoS closure at best.