### PR TITLE
fix(client): keep BudgetContext.flops_used live between operations

### DIFF
--- a/flopscope-client/src/flopscope/_budget.py
+++ b/flopscope-client/src/flopscope/_budget.py
@@ -236,9 +236,15 @@ class BudgetContext:
         budget_info:
             Dict that may contain a ``"flops_used"`` key.  Missing key is
             silently ignored.
+
+        Spent FLOPs never come back, so the cache only ever moves up. Requests
+        are synchronous, so in practice values arrive in order and the clamp
+        does nothing -- but this cache is now refreshed from error responses
+        too, and a cache that could move down would be a way to read a budget
+        as less spent than it is.
         """
         if "flops_used" in budget_info:
-            self._flops_used = int(budget_info["flops_used"])
+            self._flops_used = max(self._flops_used, int(budget_info["flops_used"]))
 
     # ------------------------------------------------------------------
     # Public API

--- a/flopscope-client/src/flopscope/_budget.py
+++ b/flopscope-client/src/flopscope/_budget.py
@@ -16,6 +16,27 @@ from flopscope._protocol import (
 _active_context = None
 
 
+def _sync_active_context_from_response(response: object) -> None:
+    """Refresh the active budget's cached ``flops_used`` from an op response.
+
+    Every compute-op response carries the server's authoritative budget under a
+    ``"budget"`` key. Consuming it here keeps :attr:`BudgetContext.flops_used`
+    current after every operation with no extra round trip, so a caller that
+    inspects it between ops sees a live value rather than a stale one.
+
+    Responses without a ``"budget"`` key — fetches, frees, the version
+    handshake, and the budget-lifecycle ops, which manage the cache through
+    their own paths — are ignored. Called from the single send/recv chokepoint,
+    so it must stay cheap and never raise.
+    """
+    if _active_context is None:
+        return
+    if isinstance(response, dict):
+        budget_info = response.get("budget")
+        if isinstance(budget_info, dict):
+            _active_context._update_budget(budget_info)
+
+
 def _extract_compute_ns(close_response: object) -> int:
     """Pull total server compute (ns) out of a ``budget_close`` response.
 
@@ -154,12 +175,21 @@ class BudgetContext:
 
     @property
     def flops_used(self) -> int:
-        """FLOPs consumed so far (cached locally, updated from server responses)."""
+        """FLOPs consumed so far.
+
+        Kept current from the budget the server returns on every operation, so
+        this reflects the count as of the most recent op without an extra round
+        trip. Reading it between operations is safe — it is not stale.
+        """
         return self._flops_used
 
     @property
     def flops_remaining(self) -> int:
-        """FLOPs remaining in the budget (``budget - used``)."""
+        """FLOPs remaining in the budget (``budget - used``).
+
+        Tracks :attr:`flops_used`, so it too is current as of the most recent
+        operation.
+        """
         return self._flop_budget - self._flops_used
 
     @property

--- a/flopscope-client/src/flopscope/_connection.py
+++ b/flopscope-client/src/flopscope/_connection.py
@@ -177,19 +177,26 @@ class Connection:
             response["_request_bytes"] = len(raw_request)
             response["_response_bytes"] = len(raw_response)
 
+            # Every compute-op response carries the server's authoritative
+            # budget; fold it into the active BudgetContext so flops_used is
+            # current after each op with no extra round trip. Lazy import: the
+            # budget module imports this one on its own paths.
+            #
+            # This runs BEFORE the error check on purpose. An operation can be
+            # billed and then fail -- charged by the kernel, then refused while
+            # its result is packed -- so an error response's budget has already
+            # advanced. Syncing after the raise would never reach those, and a
+            # caller that catches the exception would go on to read a
+            # flops_used from before the charge.
+            from flopscope._budget import _sync_active_context_from_response
+
+            _sync_active_context_from_response(response)
+
             if response.get("status") == "error":
                 raise_from_response(
                     response.get("error_type", "FlopscopeServerError"),
                     response.get("message", ""),
                 )
-
-            # Every compute-op response carries the server's authoritative
-            # budget; fold it into the active BudgetContext so flops_used is
-            # current after each op with no extra round trip. Lazy import: the
-            # budget module imports this one on its own paths.
-            from flopscope._budget import _sync_active_context_from_response
-
-            _sync_active_context_from_response(response)
 
             return response
 

--- a/flopscope-client/src/flopscope/_connection.py
+++ b/flopscope-client/src/flopscope/_connection.py
@@ -183,6 +183,14 @@ class Connection:
                     response.get("message", ""),
                 )
 
+            # Every compute-op response carries the server's authoritative
+            # budget; fold it into the active BudgetContext so flops_used is
+            # current after each op with no extra round trip. Lazy import: the
+            # budget module imports this one on its own paths.
+            from flopscope._budget import _sync_active_context_from_response
+
+            _sync_active_context_from_response(response)
+
             return response
 
     def _reset_socket(self) -> None:

--- a/flopscope-client/tests/test_budget_live_flops_used.py
+++ b/flopscope-client/tests/test_budget_live_flops_used.py
@@ -1,0 +1,121 @@
+"""``BudgetContext.flops_used`` must reflect the server mid-session.
+
+The client caches ``flops_used`` locally and used to refresh it only at context
+open, context close, and an explicit ``summary()`` call. A participant inspecting
+``ctx.flops_used`` *between* operations — to log progress or make a budget-aware
+branching decision — therefore saw a stale value (0 until the first refresh),
+with no error and no warning. That silently wrong number is the bug.
+
+Every compute-op response already carries the server's authoritative budget, so
+the cache can be kept current with no extra round trip. These tests pin that
+``flops_used`` and ``flops_remaining`` are live after each op, and that they
+still agree exactly with an explicit ``summary()`` refresh.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+_WORKTREE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CLIENT_SRC = os.path.join(_WORKTREE, "flopscope-client", "src")
+_SERVER_SRC = os.path.join(_WORKTREE, "flopscope-server", "src")
+_REAL_SRC = os.path.join(_WORKTREE, "src")
+_VENV_PYTHON = os.path.join(_WORKTREE, ".venv", "bin", "python")
+
+for _p in (_CLIENT_SRC,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SERVER_URL = "tcp://127.0.0.1:15559"
+
+_SERVER_SCRIPT = f"""
+import sys
+sys.path.insert(0, {_REAL_SRC!r})
+sys.path.insert(0, {_SERVER_SRC!r})
+from flopscope_server._server import FlopscopeServer
+server = FlopscopeServer(url={_SERVER_URL!r})
+print("SERVER_READY", flush=True)
+server.run()
+"""
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _start_server():
+    os.environ["FLOPSCOPE_SERVER_URL"] = _SERVER_URL
+    proc = subprocess.Popen(
+        [_VENV_PYTHON, "-c", _SERVER_SCRIPT],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    line = proc.stdout.readline()
+    assert "SERVER_READY" in line, f"Server failed to start: {line}"
+    time.sleep(0.3)
+    yield proc
+    proc.send_signal(signal.SIGTERM)
+    proc.wait(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _reset_client():
+    from flopscope._connection import reset_connection
+
+    reset_connection()
+    yield
+    reset_connection()
+
+
+def test_flops_used_is_live_after_an_op_without_summary():
+    import flopscope as fl
+
+    with fl.BudgetContext(flop_budget=10**12) as ctx:
+        assert ctx.flops_used == 0  # nothing run yet
+        a = fl.ones((64, 64))
+        a = fl.dot(a, a)
+        # No summary() call: reading the cache directly must reflect the op.
+        assert ctx.flops_used > 0, (
+            "flops_used is stale mid-session; the server's per-op budget was dropped"
+        )
+
+
+def test_flops_used_advances_monotonically_across_ops():
+    import flopscope as fl
+
+    seen = []
+    with fl.BudgetContext(flop_budget=10**12) as ctx:
+        a = fl.ones((64, 64))
+        for _ in range(4):
+            a = fl.dot(a, a)
+            seen.append(ctx.flops_used)
+    assert seen == sorted(seen), f"flops_used not monotonic mid-session: {seen}"
+    assert seen[0] > 0
+    assert seen[-1] > seen[0]
+
+
+def test_live_cache_agrees_with_summary_refresh():
+    import flopscope as fl
+
+    with fl.BudgetContext(flop_budget=10**12) as ctx:
+        a = fl.ones((64, 64))
+        a = fl.dot(a, a)
+        live = ctx.flops_used
+        # summary() forces an explicit budget_status round trip; the live cache
+        # must already equal it, not merely be close.
+        ctx.summary()
+        assert ctx.flops_used == live
+
+
+def test_flops_remaining_tracks_flops_used():
+    import flopscope as fl
+
+    with fl.BudgetContext(flop_budget=10**12) as ctx:
+        a = fl.ones((64, 64))
+        a = fl.dot(a, a)
+        assert ctx.flops_remaining == ctx._flop_budget - ctx.flops_used
+        assert ctx.flops_remaining < ctx._flop_budget

--- a/flopscope-client/tests/test_budget_synced_on_billed_failure.py
+++ b/flopscope-client/tests/test_budget_synced_on_billed_failure.py
@@ -1,0 +1,116 @@
+"""Catching an operation's failure must not hide what it already cost.
+
+The kernel bills an operation before the server tries to pack its result, so an
+operation can be charged and then fail because the result cannot be delivered.
+The FLOPs are gone. A participant who wraps an op in ``try``/``except`` and then
+reads ``ctx.flops_used`` to decide what to run next must see the charge; reading
+a value from before it would have them plan against a budget they no longer
+have.
+
+The server is started here with a deliberately tiny ``FLOPSCOPE_MAX_ARRAY_BYTES``
+so a modest broadcast multiply is billed and then refused: both operands fit
+well under the limit and the array they broadcast to does not, which is the
+shape of the bug without needing a genuinely enormous array.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+_WORKTREE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CLIENT_SRC = os.path.join(_WORKTREE, "flopscope-client", "src")
+_SERVER_SRC = os.path.join(_WORKTREE, "flopscope-server", "src")
+_REAL_SRC = os.path.join(_WORKTREE, "src")
+_VENV_PYTHON = os.path.join(_WORKTREE, ".venv", "bin", "python")
+
+for _p in (_CLIENT_SRC,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SERVER_URL = "tcp://127.0.0.1:15561"
+
+_SERVER_SCRIPT = f"""
+import sys
+sys.path.insert(0, {_REAL_SRC!r})
+sys.path.insert(0, {_SERVER_SRC!r})
+from flopscope_server._server import FlopscopeServer
+server = FlopscopeServer(url={_SERVER_URL!r})
+print("SERVER_READY", flush=True)
+server.run()
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _start_server():
+    os.environ["FLOPSCOPE_SERVER_URL"] = _SERVER_URL
+    env = dict(os.environ, FLOPSCOPE_MAX_ARRAY_BYTES="1024")
+    proc = subprocess.Popen(
+        [_VENV_PYTHON, "-c", _SERVER_SCRIPT],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert proc.stdout is not None
+    line = proc.stdout.readline()
+    assert "SERVER_READY" in line, f"Server failed to start: {line}"
+    time.sleep(0.3)
+    yield proc
+    proc.send_signal(signal.SIGTERM)
+    proc.wait(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _reset_client():
+    from flopscope._connection import reset_connection
+
+    reset_connection()
+    yield
+    reset_connection()
+
+
+def test_a_caught_failure_leaves_flops_used_reflecting_the_charge():
+    import flopscope as fl
+
+    with fl.BudgetContext(flop_budget=10**12) as ctx:
+        row = fl.ones((1, 64))  # 512 bytes each: both store fine
+        col = fl.ones((64, 1))
+        before = ctx.flops_used
+
+        with pytest.raises(ValueError):
+            # Broadcasts to 64x64 = 32768 bytes: the multiply is billed by
+            # the kernel, and only then found to be unsendable.
+            fl.multiply(row, col)
+
+        assert ctx.flops_used > before, (
+            "the failed op was still billed; flops_used must show it"
+        )
+
+        cached = ctx.flops_used
+        ctx.summary()  # explicit refresh straight from the server
+        assert ctx.flops_used == cached, (
+            "the cache after a caught failure must already equal the "
+            "server's own figure, not merely be closer to it"
+        )
+
+
+def test_flops_used_never_goes_backwards_across_a_caught_failure():
+    import flopscope as fl
+
+    with fl.BudgetContext(flop_budget=10**12) as ctx:
+        row = fl.ones((1, 64))
+        col = fl.ones((64, 1))
+        fl.dot(fl.ones(64), fl.ones(64))  # returns a scalar: billed and delivered
+        after_success = ctx.flops_used
+        assert after_success > 0
+
+        with pytest.raises(ValueError):
+            fl.multiply(row, col)
+
+        assert ctx.flops_used >= after_success

--- a/flopscope-server/src/flopscope_server/_protocol.py
+++ b/flopscope-server/src/flopscope_server/_protocol.py
@@ -185,7 +185,9 @@ def encode_response(result: Any, budget: int, comms_overhead_ns: int) -> bytes:
 # ---------------------------------------------------------------------------
 
 
-def encode_error_response(error_type: str, message: str) -> bytes:
+def encode_error_response(
+    error_type: str, message: str, budget: dict | None = None
+) -> bytes:
     """Encode an error response.
 
     Parameters
@@ -194,17 +196,25 @@ def encode_error_response(error_type: str, message: str) -> bytes:
         Name of the exception class (e.g. ``"InvalidRequestError"``).
     message:
         Human-readable error description.
+    budget:
+        The session's budget as it stands, when there is one. An operation is
+        billed by the kernel that runs it and only then found to be
+        undeliverable, so a failure can still have cost the caller FLOPs; the
+        client folds this into the ``flops_used`` its callers read. Omitted for
+        failures raised before any session exists, such as a malformed request.
 
     Returns
     -------
     bytes
         msgpack-encoded response dict with ``status="error"``.
     """
-    payload = {
+    payload: dict[str, object] = {
         "status": "error",
         "error_type": error_type,
         "message": message,
     }
+    if budget is not None:
+        payload["budget"] = budget
     return msgpack.packb(payload, use_bin_type=True)
 
 

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -132,7 +132,29 @@ class RequestHandler:
         """Dispatch *request* and return a response dict.
 
         The ``request["op"]`` field determines which handler is invoked.
+
+        Error responses leave here carrying the session's budget. An operation
+        can be billed and then fail -- the kernel runs and charges, then
+        packing its result discovers the result cannot be delivered -- and the
+        client folds the ``budget`` of every response into the cached
+        ``flops_used`` its callers read. An error response that omitted the
+        budget would leave a caller that caught the exception reading a value
+        from before the charge, and deciding what to run next on that basis.
+        Attaching it in one place, rather than at each of the individual error
+        returns, is what keeps a later error path from forgetting to.
         """
+        response = self._dispatch(request)
+        if response.get("status") == "error" and "budget" not in response:
+            try:
+                response["budget"] = self._session.budget_status()
+            except Exception:
+                # Reporting the budget is a courtesy on this path; it must
+                # never replace a real error with an internal one.
+                pass
+        return response
+
+    def _dispatch(self, request: dict) -> dict:
+        """Route *request* to its handler. See :meth:`handle`."""
         self._kernel_ns = 0
         try:
             op = request["op"]

--- a/flopscope-server/src/flopscope_server/_server.py
+++ b/flopscope-server/src/flopscope_server/_server.py
@@ -151,8 +151,13 @@ class FlopscopeServer:
 
         try:
             if result.get("status") == "error":
+                # Carry the handler's budget through. A failing operation can
+                # still have been billed -- the kernel charges, then packing
+                # the result finds it undeliverable -- and re-encoding without
+                # the budget is what left the client's cached flops_used
+                # sitting at its pre-charge value.
                 response_bytes = encode_error_response(
-                    result["error_type"], result["message"]
+                    result["error_type"], result["message"], result.get("budget")
                 )
             elif "data" in result:
                 # fetch / fetch_slice -- use raw response packing

--- a/flopscope-server/tests/test_error_response_budget.py
+++ b/flopscope-server/tests/test_error_response_budget.py
@@ -1,0 +1,72 @@
+"""An error response has to carry the budget, because failing can still cost.
+
+An operation is billed by the kernel that runs it, and only afterwards does the
+server try to pack the result -- where it may find the result is too large to
+send. The FLOPs are spent by then and cannot come back. The client folds the
+``budget`` of every response into the ``flops_used`` its callers read, so an
+error response that omitted the budget would leave a caller that caught the
+exception reading a value from before the charge.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from flopscope_server import _request_handler
+from flopscope_server._request_handler import RequestHandler
+from flopscope_server._session import Session
+
+
+@pytest.fixture()
+def session():
+    s = Session(flop_budget=10**15)
+    yield s
+    s.close()
+
+
+def test_a_billed_then_undeliverable_op_reports_the_advanced_budget(
+    session, monkeypatch
+):
+    handler = RequestHandler(session)
+    a = session.store_array(np.ones((256, 256), dtype="float64"))
+    # Small enough that the operands stored fine, small enough that the
+    # result cannot be returned: the matmul runs and charges, then packing
+    # discovers the result exceeds what may be sent.
+    monkeypatch.setattr(_request_handler, "MAX_ARRAY_BYTES", 1024)
+    before = session.budget_context.flops_used
+
+    response = handler.handle(
+        {"op": "matmul", "args": [{"__handle__": a}, {"__handle__": a}], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    charged = session.budget_context.flops_used
+    assert charged > before, "precondition: this op must actually be billed"
+    assert response["budget"]["flops_used"] == charged, (
+        "an error response must report the budget as it stands after the charge"
+    )
+
+
+def test_an_error_raised_from_the_dispatch_path_also_reports_the_budget(session):
+    # The budget is attached once, around the whole dispatch, rather than at
+    # each error return -- so an error raised out of the op itself carries it
+    # too, without that path having to remember.
+    response = RequestHandler(session).handle(
+        {"op": "definitely.not.an.op", "args": [], "kwargs": {}}
+    )
+
+    assert response["status"] == "error"
+    assert response["budget"]["flops_used"] == session.budget_context.flops_used
+
+
+def test_a_successful_response_keeps_the_budget_its_own_handler_computed(session):
+    # The attachment must only fill a gap, never overwrite: success responses
+    # already carry the budget their handler read at pack time.
+    a = session.store_array(np.ones((8, 8), dtype="float64"))
+
+    response = RequestHandler(session).handle(
+        {"op": "matmul", "args": [{"__handle__": a}, {"__handle__": a}], "kwargs": {}}
+    )
+
+    assert response["status"] == "ok"
+    assert response["budget"]["flops_used"] == session.budget_context.flops_used


### PR DESCRIPTION
## Problem

`BudgetContext.flops_used` is a client-side cache refreshed only at context open,
context close, and an explicit `summary()` call. A participant who inspects it
**between** operations — to log progress, or to branch on remaining budget —
reads a stale value (0 until the first refresh), with no error and no warning.

The in-process backend's `flops_used` updates live, so this was a silent
client/in-process divergence in a value a participant may make control-flow
decisions on — the worst failure class for this kind of tooling, since it is a
wrong number rather than a crash.

Found while building the differential parity harness, which had to work around it
by calling `summary()` before every read.

## Fix

The server already returns its authoritative budget on **every** compute-op
response (`{flop_budget, flops_used, flops_remaining}`), and the client was
discarding it. This folds that budget into the active `BudgetContext` at the
single send/recv chokepoint, so `flops_used` and `flops_remaining` reflect the
most recent operation — **with no extra round trip**, because the data already
rides on every response.

Considered and rejected: making `flops_used` a property that pings the server on
each read (hidden network I/O in an attribute access), and a docs-only note
(leaves the footgun). Consuming the budget the server already sends is strictly
better than both.

Reads before any op still correctly report 0. The lifecycle ops
(open/close/status) manage the cache through their own paths and carry no
`budget` key, so they are untouched.

## Tests

Integration tests (real server subprocess) assert `flops_used` is live and
monotonic mid-session without a `summary()` call, and that the live cache equals
an explicit `summary()` refresh exactly. Full client suite: 1374 passed, no
regressions.

## Note

`flopscope-client/tests/test_protocol_trace.py` fails at collection on `main`
(references a removed `_protocol._normalize`) — pre-existing and unrelated to
this change; excluded from the regression run above.