### PR TITLE
fix(billing): unwrap a one-tuple out= and stop under-billing the destination

### DIFF
--- a/src/flopscope/_array_ops.py
+++ b/src/flopscope/_array_ops.py
@@ -21,7 +21,7 @@ from numpy.typing import ArrayLike, DTypeLike
 from flopscope import _symmetry_transport as _st
 from flopscope._budget import _call_numpy, _call_user_code, _counted_wrapper
 from flopscope._docstrings import attach_docstring
-from flopscope._dtype_billing import billing_operand
+from flopscope._dtype_billing import billing_operand, store_billing_dtypes
 from flopscope._dtype_billing import heavier_billing_dtype as _heavier_billing_dtype
 from flopscope._ndarray import (
     FlopscopeArray,
@@ -38,7 +38,7 @@ from flopscope._symmetry_utils import (
     wrap_with_symmetry,
     wrap_with_trusted_symmetry,
 )
-from flopscope._validation import require_budget
+from flopscope._validation import _normalize_out, require_budget
 from flopscope.errors import (
     SymmetryError,
     UnsupportedFunctionError,
@@ -655,16 +655,36 @@ def concatenate(
 ) -> FlopscopeArray:
     """Join arrays along an axis. Cost: numel(output)."""
     budget = require_budget()
+    # ``out`` arrives through **kwargs here, so it reached neither the
+    # normalization every declared-parameter sibling gets nor the billing
+    # fold below. See the note on the destination dtype further down.
+    out = _normalize_out(kwargs.pop("out", None), "concatenate")
     arr_list = [_np.asarray(a) for a in arrays]
     cost = max(sum(a.size for a in arr_list), 1)
     groups = [(a.symmetry if isinstance(a, SymmetricTensor) else None) for a in arrays]
     raw_arrs = [_to_base_ndarray(a) for a in arrays]
+    # numpy's default casting for concatenate is ``same_kind``, which admits
+    # float -> complex, so the copy loop that actually runs is the
+    # DESTINATION's: joining float32 blocks into a complex128 buffer converts
+    # every element on the way in (measured 1.100 ms against 0.225 ms for a
+    # float32 destination, and 0.886 ms for the same join with complex128
+    # inputs). Folding the destination into the rate prices that loop --
+    # 80,000 for the case that used to bill 20,000, exactly what the
+    # all-complex128 join bills.
+    billing_dtypes = tuple(a.dtype for a in arr_list) + store_billing_dtypes(out)
+    if out is not None:
+        # Unstripped, a FlopscopeArray destination reaches numpy still wrapped
+        # and trips the internal "reached numpy.concatenate from inside an fnp
+        # wrapper" guard -- which used to happen AFTER the deduct, at full
+        # price. Passing it as ``out=`` also lets _call_numpy record the write,
+        # voiding any symmetry tag that observed the destination's buffer.
+        kwargs["out"] = _to_base_ndarray(out)
     with budget.deduct(
         "concatenate",
         flop_cost=cost,
         subscripts=None,
         shapes=(),
-        dtypes=tuple(a.dtype for a in arr_list),
+        dtypes=billing_dtypes,
     ):
         result = _call_numpy(_np.concatenate, raw_arrs, axis=axis, **kwargs)
     out_group = _st.transport_concatenate(
@@ -681,6 +701,13 @@ def concatenate(
             ],
             reason="concatenate breaks block symmetry or mixes with plain inputs",
         )
+    if out is not None:
+        # numpy.concatenate returns the destination, so hand back the caller's
+        # own object rather than a fresh view of it. A destination never
+        # carries a symmetry tag out: a tag is a billing discount, and this op
+        # cannot verify one against a buffer the caller already owns and may
+        # keep writing to.
+        return out  # type: ignore[return-value]
     if out_group is not None:
         return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
     return _asplainflopscope(result)  # type: ignore[return-value]
@@ -697,15 +724,23 @@ def stack(
 ) -> FlopscopeArray:
     """Stack arrays along a new axis. Cost: numel(output)."""
     budget = require_budget()
+    # See ``concatenate`` above: ``out`` arrives through **kwargs, so it
+    # reached neither the normalization nor the destination-dtype fold, and an
+    # unstripped FlopscopeArray destination tripped the internal strip guard
+    # after the deduct rather than before it.
+    out = _normalize_out(kwargs.pop("out", None), "stack")
     arr_list = [_np.asarray(a) for a in arrays]
     cost = max(sum(a.size for a in arr_list), 1)
     groups = [a.symmetry if isinstance(a, SymmetricTensor) else None for a in arrays]
+    billing_dtypes = tuple(a.dtype for a in arr_list) + store_billing_dtypes(out)
+    if out is not None:
+        kwargs["out"] = _to_base_ndarray(out)
     with budget.deduct(
         "stack",
         flop_cost=cost,
         subscripts=None,
         shapes=(),
-        dtypes=tuple(a.dtype for a in arr_list),
+        dtypes=billing_dtypes,
     ):
         result = _call_numpy(
             _np.stack, _to_base_ndarray_tree(arrays), axis=axis, **kwargs
@@ -720,6 +755,8 @@ def stack(
             ],
             reason="stack inputs disagree or include plain arrays",
         )
+    if out is not None:
+        return out  # type: ignore[return-value]
     if out_group is not None:
         return wrap_with_symmetry(result, out_group)  # type: ignore[return-value]
     return _asplainflopscope(result)  # type: ignore[return-value]
@@ -1676,23 +1713,61 @@ attach_docstring(
 )
 
 
-@_counted_wrapper
-def isnan(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
-    """Test element-wise for NaN. Cost: numel(input)."""
+def _counted_predicate(op_name, ufunc, x, kwargs):
+    """Shared body of ``isnan`` / ``isinf`` / ``isfinite``.
+
+    These three take ``out=`` through **kwargs, which is how the destination
+    escaped normalization, escaped the billing rate, and reached numpy still
+    wrapped when a caller passed a FlopscopeArray -- tripping the internal
+    strip guard *after* the deduct, at full price.
+
+    On the rate, the destination is folded in, but NOT because numpy runs a
+    wider predicate loop -- it does not. Every loop these ufuncs publish ends
+    in ``?`` (``np.isnan.types`` is ``'e->?', 'f->?', 'd->?', ...``), and
+    ``np.isnan.resolve_dtypes((float32, float64))`` reports ``(float32,
+    bool)``: the ``f->?`` loop runs and the bool answer is then cast into the
+    caller's buffer. The destination is a cast target, nothing more.
+
+    It is folded in because that cast is real, measurable work, not a
+    bookkeeping detail. Over 4e6 float32 values: into a bool destination
+    0.179 ms, into a float64 destination 1.314 ms, and the explicit two-step
+    -- predicate into bool (0.179 ms) then ``bool.astype(float64)``
+    (1.090 ms) -- 1.269 ms. The fused spelling IS the two-step, to within 4%,
+    so leaving the destination out of the rate handed back a free ``astype``:
+    under the shipped weights the written-out cast bills 20,000 where the
+    fused form billed 10,000.
+
+    Folding is the widest-participating-buffer rule from ``_dtype_billing``
+    applied unchanged, and what it buys is stated without reference to any
+    weights profile: a destination now widens the rate exactly as an equally
+    wide OPERAND does, so ``isnan(f32, out=f64)`` bills what ``isnan(f64)``
+    bills. A bool destination -- the natural one -- resolves with the input
+    and changes nothing.
+    """
     budget = require_budget()
+    out = _normalize_out(kwargs.pop("out", None), op_name)
     x_arr = _np.asarray(x)
     cost = x_arr.size
+    if out is not None:
+        kwargs["out"] = _to_base_ndarray(out)
     with budget.deduct(
-        "isnan",
+        op_name,
         flop_cost=cost,
         subscripts=None,
         shapes=(x_arr.shape,),
-        dtypes=(x_arr.dtype,),
+        dtypes=(x_arr.dtype,) + store_billing_dtypes(out),
     ):
         # Strip flopscope subclasses so the raw NumPy ufunc does not
         # re-dispatch through __array_ufunc__ and recurse.
-        result = _call_numpy(_np.isnan, _to_base_ndarray(x), **kwargs)
-    return result  # type: ignore[return-value]
+        result = _call_numpy(ufunc, _to_base_ndarray(x), **kwargs)
+    # numpy hands the destination back; so do we, as the caller's own object.
+    return out if out is not None else result
+
+
+@_counted_wrapper
+def isnan(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
+    """Test element-wise for NaN. Cost: numel(input)."""
+    return _counted_predicate("isnan", _np.isnan, x, kwargs)
 
 
 attach_docstring(isnan, _np.isnan, "counted_custom", "numel(input) FLOPs")
@@ -1701,18 +1776,7 @@ attach_docstring(isnan, _np.isnan, "counted_custom", "numel(input) FLOPs")
 @_counted_wrapper
 def isfinite(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Test element-wise for finiteness. Cost: numel(input)."""
-    budget = require_budget()
-    x_arr = _np.asarray(x)
-    cost = x_arr.size
-    with budget.deduct(
-        "isfinite",
-        flop_cost=cost,
-        subscripts=None,
-        shapes=(x_arr.shape,),
-        dtypes=(x_arr.dtype,),
-    ):
-        result = _call_numpy(_np.isfinite, _to_base_ndarray(x), **kwargs)
-    return result  # type: ignore[return-value]
+    return _counted_predicate("isfinite", _np.isfinite, x, kwargs)
 
 
 attach_docstring(isfinite, _np.isfinite, "counted_custom", "numel(input) FLOPs")
@@ -1721,18 +1785,7 @@ attach_docstring(isfinite, _np.isfinite, "counted_custom", "numel(input) FLOPs")
 @_counted_wrapper
 def isinf(x: ArrayLike, **kwargs: Any) -> FlopscopeArray:
     """Test element-wise for Inf. Cost: numel(input)."""
-    budget = require_budget()
-    x_arr = _np.asarray(x)
-    cost = x_arr.size
-    with budget.deduct(
-        "isinf",
-        flop_cost=cost,
-        subscripts=None,
-        shapes=(x_arr.shape,),
-        dtypes=(x_arr.dtype,),
-    ):
-        result = _call_numpy(_np.isinf, _to_base_ndarray(x), **kwargs)
-    return result  # type: ignore[return-value]
+    return _counted_predicate("isinf", _np.isinf, x, kwargs)
 
 
 attach_docstring(isinf, _np.isinf, "counted_custom", "numel(input) FLOPs")
@@ -2221,10 +2274,21 @@ def compress(
     copies each selected element at gather-tier cost (4 FLOPs each).
     """
     budget = require_budget()
+    # ``out`` arrives through **kwargs. deduct_after already made a refusal
+    # free (__exit__ does not charge on an exception), so what was actually
+    # broken here is the strip: a FlopscopeArray destination reached numpy
+    # still wrapped and tripped the internal guard. The destination's dtype
+    # deliberately does NOT join the rate -- numpy's take/compress require
+    # ``can_cast(out.dtype, a.dtype, "safe")``, so a WIDER destination is
+    # unreachable (float32 input with a float64 out is a TypeError); only
+    # same-or-narrower destinations exist, and those never move the rate.
+    out = _normalize_out(kwargs.pop("out", None), "compress")
     _warn_if_symmetric(a, "compress")
     condition_arr = _np.asarray(condition)
     cond_len = condition_arr.size
     a_arr = _np.asarray(a)
+    if out is not None:
+        kwargs["out"] = _to_base_ndarray(out)
     with budget.deduct_after(
         "compress", subscripts=None, shapes=(), dtypes=(a_arr.dtype,)
     ) as _op:
@@ -2243,7 +2307,8 @@ def compress(
             else 1
         )
         _op.set_cost(cond_len + 4 * out_size)
-    return result
+    # numpy.compress returns the destination when given one.
+    return out if out is not None else result
 
 
 attach_docstring(
@@ -2259,7 +2324,15 @@ def concat(
 ) -> FlopscopeArray:
     """Join arrays along an axis. Cost: numel(output)."""
     budget = require_budget()
+    # concat IS concatenate under another name, and had the same two defects:
+    # the destination's dtype never reached the rate (see the measurement in
+    # ``concatenate``), and an unstripped FlopscopeArray destination tripped
+    # the internal guard. deduct_after already made a refusal free.
+    out = _normalize_out(kwargs.pop("out", None), "concat")
     _concat_dtypes = tuple(_np.asarray(a).dtype for a in arrays)
+    _concat_dtypes += store_billing_dtypes(out)
+    if out is not None:
+        kwargs["out"] = _to_base_ndarray(out)
     with budget.deduct_after(
         "concat", subscripts=None, shapes=(), dtypes=_concat_dtypes
     ) as _op:
@@ -2267,7 +2340,7 @@ def concat(
             _np.concat, _to_base_ndarray_tree(arrays), axis=axis, **kwargs
         )  # type: ignore[arg-type, call-overload]
         _op.set_cost(result.size if hasattr(result, "size") else 1)
-    return result  # type: ignore[return-value]
+    return out if out is not None else result  # type: ignore[return-value]
 
 
 attach_docstring(concat, _np.concat, "counted_custom", "numel(output) FLOPs")
@@ -3393,6 +3466,15 @@ def take(
 ) -> FlopscopeArray:
     """Take elements from array along axis. Cost: numel(output)."""
     budget = require_budget()
+    # take already declared ``out`` and already stripped it, but it was the one
+    # op in the codebase that accepted ``out=dest`` and refused ``out=(dest,)``
+    # -- every sibling unwraps the one-tuple numpy's own ufunc protocol
+    # unwraps. Normalizing here makes the two spellings the same call.
+    # No destination-dtype fold: numpy requires
+    # ``can_cast(out.dtype, a.dtype, "safe")``, so a wider destination cannot
+    # be reached (float32 input, float64 out -> TypeError), and a narrower one
+    # never moves the rate.
+    out = _normalize_out(out, "take")
     _a_arr = _np.asarray(a)
     with budget.deduct_after(
         "take", subscripts=None, shapes=(), dtypes=(_a_arr.dtype,)
@@ -3406,7 +3488,9 @@ def take(
             mode=mode,  # type: ignore[arg-type]
         )
         _op.set_cost(result.size if hasattr(result, "size") else 1)
-    return result  # type: ignore[return-value]
+    # numpy.take returns the destination; hand back the caller's own object
+    # rather than the stripped view we passed down.
+    return out if out is not None else result  # type: ignore[return-value]
 
 
 attach_docstring(take, _np.take, "counted_custom", "numel(output) FLOPs")

--- a/src/flopscope/_counting_ops.py
+++ b/src/flopscope/_counting_ops.py
@@ -25,7 +25,7 @@ from flopscope._dtype_billing import (
 )
 from flopscope._flops import _ceil_log2
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray, _to_base_ndarray_tree
-from flopscope._validation import require_budget
+from flopscope._validation import _normalize_out, require_budget
 from flopscope.errors import _warn_remote_callback
 
 # Estimator surcharge multipliers for string-bins histogram calls (FLOPs/elem above 2n min/max floor)
@@ -56,6 +56,10 @@ def trace(
     out: FlopscopeArray | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "trace")
     a = _np.asarray(a)
     # Normalise negative axes
     ndim = a.ndim

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -13,7 +13,11 @@ from flopscope._config import get_setting
 from flopscope._dtype_billing import resolve_billing_dtype, store_billing_dtypes
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._perm_group import SymmetryGroup
-from flopscope._pointwise import _prepare_symmetric_out, _validate_result_symmetry
+from flopscope._pointwise import (
+    _prepare_symmetric_out,
+    _require_ndarray_out,
+    _validate_result_symmetry,
+)
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import normalize_symmetry_input, validate_symmetry_group
 from flopscope._validation import maybe_check_nan_inf, require_budget
@@ -583,6 +587,13 @@ def einsum(
         target_symmetry = normalize_symmetry_input(symmetry, ndim=len(output_subscript))
     else:
         target_symmetry = info.output_symmetry
+    # Before anything is billed: a wrapped destination (``out=[dest]``) would
+    # otherwise reach the copy below, where ``_np.asarray`` builds a new array
+    # from the container -- the result lands in that temporary, ``dest`` keeps
+    # its old contents, and the caller gets the untouched wrapper back having
+    # paid for the contraction.
+    _require_ndarray_out(out, "einsum")
+
     effective_out_symmetry = target_symmetry
     if effective_out_symmetry is None and isinstance(out, SymmetricTensor):
         effective_out_symmetry = out.symmetry

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -15,12 +15,11 @@ from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._perm_group import SymmetryGroup
 from flopscope._pointwise import (
     _prepare_symmetric_out,
-    _require_ndarray_out,
     _validate_result_symmetry,
 )
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import normalize_symmetry_input, validate_symmetry_group
-from flopscope._validation import maybe_check_nan_inf, require_budget
+from flopscope._validation import _normalize_out, maybe_check_nan_inf, require_budget
 from flopscope._write_epoch import note_write
 
 
@@ -592,7 +591,7 @@ def einsum(
     # from the container -- the result lands in that temporary, ``dest`` keeps
     # its old contents, and the caller gets the untouched wrapper back having
     # paid for the contraction.
-    _require_ndarray_out(out, "einsum")
+    out = _normalize_out(out, "einsum")
 
     effective_out_symmetry = target_symmetry
     if effective_out_symmetry is None and isinstance(out, SymmetricTensor):
@@ -626,7 +625,13 @@ def einsum(
 
     if out is not None:
         _validate_result_symmetry(result, target_symmetry)
-        _np.copyto(_np.asarray(out), _np.asarray(result), casting="unsafe")
+        # ``_to_base_ndarray``, never ``_np.asarray``: asarray on anything that
+        # is not already an array builds a NEW buffer, and the copy below then
+        # fills that temporary while the caller's destination keeps its old
+        # contents. Guarding the argument stops a container getting here, but
+        # taking the materialising call out is what makes the whole class of
+        # silent mis-write structurally impossible rather than merely gated.
+        _np.copyto(_to_base_ndarray(out), _np.asarray(result), casting="unsafe")
         # Internal copy, so _call_numpy's hook never sees it: record the write
         # or a tag on out's buffer (or on an alias of it) would survive.
         note_write(out)

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -219,6 +219,23 @@ def _supports_out_argument(np_func) -> bool:
         return False
 
 
+def _require_ndarray_out(out, op_name):
+    """``out=`` must be the destination array itself, not a container holding it.
+
+    numpy rejects a wrapped destination for ufuncs, but not everywhere: on the
+    einsum path ``_np.asarray([dest])`` silently builds a NEW array, so the copy
+    lands in that temporary, ``dest`` keeps its old contents, and the caller gets
+    the untouched wrapper back -- charged in full for a result they never
+    received. Reject it up front, before anything is billed.
+    """
+    if out is None or isinstance(out, _np.ndarray):
+        return
+    raise TypeError(
+        f"{op_name}(): out= must be an array, got {type(out).__name__}. "
+        f"Pass the destination array itself, not a container holding it."
+    )
+
+
 def _prepare_symmetric_out(out, target_symmetry):
     if not isinstance(out, SymmetricTensor):
         return target_symmetry
@@ -378,6 +395,7 @@ def _call_with_optional_out(np_func, *args, out=None, supports_out=False, **kwar
             kwargs[k] = _to_base_ndarray(v)
         elif isinstance(v, (tuple, list)):
             kwargs[k] = _to_base_ndarray_tree(v)
+    _require_ndarray_out(out, getattr(np_func, "__name__", "op"))
     out_stripped = _to_base_ndarray(out) if out is not None else None
     if out is None:
         return _call_numpy(np_func, *args, **kwargs)

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -1977,6 +1977,19 @@ def clip(
     Output shape is the broadcast of a with all bound arrays.
     """
     budget = require_budget()
+    # ``out`` is keyword-only in this signature but numpy's is
+    # ``clip(a, a_min, a_max, out=None, ...)``, and clip.__signature__ is
+    # overwritten with numpy's below -- so a caller following the advertised
+    # signature passes the destination as the third positional. It would
+    # otherwise land in *args and be counted as a third BOUND: measured 12,000
+    # FLOPs against 8,000 for the identical keyword call, because every bound
+    # costs numel, and the destination's dtype never reached the rate at all.
+    if len(args) >= 3:
+        args, out_positional = args[:2], args[2]
+        if out is not None and out_positional is not None:
+            raise TypeError("clip(): out= given both positionally and by keyword")
+        if out is None:
+            out = out_positional
     # Above every later read of ``out`` -- the billing dtype, the
     # symmetry check, and what gets returned -- and above the deduct,
     # so a refused form costs nothing.
@@ -2941,14 +2954,34 @@ def ptp(
     )
 
     budget = require_budget()
+    # ``out`` arrives inside **kwargs here rather than as a named parameter,
+    # which is how it escaped both the normalization every sibling reduction
+    # gets and the destination-dtype fold below. Left alone, a wider
+    # destination was free -- ptp into a complex128 buffer billed the same as
+    # no destination at all, where max/min bill four times as much -- a
+    # refused form was charged in full before numpy rejected it, and an
+    # unstripped FlopscopeArray reached numpy and tripped an internal guard.
+    out = _normalize_out(kwargs.pop("out", None), "ptp")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     axes_summed = _normalize_axis(axis, a.ndim)
     symmetry = a.symmetry if isinstance(a, SymmetricTensor) else None
     m = _num_output_orbits(tuple(a.shape), axes_summed, symmetry)
     cost = 2 * reduction_cost(a.shape, axis, symmetry=symmetry) + m
+    billing_dtype = reduction_billing_dtype(
+        a.dtype,
+        explicit_dtype=kwargs.get("dtype"),
+        out_dtype=out.dtype if isinstance(out, _np.ndarray) else None,
+        default_dtype=a.dtype,
+    )
+    if out is not None:
+        kwargs["out"] = _to_base_ndarray(out)
     with budget.deduct(
-        "ptp", flop_cost=cost, subscripts=None, shapes=(a.shape,), dtypes=(a.dtype,)
+        "ptp",
+        flop_cost=cost,
+        subscripts=None,
+        shapes=(a.shape,),
+        dtypes=(billing_dtype,),
     ):
         stripped = _to_base_ndarray(a)
         if hasattr(_np, "ptp"):
@@ -2957,7 +2990,7 @@ def ptp(
             result = _call_numpy(_np.max, stripped, axis=axis, **kwargs) - _call_numpy(
                 _np.min, stripped, axis=axis, **kwargs
             )
-    return result  # type: ignore[return-value]
+    return _wrap_result(result, out=out, symmetry=None)  # type: ignore[return-value]
 
 
 attach_docstring(

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -3217,6 +3217,15 @@ def outer(
     canonical_subs = info.canonical_subscripts
     if output_sym is not None:
         output_sym = _prepare_symmetric_out(out, output_sym)
+    elif isinstance(out, SymmetricTensor):
+        # A SymmetricTensor destination is not exotic: a square constant fill
+        # picks up an INFERRED symmetry tag, so ``fnp.zeros((n, n))`` -- the
+        # obvious way to build a destination -- already is one. numpy is not
+        # allowed to write it directly (that would leave the tag standing over
+        # data it never saw), so the write is done by ``_wrap_result`` below.
+        # Validating the tag HERE, above the deduct, keeps a destination whose
+        # tag cannot survive the result free to refuse rather than charged.
+        _prepare_symmetric_out(out, None)
     billing_dtypes: tuple = (a.dtype, b.dtype)
     if isinstance(out, _np.ndarray):
         billing_dtypes += store_billing_dtypes(out)
@@ -3231,12 +3240,25 @@ def outer(
             _np.outer,
             _to_base_ndarray(a),
             _to_base_ndarray(b),
-            out=None if isinstance(out, SymmetricTensor) else out,
+            # The operands are stripped; the destination was not, so a
+            # FlopscopeArray ``out`` reached numpy still wrapped and tripped
+            # the internal "reached numpy.outer from inside an fnp wrapper"
+            # guard -- after the deduct, so the caller paid the whole
+            # contraction and then got a RuntimeError. The strip is a
+            # zero-copy view, so numpy still writes the caller's buffer.
+            out=None if isinstance(out, SymmetricTensor) else _to_base_ndarray(out),
         )
-    if output_sym is None:
+    if output_sym is None and not isinstance(out, SymmetricTensor):
         if out is not None:
             return out
         return result  # type: ignore[return-value]
+    # A SymmetricTensor destination reaches _wrap_result even when the result
+    # carries no symmetry. It used to take the branch above and return itself
+    # UNWRITTEN: numpy had been handed out=None, nothing ever copied the answer
+    # across, and the caller got their untouched destination back having paid
+    # the whole contraction, with no exception. _wrap_result copies the result
+    # in, records the write so no tag outlives the data it described, and drops
+    # the inferred tag the destination no longer earns.
     return _wrap_result(result, out=out, symmetry=output_sym)  # type: ignore[return-value]
 
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -51,7 +51,7 @@ from flopscope._symmetry_utils import (
     restrict_group_to_axes,
     unique_elements_for_shape,
 )
-from flopscope._validation import maybe_check_nan_inf, require_budget
+from flopscope._validation import _normalize_out, maybe_check_nan_inf, require_budget
 from flopscope._write_epoch import note_write
 from flopscope.errors import (
     CostFallbackWarning,
@@ -219,14 +219,27 @@ def _supports_out_argument(np_func) -> bool:
         return False
 
 
-def _require_ndarray_out(out, op_name):
-    """``out=`` must be the destination array itself, not a container holding it.
+def _is_out_like(value) -> bool:
+    """Is *value*, sitting in a positional ``out`` slot, meant to be ``out``?
 
-    numpy rejects a wrapped destination for ufuncs, but not everywhere: on the
-    einsum path ``_np.asarray([dest])`` silently builds a NEW array, so the copy
-    lands in that temporary, ``dest`` keeps its old contents, and the caller gets
-    the untouched wrapper back -- charged in full for a result they never
-    received. Reject it up front, before anything is billed.
+    Anything that is not ``None`` is. The slot index comes from numpy's own
+    parameter list for the op (``_params.index("out")``), so a value there is
+    the caller's ``out`` whatever its type -- and numpy's ``out`` accepts only
+    an array or ``None``. Recognising it is what lets :func:`_normalize_out`
+    refuse a bad one for free; leaving it unrecognised would pass it through
+    to numpy, which raises only after the reduction has been billed.
+    """
+    return value is not None
+
+
+def _require_ndarray_out(out, op_name):
+    """Internal tripwire: ``out`` must already have been normalized.
+
+    Every public entry point rebinds ``out`` through :func:`_normalize_out` at
+    the top of its wrapper, so by the time control reaches here a container is
+    unreachable by construction. It is kept because the failure it catches is
+    silent otherwise: a wrapper added later without the normalize call would
+    not raise, it would quietly bill the contraction at the wrong rate.
     """
     if out is None or isinstance(out, _np.ndarray):
         return
@@ -532,6 +545,10 @@ def _counted_unary(np_func, op_name: str):
         x: ArrayLike, out: FlopscopeArray | None = None, **kwargs: Any
     ) -> FlopscopeArray:
         budget = require_budget()
+        # Above every later read of ``out`` -- the billing dtype, the
+        # symmetry check, and what gets returned -- and above the deduct,
+        # so a refused form costs nothing.
+        out = _normalize_out(out, op_name)
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
         symmetry = _symmetry_of(x)
@@ -598,6 +615,10 @@ def _free_unary(np_func, op_name: str):
         x: ArrayLike, out: FlopscopeArray | None = None, **kwargs: Any
     ) -> FlopscopeArray:
         budget = require_budget()
+        # Above every later read of ``out`` -- the billing dtype, the
+        # symmetry check, and what gets returned -- and above the deduct,
+        # so a refused form costs nothing.
+        out = _normalize_out(out, op_name)
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
         symmetry = _symmetry_of(x)
@@ -657,6 +678,10 @@ def _counted_unary_multi(np_func, op_name: str):
         **kwargs: Any,
     ) -> tuple[FlopscopeArray, FlopscopeArray]:
         budget = require_budget()
+        # Above every later read of ``out`` -- the billing dtype, the
+        # symmetry check, and what gets returned -- and above the deduct,
+        # so a refused form costs nothing.
+        out = _normalize_out(out, op_name, nout=nout)
         if not isinstance(x, _np.ndarray):
             x = _np.asarray(x)
         symmetry = _symmetry_of(x)
@@ -713,6 +738,10 @@ def _counted_binary(np_func, op_name: str):
         x: ArrayLike, y: ArrayLike, out: FlopscopeArray | None = None, **kwargs: Any
     ) -> FlopscopeArray:
         budget = require_budget()
+        # Above every later read of ``out`` -- the billing dtype, the
+        # symmetry check, and what gets returned -- and above the deduct,
+        # so a refused form costs nothing.
+        out = _normalize_out(out, op_name)
         # Preserve original (possibly Python-scalar) values for the actual
         # numpy call so that NEP 50 weak-typing rules apply correctly. We
         # only need ndarray views for shape and symmetry inspection below.
@@ -834,6 +863,10 @@ def _counted_binary_multi(np_func, op_name: str):
         **kwargs: Any,
     ) -> tuple[FlopscopeArray, FlopscopeArray]:
         budget = require_budget()
+        # Above every later read of ``out`` -- the billing dtype, the
+        # symmetry check, and what gets returned -- and above the deduct,
+        # so a refused form costs nothing.
+        out = _normalize_out(out, op_name, nout=nout)
         # Preserve original (possibly Python-scalar) values for the actual
         # numpy call so that NEP 50 weak-typing rules apply correctly. We
         # only need ndarray views for shape and symmetry inspection below.
@@ -967,6 +1000,10 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
     :func:`_symmetry_adjusted_cost`).
     """
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, f"{ufunc.__name__}.outer", nout=ufunc.nout)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
@@ -1055,6 +1092,10 @@ def _counted_ufunc_reduce_generic(
     :func:`reduce_group(symmetry, ndim, axis, keepdims)`.
     """
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, f"{ufunc.__name__}.reduce", nout=ufunc.nout)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -1107,6 +1148,10 @@ def _counted_ufunc_accumulate_generic(ufunc, a, *, axis=0, out=None, **kwargs):
     symmetry on the accumulate axis only).
     """
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, f"{ufunc.__name__}.accumulate", nout=ufunc.nout)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -1154,6 +1199,10 @@ def _counted_ufunc_reduceat(ufunc, a, indices, *, axis=0, out=None, **kwargs):
     boundaries don't respect any axis-permutation group action.
     """
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, f"{ufunc.__name__}.reduceat", nout=ufunc.nout)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     cost = _builtins.max(int(a.size), 1)
@@ -1351,15 +1400,20 @@ def _counted_reduction(
         # Resolve `out` from either kwargs OR a positional slot in args
         # (per-function — see _out_args_idx computed at factory build time).
         args_list = list(args)
-        out = kwargs.pop("out", None)
+        # Normalized before anything reads it: unlike the other wrappers this
+        # one cannot normalize at the top, because ``out`` is not bound yet --
+        # it arrives either as a keyword or in a positional slot. Both routes
+        # go through the same helper here, ahead of _prepare_symmetric_out,
+        # the out_dtype billing fold below, and the deduct.
+        out = _normalize_out(kwargs.pop("out", None), op_name)
         out_came_from_args = False
         if (
             out is None
             and _out_args_idx is not None
             and 0 <= _out_args_idx < len(args_list)
-            and isinstance(args_list[_out_args_idx], _np.ndarray)
+            and _is_out_like(args_list[_out_args_idx])
         ):
-            out = args_list[_out_args_idx]
+            out = _normalize_out(args_list[_out_args_idx], op_name)
             out_came_from_args = True
 
         new_symmetry = (
@@ -1534,6 +1588,10 @@ def around(
 ) -> FlopscopeArray | Any:
     """Counted version of np.around. Cost = numel(output) FLOPs."""
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "around")
     a_is_scalar = not isinstance(a, _np.ndarray) and _np.ndim(a) == 0
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
@@ -1644,6 +1702,10 @@ def round(
 ) -> FlopscopeArray | Any:
     """Counted version of np.round. Cost = numel(output) FLOPs."""
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "round")
     a_is_scalar = not isinstance(a, _np.ndarray) and _np.ndim(a) == 0
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
@@ -1915,6 +1977,10 @@ def clip(
     Output shape is the broadcast of a with all bound arrays.
     """
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "clip")
     a_orig = a
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
@@ -2006,6 +2072,10 @@ def _counted_mean(np_func, op_name: str):
         )
 
         budget = require_budget()
+        # Above every later read of ``out`` -- the billing dtype, the
+        # symmetry check, and what gets returned -- and above the deduct,
+        # so a refused form costs nothing.
+        out = _normalize_out(out, op_name)
         if not isinstance(a, _np.ndarray):
             a = _np.asarray(a)
         symmetry = _symmetry_of(a)
@@ -2105,6 +2175,10 @@ def _counted_variance(np_func, op_name: str, *, with_sqrt: bool):
         **kwargs: Any,
     ) -> FlopscopeArray:
         budget = require_budget()
+        # Above every later read of ``out`` -- the billing dtype, the
+        # symmetry check, and what gets returned -- and above the deduct,
+        # so a refused form costs nothing.
+        out = _normalize_out(out, op_name)
         if not isinstance(a, _np.ndarray):
             a = _np.asarray(a)
         symmetry = _symmetry_of(a)
@@ -2382,6 +2456,10 @@ def median(
     import math as _math
 
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "median")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -2456,6 +2534,10 @@ def nanmedian(
     import math as _math
 
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "nanmedian")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -2522,6 +2604,10 @@ def nanpercentile(
     import math as _math
 
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "nanpercentile")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -2608,6 +2694,10 @@ def nanquantile(
     import math as _math
 
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "nanquantile")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -2688,6 +2778,10 @@ def percentile(
     import math as _math
 
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "percentile")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -2767,6 +2861,10 @@ def quantile(
     import math as _math
 
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "quantile")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     sym = _symmetry_of(a)
@@ -2902,6 +3000,10 @@ def _einsum_routed_binary(
     from flopscope._einsum import _resolve_cost_and_output_symmetry
 
     budget = require_budget()
+    # Above every later read of ``out``: the billing gate below, the forward
+    # to numpy, and ``result = out``. A tuple reaching those bills the
+    # contraction without the destination's dtype and hands the tuple back.
+    out = _normalize_out(out, op_name)
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
@@ -3047,6 +3149,10 @@ def outer(
 ) -> FlopscopeArray:
     """Counted version of np.outer."""
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "outer")
     # Capture aliasing BEFORE asarray conversion so outer(v, v) is detected
     # even when v is a list or other non-ndarray type.
     a_orig_is_b_orig = a is b

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -1984,7 +1984,24 @@ def clip(
     # otherwise land in *args and be counted as a third BOUND: measured 12,000
     # FLOPs against 8,000 for the identical keyword call, because every bound
     # costs numel, and the destination's dtype never reached the rate at all.
-    if len(args) >= 3:
+    # Exactly three, never "three or more": numpy's clip has four positional
+    # slots and raises for a fifth, and truncating args here would swallow the
+    # extras instead. That is worse than a lenient parse -- ``where`` is
+    # keyword-only in numpy's clip, so a caller passing it positionally gets a
+    # TypeError from numpy, while a silent truncation would hand back an
+    # UNMASKED clip and no warning. Anything past the fourth slot is left for
+    # numpy to reject in its own words.
+    if len(args) > 3:
+        # numpy has exactly four positional slots (a, a_min, a_max, out) and
+        # raises for a fifth. Extras must not be silently absorbed as further
+        # BOUNDS: ``where`` is keyword-only in numpy's clip, so a caller
+        # passing it positionally would otherwise get an UNMASKED clip back
+        # and no warning. Raise in numpy's own words rather than inventing one.
+        raise TypeError(
+            f"clip() takes from 1 to 4 positional arguments but "
+            f"{len(args) + 1} were given"
+        )
+    if len(args) == 3:
         args, out_positional = args[:2], args[2]
         if out is not None and out_positional is not None:
             raise TypeError("clip(): out= given both positionally and by keyword")

--- a/src/flopscope/_validation.py
+++ b/src/flopscope/_validation.py
@@ -67,10 +67,14 @@ def _normalize_out(out: object, op_name: str, *, nout: int = 1) -> Any:
             f"multi-output {op_name} requires out= to be a tuple of length "
             f"{nout}; got {type(out).__name__} of length {length}"
         )
+    # numpy's own wording ("return arrays must be of ArrayType") is kept in
+    # the message on purpose. Code in the wild matches on it -- numpy's fft
+    # test suite among it -- and intercepting the argument earlier than numpy
+    # does should not change what the failure looks like to a caller.
     raise TypeError(
-        f"{op_name}(): out= must be an array, or a 1-tuple holding one, got "
-        f"{type(out).__name__}. Pass the destination array itself, not a "
-        f"container holding it."
+        f"{op_name}(): return arrays must be of ArrayType -- out= must be an "
+        f"array, or a 1-tuple holding one, not {type(out).__name__}. Pass the "
+        f"destination array itself, not a container holding it."
     )
 
 

--- a/src/flopscope/_validation.py
+++ b/src/flopscope/_validation.py
@@ -47,34 +47,51 @@ def _normalize_out(out: object, op_name: str, *, nout: int = 1) -> Any:
     the bare destination, or (for a multi-output op) the tuple unchanged.
     Typed ``Any`` because which of those it is depends on ``nout``, and
     every caller assigns it straight back over its own ``out`` parameter.
+
+    The refusals mirror numpy's ufunc parser exactly, both in class and in
+    wording, because intercepting the argument earlier than numpy does should
+    not change what the failure looks like to a caller. Measured on numpy
+    2.2.6 -- a length mismatch is a ``ValueError`` and a type mismatch is a
+    ``TypeError``, which is not a distinction worth inventing our own version
+    of::
+
+        np.modf(a, out=d)         TypeError:  'out' must be a tuple of arrays
+        np.modf(a, out=(d,))      ValueError: The 'out' tuple must have
+                                              exactly one entry per ufunc output
+        np.multiply(a, a, out=()) ValueError: (same)
+        np.multiply(a, a, out=[d]) TypeError: return arrays must be of ArrayType
     """
-    if out is None or isinstance(out, np.ndarray):
+    if out is None:
         return out
+
+    if isinstance(out, np.ndarray):
+        if nout == 1:
+            return out
+        # A bare array names one destination, and a multi-output ufunc needs
+        # one per output. numpy deprecated this in 1.10 and made it a hard
+        # error in gh-14682; refusing it here is what makes it free rather
+        # than charged, since numpy only gets to see it after the deduct.
+        raise TypeError(f"{op_name}(): 'out' must be a tuple of arrays")
+
     # ``type(out) is tuple``, not ``isinstance``: numpy refuses a namedtuple
     # or any tuple subclass here, and being more permissive than numpy buys
     # nothing. ``_builtins.all`` rather than ``all``: ``all`` is itself a
-    # counted flopscope operation, and the modules that call this helper
-    # rebind the name to it -- validating an argument must never bill.
-    if (
-        type(out) is tuple
-        and len(out) == nout
-        and _builtins.all(o is None or isinstance(o, np.ndarray) for o in out)
-    ):
-        return out[0] if nout == 1 else out
-    if nout != 1:
-        length = len(out) if isinstance(out, (tuple, list)) else "?"
-        raise TypeError(
-            f"multi-output {op_name} requires out= to be a tuple of length "
-            f"{nout}; got {type(out).__name__} of length {length}"
-        )
-    # numpy's own wording ("return arrays must be of ArrayType") is kept in
-    # the message on purpose. Code in the wild matches on it -- numpy's fft
-    # test suite among it -- and intercepting the argument earlier than numpy
-    # does should not change what the failure looks like to a caller.
+    # counted flopscope operation, and this module's callers rebind the name
+    # to it -- validating an argument must never bill.
+    if type(out) is tuple:
+        if len(out) != nout:
+            raise ValueError(
+                f"{op_name}(): The 'out' tuple must have exactly one entry "
+                f"per ufunc output"
+            )
+        if _builtins.all(o is None or isinstance(o, np.ndarray) for o in out):
+            return out[0] if nout == 1 else out
+
     raise TypeError(
         f"{op_name}(): return arrays must be of ArrayType -- out= must be an "
-        f"array, or a 1-tuple holding one, not {type(out).__name__}. Pass the "
-        f"destination array itself, not a container holding it."
+        f"array, or a tuple of {nout} holding one per output, not "
+        f"{type(out).__name__}. Pass the destination array itself, not a "
+        f"container holding it."
     )
 
 

--- a/src/flopscope/_validation.py
+++ b/src/flopscope/_validation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import builtins as _builtins
 import warnings
+from typing import Any
 
 import numpy as np
 
@@ -18,6 +20,58 @@ def require_budget():
     from flopscope._budget import _get_global_default
 
     return _get_global_default()
+
+
+def _normalize_out(out: object, op_name: str, *, nout: int = 1) -> Any:
+    """Reduce ``out=`` to the destination array itself, or refuse it.
+
+    numpy's ufunc protocol lets a caller pass the destination either bare or
+    inside a tuple of length ``nout``; ``np.multiply(a, b, out=(dest,))`` and
+    ``out=dest`` mean the same thing. flopscope has to see through the tuple
+    for itself, because it reads ``out`` several times before numpy ever gets
+    it -- to pick the billing dtype, to check symmetry, and to decide what to
+    hand back. A tuple slipping past those reads is not a cosmetic difference:
+    the destination's dtype stops participating in the rate, so a contraction
+    into a wider buffer bills as if the buffer were not there.
+
+    Worse on the einsum path, which never forwards ``out`` to numpy at all:
+    there a container reaches ``_np.asarray(container)``, which builds a NEW
+    array, so the result lands in that temporary, the real destination keeps
+    its old contents, and the caller gets the untouched container back having
+    paid in full.
+
+    So: unwrap what numpy would unwrap, refuse everything else, and do it
+    before a single FLOP is charged.
+
+    Returns the value ``out`` should be for the rest of the call -- ``None``,
+    the bare destination, or (for a multi-output op) the tuple unchanged.
+    Typed ``Any`` because which of those it is depends on ``nout``, and
+    every caller assigns it straight back over its own ``out`` parameter.
+    """
+    if out is None or isinstance(out, np.ndarray):
+        return out
+    # ``type(out) is tuple``, not ``isinstance``: numpy refuses a namedtuple
+    # or any tuple subclass here, and being more permissive than numpy buys
+    # nothing. ``_builtins.all`` rather than ``all``: ``all`` is itself a
+    # counted flopscope operation, and the modules that call this helper
+    # rebind the name to it -- validating an argument must never bill.
+    if (
+        type(out) is tuple
+        and len(out) == nout
+        and _builtins.all(o is None or isinstance(o, np.ndarray) for o in out)
+    ):
+        return out[0] if nout == 1 else out
+    if nout != 1:
+        length = len(out) if isinstance(out, (tuple, list)) else "?"
+        raise TypeError(
+            f"multi-output {op_name} requires out= to be a tuple of length "
+            f"{nout}; got {type(out).__name__} of length {length}"
+        )
+    raise TypeError(
+        f"{op_name}(): out= must be an array, or a 1-tuple holding one, got "
+        f"{type(out).__name__}. Pass the destination array itself, not a "
+        f"container holding it."
+    )
 
 
 def validate_ndarray(*arrays: object) -> None:

--- a/src/flopscope/numpy/fft/_transforms.py
+++ b/src/flopscope/numpy/fft/_transforms.py
@@ -16,7 +16,7 @@ from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._dtype_billing import fft_billing_dtype
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
-from flopscope._validation import require_budget
+from flopscope._validation import _normalize_out, require_budget
 
 # numpy 2.1 reversed the remaining-axis execution order that rfftn/rfft2 use
 # after the real FFT on the last axis (forward on 2.0.x, reversed from 2.1
@@ -255,6 +255,10 @@ def fft(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.fft")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if n is None:
@@ -292,6 +296,10 @@ def ifft(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.ifft")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if n is None:
@@ -329,6 +337,10 @@ def rfft(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.rfft")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if n is None:
@@ -366,6 +378,10 @@ def irfft(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.irfft")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if n is None:
@@ -404,6 +420,10 @@ def fft2(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.fft2")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -460,6 +480,10 @@ def ifft2(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.ifft2")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -516,6 +540,10 @@ def rfft2(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.rfft2")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -572,6 +600,10 @@ def irfft2(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.irfft2")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -646,6 +678,10 @@ def fftn(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.fftn")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -702,6 +738,10 @@ def ifftn(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.ifftn")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -758,6 +798,10 @@ def rfftn(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.rfftn")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -814,6 +858,10 @@ def irfftn(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.irfftn")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if axes is None:
@@ -888,6 +936,10 @@ def hfft(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.hfft")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if n is None:
@@ -928,6 +980,10 @@ def ihfft(
     out: ArrayLike | None = None,
 ) -> FlopscopeArray:
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "fft.ihfft")
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if n is None:

--- a/src/flopscope/numpy/linalg/_compound.py
+++ b/src/flopscope/numpy/linalg/_compound.py
@@ -12,7 +12,7 @@ from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
 from flopscope._dtype_billing import linalg_billing_dtypes
 from flopscope._ndarray import FlopscopeArray, _asflopscope, _to_base_ndarray
-from flopscope._validation import require_budget
+from flopscope._validation import _normalize_out, require_budget
 from flopscope.numpy.linalg._solvers import _batch_size, _has_zero_dim
 
 
@@ -80,6 +80,10 @@ def multi_dot(
 ) -> FlopscopeArray:
     """Efficient multi-matrix dot product with FLOP counting."""
     budget = require_budget()
+    # Above every later read of ``out`` -- the billing dtype, the
+    # symmetry check, and what gets returned -- and above the deduct,
+    # so a refused form costs nothing.
+    out = _normalize_out(out, "linalg.multi_dot")
     inputs_were_whest = any(isinstance(a, FlopscopeArray) for a in arrays)
     arrays = [a if isinstance(a, _np.ndarray) else _np.asarray(a) for a in arrays]
     shapes = [arr.shape for arr in arrays]

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -622,7 +622,7 @@ def test_we_modf_invalid_out_tuple_length_raises():
     with flops.BudgetContext(flop_budget=int(1e10)):
         a = fnp.array([1.5, 2.5, 3.0])
         single = fnp.zeros(3)
-        with pytest.raises(TypeError, match="tuple of length 2"):
+        with pytest.raises(ValueError, match="exactly one entry per ufunc output"):
             fnp.modf(a, out=(single,))  # pyright: ignore[reportArgumentType]
 
 

--- a/tests/test_array_protocols.py
+++ b/tests/test_array_protocols.py
@@ -622,7 +622,7 @@ def test_we_modf_invalid_out_tuple_length_raises():
     with flops.BudgetContext(flop_budget=int(1e10)):
         a = fnp.array([1.5, 2.5, 3.0])
         single = fnp.zeros(3)
-        with pytest.raises(TypeError, match="length"):
+        with pytest.raises(TypeError, match="tuple of length 2"):
             fnp.modf(a, out=(single,))  # pyright: ignore[reportArgumentType]
 
 

--- a/tests/test_nonnumeric_out_billing.py
+++ b/tests/test_nonnumeric_out_billing.py
@@ -137,3 +137,30 @@ def test_nonnumeric_operands_still_bill_neutral():
     neutral = _billed(lambda: fnp.multiply(o, o))
     same_shape_f64 = _billed(lambda: fnp.multiply(np.ones((2, 2)), np.ones((2, 2))))
     assert neutral < same_shape_f64  # f64 rate is 2.0, object stays 1.0
+
+
+# --- the gate must not be reachable around, via a container ---------------
+
+
+@pytest.mark.parametrize("wrap", [lambda d: d, lambda d: (d,)], ids=["bare", "tuple"])
+def test_a_nonnumeric_out_does_not_discount_through_a_container(wrap):
+    """The whole gate is ``isinstance(out, np.ndarray)``, so a container used
+    to slip past it -- billing as though no destination were supplied at all.
+    Normalizing ``out`` before the gate is what keeps the tuple honest."""
+    load_weights()
+    a, b = _complex_pair()
+    honest = _billed(lambda: fnp.vecdot(a, b))
+    out = np.empty(N, dtype=object)
+    assert _billed(lambda: fnp.vecdot(a, b, out=wrap(out))) == honest
+
+
+@pytest.mark.parametrize("wrap", [lambda d: d, lambda d: (d,)], ids=["bare", "tuple"])
+def test_a_numeric_widening_out_bills_wider_through_a_container(wrap):
+    """The converse direction: the widest-participating-buffer charge must
+    apply to a wrapped destination exactly as it does to a bare one, or the
+    container becomes a way to buy a wide accumulator at the narrow rate."""
+    load_weights()
+    a, b = _real_pair()
+    narrow = _billed(lambda: fnp.vecdot(a, b))
+    wide = np.zeros(N, dtype=np.complex128)
+    assert _billed(lambda: fnp.vecdot(a, b, out=wrap(wide))) > narrow

--- a/tests/test_out_arg_wrapped_destination.py
+++ b/tests/test_out_arg_wrapped_destination.py
@@ -1275,3 +1275,92 @@ def test_out_none_and_absent_are_unaffected(budget):
     b = fnp.array([3.0, 4.0])
     assert np.asarray(fnp.multiply(a, b)).tolist() == [3.0, 8.0]
     assert np.asarray(fnp.multiply(a, b, out=None)).tolist() == [3.0, 8.0]
+
+
+# ---------------------------------------------------------------------------
+# The two destination channels that a derived tuple-parity sweep cannot see
+# ---------------------------------------------------------------------------
+#
+# Both of these move the bare and the 1-tuple form by the SAME amount, so the
+# derived parity test above stays green whichever way they go. They need their
+# own assertions, or the fixes they pin can be reverted silently.
+
+
+def test_ptp_folds_its_destination_dtype_like_its_reduction_siblings():
+    # ptp takes out= through **kwargs, so it reached neither the normalization
+    # nor the destination-dtype fold. A wider destination was free: reverting
+    # the fold leaves this at a quarter price while every other test passes.
+    rng = np.random.default_rng(4)
+    with fl.BudgetContext(flop_budget=10**14, quiet=True) as ctx:
+        a = fnp.asarray(rng.standard_normal((200, 200)).astype("float32"))
+        wide = np.zeros(200, dtype="complex128")
+
+        before = ctx.flops_used
+        fnp.ptp(a, axis=-1)
+        bare = ctx.flops_used - before
+
+        before = ctx.flops_used
+        fnp.ptp(a, axis=-1, out=wide)
+        widened = ctx.flops_used - before
+
+        # The sibling is the real oracle: ptp and amax share a registry
+        # category, so whatever ratio a wide destination earns for one it must
+        # earn for the other. Comparing ptp against ITSELF would pass on any
+        # ratio including 1.0; comparing against amax is the outlier check
+        # that found this defect in the first place, and it does not need
+        # re-tuning when the dtype weights move.
+        sibling_wide = np.zeros(200, dtype="complex128")
+        before = ctx.flops_used
+        fnp.amax(a, axis=-1)
+        sibling_bare = ctx.flops_used - before
+
+        before = ctx.flops_used
+        fnp.amax(a, axis=-1, out=sibling_wide)
+        sibling_widened = ctx.flops_used - before
+
+    assert widened > bare, (
+        f"ptp billed {widened} into a complex128 destination against {bare} "
+        f"with none -- the destination's dtype is not reaching the rate"
+    )
+    assert widened / bare == sibling_widened / sibling_bare, (
+        f"ptp widened by {widened / bare}x where its sibling amax widened by "
+        f"{sibling_widened / sibling_bare}x for the same destination"
+    )
+
+
+def test_clip_prices_a_positional_destination_like_a_keyword_one():
+    # clip declares out keyword-only but republishes numpy's signature, which
+    # advertises it as the fourth positional. Without the positional channel
+    # the destination lands in *args and is counted as an extra BOUND, so it
+    # costs MORE than the keyword spelling and its dtype never reaches the rate.
+    rng = np.random.default_rng(4)
+    with fl.BudgetContext(flop_budget=10**14, quiet=True) as ctx:
+        a = fnp.asarray(rng.standard_normal(1000).astype("float32"))
+        kw_dest = np.zeros(1000, dtype="complex128")
+        pos_dest = np.zeros(1000, dtype="complex128")
+
+        before = ctx.flops_used
+        fnp.clip(a, -1.0, 1.0, out=kw_dest)  # pyright: ignore[reportArgumentType]
+        keyword_cost = ctx.flops_used - before
+
+        before = ctx.flops_used
+        fnp.clip(a, -1.0, 1.0, pos_dest)
+        positional_cost = ctx.flops_used - before
+
+    assert positional_cost == keyword_cost
+    assert np.array_equal(np.asarray(kw_dest), np.asarray(pos_dest))
+
+
+def test_clip_does_not_swallow_positionals_past_the_destination_slot():
+    # numpy's clip has four positional slots and rejects a fifth. Consuming
+    # "three or more" here would truncate the extras instead -- and because
+    # `where` is keyword-only in numpy's clip, a caller passing it positionally
+    # would get an UNMASKED clip back rather than numpy's TypeError.
+    rng = np.random.default_rng(4)
+    with fl.BudgetContext(flop_budget=10**12, quiet=True) as ctx:
+        a = fnp.asarray(rng.standard_normal(100).astype("float64"))
+        dest = np.zeros(100, dtype="float64")
+        mask = np.zeros(100, dtype=bool)
+
+        with pytest.raises(TypeError):
+            fnp.clip(a, -1.0, 1.0, dest, mask)  # pyright: ignore[reportArgumentType]

--- a/tests/test_out_arg_wrapped_destination.py
+++ b/tests/test_out_arg_wrapped_destination.py
@@ -197,6 +197,12 @@ def _bad_forms(dest):
     }
 
 
+#: numpy distinguishes the two: a tuple of the wrong LENGTH is a ValueError
+#: ("The 'out' tuple must have exactly one entry per ufunc output"), anything
+#: of the wrong TYPE is a TypeError ("return arrays must be of ArrayType").
+_WRONG_LENGTH = {"two-tuple", "empty-tuple"}
+
+
 @pytest.mark.parametrize("form", sorted(_bad_forms(None)))
 def test_a_refused_out_form_costs_nothing_on_every_path(budget, form):
     # Every array is built BEFORE the measurement starts. Constructing one
@@ -215,7 +221,8 @@ def test_a_refused_out_form_costs_nothing_on_every_path(budget, form):
     for name, call, dest in cases:
         bad = _bad_forms(dest)[form]
         before = budget.flops_used
-        with pytest.raises(TypeError):
+        expected = ValueError if form in _WRONG_LENGTH else TypeError
+        with pytest.raises(expected):
             call(bad)
         assert budget.flops_used == before, (
             f"{name} was billed for refusing out={form}; a refusal must be free"
@@ -234,7 +241,8 @@ def test_einsum_refuses_the_container_forms_it_used_to_mis_write(budget):
 
     for bad in bad_forms:
         dest_before = budget.flops_used
-        with pytest.raises(TypeError, match="out= must be an array"):
+        expected = ValueError if isinstance(bad, tuple) else TypeError
+        with pytest.raises(expected):
             fnp.einsum("ij,jk->ik", a, b, out=bad)
         assert budget.flops_used == dest_before
 
@@ -273,7 +281,7 @@ def test_a_wrong_length_multi_output_tuple_is_refused_for_free(budget):
     src = fnp.array([1.5, 2.5])
     dest = fnp.zeros(2)
     before = budget.flops_used
-    with pytest.raises(TypeError, match="tuple of length 2"):
+    with pytest.raises(ValueError, match="exactly one entry per ufunc output"):
         fnp.modf(src, out=(dest,))  # pyright: ignore[reportArgumentType]
     assert budget.flops_used == before
 

--- a/tests/test_out_arg_wrapped_destination.py
+++ b/tests/test_out_arg_wrapped_destination.py
@@ -1,0 +1,84 @@
+"""A wrapped ``out=`` destination must be refused, not silently mis-written.
+
+``out=[dest]`` — the destination wrapped in a container — used to be accepted by
+the einsum path: ``_np.asarray([dest])`` builds a NEW array from the container,
+so the copy landed in that temporary, ``dest`` kept its old contents, and the
+caller received the untouched wrapper back having been billed the full
+contraction. A plausible-looking array of the wrong values, at full price, is
+the worst failure class in a metering system.
+
+numpy rejects a wrapped destination for ufuncs on its own, so this only ever bit
+the paths that copy into ``out`` themselves. The guard sits before billing, so a
+refused call costs nothing.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import flopscope as fl
+import flopscope.numpy as fnp
+
+
+@pytest.fixture()
+def budget():
+    with fl.BudgetContext(flop_budget=10**12, quiet=True) as ctx:
+        yield ctx
+
+
+def test_einsum_wrapped_out_is_refused_and_costs_nothing(budget):
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    b = fnp.array([[5.0, 6.0], [7.0, 8.0]])
+    dest = fnp.array([[0.0, 0.0], [0.0, 0.0]])
+    before = budget.flops_used
+
+    with pytest.raises(TypeError, match="out= must be an array"):
+        fnp.einsum("ij,jk->ik", a, b, out=[dest])
+
+    assert budget.flops_used == before, "a refused call must not be billed"
+    assert np.array_equal(np.asarray(dest), np.zeros((2, 2)))
+
+
+def test_einsum_with_a_real_out_still_works(budget):
+    a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
+    b = fnp.array([[5.0, 6.0], [7.0, 8.0]])
+    dest = fnp.array([[0.0, 0.0], [0.0, 0.0]])
+
+    result = fnp.einsum("ij,jk->ik", a, b, out=dest)
+
+    expected = [[19.0, 22.0], [43.0, 50.0]]
+    assert np.asarray(result).tolist() == expected
+    assert np.asarray(dest).tolist() == expected, "out= must receive the result"
+    assert result is dest, "out= must return the destination itself"
+
+
+@pytest.mark.parametrize("wrapper", [list, tuple])
+def test_pointwise_wrapped_out_is_refused(budget, wrapper):
+    a = fnp.array([1.0, 2.0])
+    b = fnp.array([3.0, 4.0])
+    dest = fnp.array([0.0, 0.0])
+
+    with pytest.raises(TypeError):
+        fnp.multiply(a, b, out=wrapper([dest]))
+
+    assert np.array_equal(np.asarray(dest), np.zeros(2))
+
+
+def test_out_still_works_on_the_routed_binaries(budget):
+    """vecdot/matvec/vecmat expose out= publicly; they must keep working."""
+    eye = fnp.array([[1.0, 0.0], [0.0, 1.0]])
+    v = fnp.array([3.0, 4.0])
+
+    dest = fnp.array([0.0, 0.0])
+    assert np.asarray(fnp.matvec(eye, v, out=dest)).tolist() == [3.0, 4.0]
+
+    scalar_dest = fnp.array(0.0)
+    assert float(np.asarray(fnp.vecdot(v, v, out=scalar_dest))) == 25.0
+
+
+def test_out_none_and_absent_are_unaffected(budget):
+    a = fnp.array([1.0, 2.0])
+    b = fnp.array([3.0, 4.0])
+    assert np.asarray(fnp.multiply(a, b)).tolist() == [3.0, 8.0]
+    assert np.asarray(fnp.multiply(a, b, out=None)).tolist() == [3.0, 8.0]

--- a/tests/test_out_arg_wrapped_destination.py
+++ b/tests/test_out_arg_wrapped_destination.py
@@ -33,6 +33,7 @@ import pytest
 
 import flopscope as fl
 import flopscope.numpy as fnp
+from flopscope._symmetric import SymmetricTensor
 
 
 @pytest.fixture()
@@ -119,6 +120,271 @@ def test_a_one_tuple_out_bills_exactly_like_a_bare_out(budget, name, call, make_
         f"{name}: out=(dest,) billed {tuple_cost} where out=dest billed "
         f"{bare_cost} — the destination's dtype is not reaching the rate"
     )
+
+
+#: The ops whose ``out=`` arrives inside **kwargs rather than as a declared
+#: parameter, which is how they escaped the normalization every sibling gets.
+#: ``take`` is the odd one out: it declares ``out``, strips it, and still
+#: refused ``out=(dest,)`` — the only op in the codebase inconsistent with its
+#: siblings on the one-tuple.
+_KWARGS_OUT_OPS = [
+    (
+        "concatenate",
+        lambda o: fnp.concatenate([_f32(64, 32), _f32(64, 32)], out=o),
+        lambda: fnp.zeros((128, 32), dtype="float32"),
+    ),
+    (
+        "stack",
+        lambda o: fnp.stack([_f32(64, 32), _f32(64, 32)], out=o),
+        lambda: fnp.zeros((2, 64, 32), dtype="float32"),
+    ),
+    (
+        "concat",
+        lambda o: fnp.concat([_f32(64, 32), _f32(64, 32)], out=o),
+        lambda: fnp.zeros((128, 32), dtype="float32"),
+    ),
+    (
+        "isnan",
+        lambda o: fnp.isnan(_f32(64, 32), out=o),
+        lambda: fnp.zeros((64, 32), dtype="bool"),
+    ),
+    (
+        "isinf",
+        lambda o: fnp.isinf(_f32(64, 32), out=o),
+        lambda: fnp.zeros((64, 32), dtype="bool"),
+    ),
+    (
+        "isfinite",
+        lambda o: fnp.isfinite(_f32(64, 32), out=o),
+        lambda: fnp.zeros((64, 32), dtype="bool"),
+    ),
+    (
+        "compress",
+        lambda o: fnp.compress(
+            np.array([True, False] * 32), _f32(64, 32), axis=0, out=o
+        ),
+        lambda: fnp.zeros((32, 32), dtype="float32"),
+    ),
+    (
+        "take",
+        lambda o: fnp.take(_f32(64, 32), np.arange(32), axis=0, out=o),
+        lambda: fnp.zeros((32, 32), dtype="float32"),
+    ),
+    (
+        "outer",
+        lambda o: fnp.outer(_f32(64), _f32(64), out=o),
+        lambda: fnp.zeros((64, 64), dtype="float32"),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
+)
+def test_a_kwargs_out_op_bills_a_one_tuple_like_a_bare_array(
+    budget, name, call, make_dest
+):
+    bare_cost, _ = _billed(budget, lambda: call(make_dest()))
+    tuple_cost, _ = _billed(budget, lambda: call((make_dest(),)))
+    assert tuple_cost == bare_cost, (
+        f"{name}: out=(dest,) billed {tuple_cost} where out=dest billed {bare_cost}"
+    )
+
+
+@pytest.mark.parametrize(
+    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
+)
+def test_a_kwargs_out_op_refuses_a_list_for_free(budget, name, call, make_dest):
+    # Built before the measurement: allocating the destination costs FLOPs of
+    # its own, and building it inside is how "refusal is free" measures the
+    # wrong thing. Every one of these charged in full before refusing.
+    dest = make_dest()
+    before = budget.flops_used
+    with pytest.raises(TypeError, match="out= must be an array"):
+        call([dest])
+    assert budget.flops_used == before, f"{name} was billed for refusing out=[dest]"
+
+
+@pytest.mark.parametrize(
+    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
+)
+def test_a_kwargs_out_op_accepts_a_flopscope_destination(budget, name, call, make_dest):
+    # The destination a participant actually holds is a FlopscopeArray. Every
+    # one of these forwarded it to numpy still wrapped, tripping the internal
+    # "missing _to_base_ndarray() strip" guard — after the deduct, so the
+    # caller paid in full and then got a RuntimeError.
+    dest = make_dest()
+    result = call(dest)
+    assert result is dest, f"{name} did not hand back the destination"
+
+
+@pytest.mark.parametrize(
+    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
+)
+def test_a_kwargs_out_op_treats_a_none_holding_tuple_as_no_destination(
+    budget, name, call, make_dest
+):
+    # out=(None,) is numpy's "allocate this slot for me", not a destination.
+    result = call((None,))
+    assert result is not None and result.dtype != np.dtype(object)
+
+
+# ---------------------------------------------------------------------------
+# The destination's dtype has to reach the rate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,call,shape",
+    [
+        ("concatenate", lambda o, a, b: fnp.concatenate([a, b], out=o), (128, 32)),
+        ("stack", lambda o, a, b: fnp.stack([a, b], out=o), (2, 64, 32)),
+        ("concat", lambda o, a, b: fnp.concat([a, b], out=o), (128, 32)),
+    ],
+)
+def test_a_join_into_a_wider_destination_bills_the_destinations_loop(
+    budget, name, call, shape
+):
+    """float32 blocks joined into a complex128 buffer convert on the way in.
+
+    numpy's default casting for these is ``same_kind``, which admits
+    float -> complex, so the copy loop that runs is the destination's. It used
+    to bill as though the destination were not there — the same price as the
+    all-float32 join, for a complex128 result.
+    """
+    a, b = _f32(64, 32), _f32(64, 32)
+    native, _ = _billed(budget, lambda: call(fnp.zeros(shape, dtype="float32"), a, b))
+    wider, _ = _billed(budget, lambda: call(fnp.zeros(shape, dtype="complex128"), a, b))
+
+    # The reference is the same join with complex128 INPUTS: writing that many
+    # complex128 elements costs what it costs, whichever end declares the dtype.
+    ac, bc = fnp.astype(a, "complex128"), fnp.astype(b, "complex128")
+    reference, _ = _billed(
+        budget, lambda: call(fnp.zeros(shape, dtype="complex128"), ac, bc)
+    )
+
+    assert wider > native, f"{name}: a complex128 destination billed as float32"
+    assert wider == reference, (
+        f"{name}: complex128 destination billed {wider}, but the same write from "
+        f"complex128 inputs bills {reference}"
+    )
+
+
+@pytest.mark.parametrize("op", ["isnan", "isinf", "isfinite"])
+def test_a_predicate_into_a_wider_destination_bills_the_cast_it_performs(budget, op):
+    """The predicates return bool, and numpy does NOT widen their loop.
+
+    Every loop these ufuncs publish ends in ``?``, and
+    ``np.isnan.resolve_dtypes((float32, float64))`` reports ``(float32, bool)``:
+    the float32 loop runs and the bool answer is cast into the caller's buffer.
+    The destination is a cast target, not a wider predicate.
+
+    It is still charged, because that cast is real work flopscope already
+    prices: over 4e6 float32 values, into bool 0.179 ms, into float64 1.314 ms,
+    and the explicit two-step (predicate into bool, then ``astype(float64)``)
+    1.269 ms — the fused spelling IS the two-step. Leaving the destination out
+    of the rate handed back a free ``astype``.
+    """
+    call = getattr(fnp, op)
+    x = _f32(64, 32)
+    bool_dest = fnp.zeros((64, 32), dtype="bool")
+    f64_dest = fnp.zeros((64, 32), dtype="float64")
+    c128_dest = fnp.zeros((64, 32), dtype="complex128")
+    # Same values, declared wide by the OPERAND instead of by the destination.
+    x_f64 = fnp.astype(x, "float64")
+    x_c128 = fnp.astype(x, "complex128")
+
+    plain, _ = _billed(budget, lambda: call(x))
+    natural, _ = _billed(budget, lambda: call(x, out=bool_dest))
+    assert natural == plain, "a bool destination is the natural one; it must be free"
+
+    # The rule, stated so it does not depend on the weights profile: the
+    # destination widens the rate exactly as an equally wide OPERAND does —
+    # "widest participating buffer", not "widest operand".
+    for dest, wide_operand, label in (
+        (f64_dest, x_f64, "float64"),
+        (c128_dest, x_c128, "complex128"),
+    ):
+        via_dest, _ = _billed(budget, lambda d=dest: call(x, out=d))
+        via_operand, _ = _billed(budget, lambda w=wide_operand: call(w))
+        assert via_dest == via_operand, (
+            f"{op} into a {label} destination billed {via_dest}, but the same "
+            f"predicate over {label} operands bills {via_operand}"
+        )
+
+    # A strict increase, pinned on the complex destination rather than the
+    # float64 one: the complex structure factor comes from the registry, not
+    # the weights table, so this bites under any weights profile — including
+    # the test profile, where float64 and float32 happen to share a rate and a
+    # float64 destination legitimately costs the same as a bool one.
+    c128_cost, _ = _billed(budget, lambda: call(x, out=c128_dest))
+    assert c128_cost > natural, (
+        f"{op} into a complex128 destination billed {c128_cost}, the same as "
+        f"the bool destination — the cast into it is free"
+    )
+
+
+@pytest.mark.parametrize("op", ["take", "compress"])
+def test_take_and_compress_cannot_reach_a_wider_destination_at_all(budget, op):
+    """Why those two get no destination-dtype fold, unlike their siblings.
+
+    numpy requires ``can_cast(out.dtype, a.dtype, "safe")`` for take/compress,
+    so a wider destination is not a mispriced call — it is not a call. Only
+    same-or-narrower destinations exist, and those never move the rate. This
+    pins the premise; if numpy ever relaxes it, the fold becomes necessary and
+    this test is what says so.
+    """
+    a = np.arange(64 * 32, dtype="float32").reshape(64, 32)
+    wider = np.zeros((32, 32), dtype="float64")
+    with pytest.raises(TypeError, match="Cannot cast"):
+        if op == "take":
+            np.take(a, np.arange(32), axis=0, out=wider)
+        else:
+            np.compress(np.array([True, False] * 32), a, axis=0, out=wider)
+
+
+# ---------------------------------------------------------------------------
+# outer: a symmetric destination used to be returned unwritten
+# ---------------------------------------------------------------------------
+
+
+def test_outer_writes_a_symmetric_destination_it_used_to_silently_skip(budget):
+    """``fnp.zeros((n, n))`` IS a SymmetricTensor — a square constant fill picks
+    up an inferred symmetry tag — so this is the obvious way to build a
+    destination, not an exotic one.
+
+    numpy was handed ``out=None`` for it (correct: a direct write would leave
+    the tag standing over data numpy never showed us), but nothing then copied
+    the result across when the result carried no symmetry of its own. The
+    caller got their untouched destination back, having paid the whole
+    contraction, with no exception raised.
+    """
+    dest = fnp.zeros((8, 8))
+    # The premise of the whole test, asserted rather than assumed.
+    assert isinstance(dest, SymmetricTensor) and dest.symmetry is not None
+    a = fnp.asarray(np.arange(8.0))
+    b = fnp.asarray(np.arange(8.0) + 1.0)
+
+    result = fnp.outer(a, b, out=dest)
+
+    assert result is dest
+    assert np.allclose(np.asarray(dest), np.outer(np.arange(8.0), np.arange(8.0) + 1.0))
+    # The inferred tag described the zeros; it must not survive the write.
+    assert dest.symmetry is None
+
+
+def test_outer_still_carries_a_real_symmetry_into_a_symmetric_destination(budget):
+    dest = fnp.zeros((8, 8))
+    assert isinstance(dest, SymmetricTensor)
+    v = fnp.asarray(np.arange(8.0) + 1.0)
+
+    result = fnp.outer(v, v, out=dest)
+
+    assert result is dest
+    assert np.allclose(
+        np.asarray(dest), np.outer(np.arange(8.0) + 1, np.arange(8.0) + 1)
+    )
+    assert dest.symmetry is not None
 
 
 def test_a_one_tuple_out_bills_like_a_bare_out_through_the_positional_slot(budget):

--- a/tests/test_out_arg_wrapped_destination.py
+++ b/tests/test_out_arg_wrapped_destination.py
@@ -22,18 +22,49 @@ worst failure class in a metering system.
 Lists stay refused, because numpy refuses them everywhere. Refusals happen
 before ``budget.deduct``, so they cost nothing — the property the whole fix
 turns on, and the one the earlier version of this guard did not have.
+
+Why the coverage here is DERIVED rather than hand-listed
+--------------------------------------------------------
+``_normalize_out`` is called from ~48 wrapper sites. A hand-written
+parametrize list pins whichever of them the author happened to think of, and
+mutation testing says exactly what that is worth: with a hand-listed set of
+seven ops, the guard could be deleted from the other 34 sites and the entire
+repository suite still passed.
+
+So the op set under test is discovered from the registry and the module
+surface, and the arguments are generated: an op that accepts ``out=`` is
+enumerated whether or not anyone remembered it, and one added later is
+enumerated the day it lands. Ops the generator legitimately cannot drive are
+listed in ``_NOT_DRIVEN`` **with a reason**, and that list is asserted against
+the discovered set from both directions, so it can neither grow silently nor
+keep a stale entry.
+
+The invariants, for every op that takes a destination:
+
+(a) ``flops_used`` never decreases — no refunds, anywhere;
+(b) a refused ``out=`` form costs ZERO;
+(c) ``out=(d,)`` bills EXACTLY what ``out=d`` bills, and returns ``d`` itself.
 """
 
 from __future__ import annotations
 
 import collections
+import functools
+import inspect
+import types
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import pytest
 
 import flopscope as fl
 import flopscope.numpy as fnp
+from flopscope._budget import get_active_budget
+from flopscope._registry import REGISTRY
 from flopscope._symmetric import SymmetricTensor
+
+SEED = 20260727
 
 
 @pytest.fixture()
@@ -43,7 +74,7 @@ def budget():
 
 
 def _rng():
-    return np.random.default_rng(20260727)
+    return np.random.default_rng(SEED)
 
 
 def _f32(*shape):
@@ -53,180 +84,833 @@ def _f32(*shape):
     return fnp.asarray(_rng().standard_normal(shape).astype("float32"))
 
 
-def _billed(ctx, fn):
+def _billed(ctx, fn, *args, **kwargs):
     before = ctx.flops_used
-    result = fn()
+    result = fn(*args, **kwargs)
     return ctx.flops_used - before, result
 
 
 # ---------------------------------------------------------------------------
-# The tuple bills exactly like the bare array — the point of the change
+# Discovery: which ops take a destination at all
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "name,call,make_dest",
-    [
-        (
-            "matvec",
-            lambda o: fnp.matvec(_f32(256, 256), _f32(256), out=o),
-            lambda: fnp.zeros(256, dtype="complex128"),
+def _walk(root: Any, dotted: str) -> Any:
+    obj = root
+    for part in dotted.split("."):
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+    return obj
+
+
+def _resolve(name: str) -> Any:
+    """The flopscope callable a registry/surface name refers to."""
+    return _walk(fnp, name) or _walk(fl, name)
+
+
+def _numpy_takes_out(np_fn: Any) -> bool:
+    """Does numpy's own callable accept ``out=``?
+
+    Needed only for wrappers that take ``out`` inside ``**kwargs`` rather than
+    as a declared parameter — the exact shape that let this whole family of
+    ops escape the normalization every sibling gets. ``np.concatenate`` is a C
+    builtin with no introspectable signature, so its synthesized docstring
+    header is the only machine-readable statement that it takes a destination.
+    """
+    if np_fn is None:
+        return False
+    if isinstance(np_fn, np.ufunc):
+        return True
+    try:
+        return "out" in inspect.signature(np_fn).parameters
+    except (TypeError, ValueError):
+        header = (getattr(np_fn, "__doc__", None) or "").lstrip().split("\n\n", 1)[0]
+        return "out=" in header
+
+
+def _advertised_out_kind(fs_fn: Any) -> str | None:
+    try:
+        sig = inspect.signature(fs_fn)
+    except (TypeError, ValueError):
+        return None
+    if "out" in sig.parameters:
+        return "declared"
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return "kwargs"
+    return None
+
+
+def _declares_out_in_its_own_code(fs_fn: Any) -> bool:
+    """Does some wrapper in the chain take an ``out`` parameter of its own?
+
+    Every wrapper republishes numpy's signature via ``_apply_numpy_signature``,
+    so ``inspect.signature`` reports what numpy takes — which is not always
+    what flopscope takes. ``fnp.real`` accepts ``out=`` while advertising
+    ``np.real``'s ``(val)``; discovery that trusted the advertised signature
+    alone missed it, and mutation testing found the miss by deleting its guard
+    with nothing failing. The ``__wrapped__`` chain still has the real
+    parameter list, so ask that too.
+
+    Only ``out`` is read from the chain, never ``**kwargs``: every counted
+    wrapper is ``(*args, **kwargs)`` plumbing, so a varkw frame says nothing
+    about the op — ``fnp.matmul`` has one and takes no destination at all.
+    """
+    seen: set[int] = set()
+    fn = fs_fn
+    while fn is not None and id(fn) not in seen:
+        seen.add(id(fn))
+        code = getattr(fn, "__code__", None)
+        if code is not None:
+            named = code.co_varnames[: code.co_argcount + code.co_kwonlyargcount]
+            if "out" in named:
+                return True
+        fn = getattr(fn, "__wrapped__", None)
+    return False
+
+
+def _out_kind(fs_fn: Any, np_fn: Any) -> str | None:
+    """``"declared"``, ``"kwargs"``, or None if the op takes no destination."""
+    advertised = _advertised_out_kind(fs_fn)
+    if advertised == "declared" or _declares_out_in_its_own_code(fs_fn):
+        return "declared"
+    if advertised == "kwargs":
+        # A ``**kwargs`` wrapper only forwards a destination if numpy has one
+        # to receive; without that check every wrapper in the codebase would
+        # look like it took an out=.
+        return "kwargs" if _numpy_takes_out(np_fn) else None
+    return None
+
+
+def _discover_out_ops() -> dict[str, str]:
+    """Every ``out=``-accepting op, from the registry AND the module surface.
+
+    Both sources, because neither alone is complete: the registry knows about
+    methods that live on a class (``random.Generator.random``) which no
+    attribute walk over the namespace reaches, and the surface knows about
+    anything exposed to a caller that the registry has not caught up with
+    (``isnat``, whose registry entry is ``blacklisted``).
+    """
+    found: dict[str, str] = {}
+    for name in REGISTRY:
+        fs_fn = _resolve(name)
+        if fs_fn is None or not callable(fs_fn):
+            continue
+        kind = _out_kind(fs_fn, _walk(np, name))
+        if kind:
+            found[name] = kind
+
+    def scan(fs_mod: Any, np_mod: Any, prefix: str) -> None:
+        for attr in dir(fs_mod):
+            if attr.startswith("_"):
+                continue
+            obj = getattr(fs_mod, attr)
+            if isinstance(obj, types.ModuleType) or not callable(obj):
+                continue
+            kind = _out_kind(obj, getattr(np_mod, attr, None) if np_mod else None)
+            if kind:
+                found.setdefault(prefix + attr, kind)
+
+    scan(fnp, np, "")
+    scan(fnp.fft, np.fft, "fft.")
+    scan(fnp.linalg, np.linalg, "linalg.")
+    return found
+
+
+#: Ops that accept ``out=`` but that the generic driver cannot exercise, each
+#: with the reason. Every entry is asserted against below — a stale one fails
+#: :func:`test_the_not_driven_list_is_neither_stale_nor_a_silent_skip`, and an
+#: op added later that nobody drives fails
+#: :func:`test_every_out_accepting_op_is_actually_driven`. The list can only
+#: shrink or be argued for; it cannot grow by accident.
+_NOT_DRIVEN: dict[str, str] = {
+    # numpy's own out= for these is NOT the ufunc protocol: it takes an array
+    # and nothing else, and refuses a 1-tuple itself. Normalizing here would
+    # make flopscope MORE permissive than numpy, so there is no tuple parity
+    # to assert. The premise is pinned in
+    # test_the_ops_numpy_itself_refuses_a_container_for.
+    "choose": "np.choose's out= refuses a 1-tuple in numpy itself",
+    "random.Generator.random": "Generator.random's out= refuses a container in numpy itself",
+    "random.Generator.standard_normal": (
+        "Generator.standard_normal's out= refuses a container in numpy itself"
+    ),
+    "random.Generator.standard_exponential": (
+        "Generator.standard_exponential's out= refuses a container in numpy itself"
+    ),
+    "random.Generator.standard_gamma": (
+        "Generator.standard_gamma's out= refuses a container in numpy itself"
+    ),
+    "random.Generator.permuted": (
+        "Generator.permuted's out= refuses a container in numpy itself"
+    ),
+    # nout=2: the tuple IS the protocol, so "a 1-tuple bills like a bare
+    # array" is not the invariant. Driven by test_a_multi_output_op_* instead.
+    "modf": "multi-output (nout=2); driven by the multi-output tests",
+    "frexp": "multi-output (nout=2); driven by the multi-output tests",
+    "divmod": "multi-output (nout=2); driven by the multi-output tests",
+}
+
+#: The ops in ``_NOT_DRIVEN`` whose stated reason is "numpy itself refuses a
+#: container here", paired with a call that demonstrates it against RAW numpy.
+_NUMPY_REFUSES_THE_CONTAINER: dict[str, Callable[[Any], Any]] = {
+    "choose": lambda out: np.choose(
+        np.array([0, 1] * 4), [np.zeros(8), np.ones(8)], out=out
+    ),
+    "random.Generator.random": lambda out: np.random.default_rng(0).random(out=out),
+    "random.Generator.standard_normal": lambda out: np.random.default_rng(
+        0
+    ).standard_normal(out=out),
+    "random.Generator.standard_exponential": lambda out: np.random.default_rng(
+        0
+    ).standard_exponential(out=out),
+    "random.Generator.standard_gamma": lambda out: np.random.default_rng(
+        0
+    ).standard_gamma(1.0, out=out),
+    "random.Generator.permuted": lambda out: np.random.default_rng(0).permuted(
+        np.arange(8.0), out=out
+    ),
+}
+
+_DISCOVERED = _discover_out_ops()
+_DRIVEN_NAMES = sorted(set(_DISCOVERED) - set(_NOT_DRIVEN))
+
+
+# ---------------------------------------------------------------------------
+# Driving: generated arguments, so a new op needs no new hand-written call
+# ---------------------------------------------------------------------------
+
+
+def _arr(shape: tuple[int, ...], kind: str = "float", offset: int = 0):
+    rng = np.random.default_rng(SEED + offset)
+    if kind == "float":
+        # In (0.25, 0.75): inside the domain of every unary op on the surface
+        # (log, sqrt, arcsin, arctanh, ...), and never a constant fill, which
+        # on a square shape would pick up an inferred symmetry tag.
+        values: Any = rng.random(shape) * 0.5 + 0.25
+    elif kind == "int":
+        values = rng.integers(1, 5, size=shape)
+    elif kind == "bool":
+        values = rng.random(shape) > 0.5
+    elif kind == "complex":
+        values = rng.random(shape) + 1j * rng.random(shape)
+    elif kind == "datetime":
+        values = np.arange(shape[0], dtype="int64").astype("datetime64[ns]")
+    else:  # pragma: no cover - typo guard
+        raise AssertionError(f"unknown kind {kind}")
+    return fnp.asarray(values)
+
+
+#: Argument shapes tried in order for each op; the first one the op accepts
+#: (and answers with an ndarray) becomes its driver. Deliberately a battery
+#: rather than a per-category lookup: registry categories are not a reliable
+#: guide to a signature (``isclose`` is tagged unary and is binary), and an
+#: invalid call is filtered for free.
+_RECIPES: list[tuple[str, Callable[[], tuple[tuple, dict]]]] = [
+    ("unary-1d", lambda: ((_arr((64,)),), {})),
+    ("unary-2d", lambda: ((_arr((6, 5)),), {})),
+    ("unary-int", lambda: ((_arr((64,), "int"),), {})),
+    ("unary-bool", lambda: ((_arr((64,), "bool"),), {})),
+    ("unary-datetime", lambda: ((_arr((8,), "datetime"),), {})),
+    ("binary-1d", lambda: ((_arr((64,)), _arr((64,), offset=1)), {})),
+    ("binary-int", lambda: ((_arr((64,), "int"), _arr((64,), "int", 1)), {})),
+    ("binary-bool", lambda: ((_arr((64,), "bool"), _arr((64,), "bool", 1)), {})),
+    ("reduce-axis", lambda: ((_arr((6, 5)),), {"axis": -1})),
+    ("reduce-axis-int", lambda: ((_arr((6, 5), "int"),), {"axis": -1})),
+    ("sequence", lambda: (([_arr((6, 5)), _arr((6, 5), offset=1)],), {})),
+    ("matrix", lambda: ((_arr((6, 6)),), {})),
+    ("quantile", lambda: ((_arr((64,)), 0.5), {})),
+    ("clip", lambda: ((_arr((64,)), 0.3, 0.6), {})),
+    ("take", lambda: ((_arr((64,)), np.arange(8)), {})),
+    ("compress", lambda: ((np.array([True, False] * 32), _arr((64,))), {})),
+    ("outer", lambda: ((_arr((16,)), _arr((16,), offset=1)), {})),
+    ("einsum", lambda: (("ij,jk->ik", _arr((6, 6)), _arr((6, 4), offset=1)), {})),
+    ("matvec", lambda: ((_arr((6, 6)), _arr((6,), offset=1)), {})),
+    ("vecmat", lambda: ((_arr((6,)), _arr((6, 6), offset=1)), {})),
+    (
+        "chain",
+        lambda: (
+            (
+                [
+                    _arr((6, 6)),
+                    _arr((6, 6), offset=1),
+                    _arr((6, 6), offset=2),
+                ],
+            ),
+            {},
         ),
-        (
-            "vecmat",
-            lambda o: fnp.vecmat(_f32(256), _f32(256, 256), out=o),
-            lambda: fnp.zeros(256, dtype="complex128"),
-        ),
-        (
-            "vecdot",
-            lambda o: fnp.vecdot(_f32(256), _f32(256), out=o),
-            lambda: fnp.zeros((), dtype="complex128"),
-        ),
-        (
-            "multiply",
-            lambda o: fnp.multiply(_f32(1000), _f32(1000), out=o),
-            lambda: fnp.zeros(1000, dtype="complex128"),
-        ),
-        (
-            "add",
-            lambda o: fnp.add(_f32(1000), 0.0, out=o),
-            lambda: fnp.zeros(1000, dtype="float64"),
-        ),
-        (
-            "clip",
-            lambda o: fnp.clip(_f32(1000), -1.0, 1.0, out=o),
-            lambda: fnp.zeros(1000, dtype="complex128"),
-        ),
-        (
-            "einsum",
-            lambda o: fnp.einsum("ij,jk->ik", _f32(64, 64), _f32(64, 32), out=o),
-            lambda: fnp.zeros((64, 32), dtype="complex128"),
-        ),
-        (
-            "fft.fft",
-            lambda o: fnp.fft.fft(_f32(64), out=o),
-            lambda: fnp.zeros(64, dtype="complex128"),
-        ),
-    ],
-)
-def test_a_one_tuple_out_bills_exactly_like_a_bare_out(budget, name, call, make_dest):
-    # The regression net. The guard's own tests going green is NOT evidence
-    # the under-bill closed: a prototype had every wrapped-out test passing
-    # while add(f32, 0.0, out=(f64,)) still billed half price.
-    bare_cost, _ = _billed(budget, lambda: call(make_dest()))
-    tuple_cost, _ = _billed(budget, lambda: call((make_dest(),)))
+    ),
+    ("complex-1d", lambda: ((_arr((64,), "complex"),), {})),
+]
+
+_RECIPES_BY_LABEL = dict(_RECIPES)
+
+#: Destinations tried in order. The WIDER ones come first on purpose: with a
+#: destination of the natural result dtype, dropping the normalization changes
+#: nothing measurable — the tuple reaches numpy, numpy unwraps it, and the
+#: billing fold that got skipped had nothing to fold. It is the wide buffer
+#: that makes the skipped fold visible as a cheaper bill.
+_DEST_DTYPES = ("complex128", "float64", None)
+
+
+def _dest(shape, dtype):
+    # Built from a plain numpy zeros: fnp.zeros on a square shape infers a
+    # symmetry tag, which is a billing discount, not a neutral destination.
+    return fnp.asarray(np.zeros(shape, dtype))
+
+
+def _widest_accepted_dest(call_with_dest, shape, natural) -> str:
+    """The widest destination dtype the op accepts, per ``_DEST_DTYPES``.
+
+    Not every op can be handed a wider buffer — ``argmax`` writes indices and
+    refuses anything but an integer one — so the ladder ends at the natural
+    result dtype, which every op accepts by construction.
+    """
+    for dtype in _DEST_DTYPES:
+        chosen = dtype or str(np.asarray(natural).dtype)
+        try:
+            _quietly(call_with_dest, _dest(shape, chosen))
+        except Exception:
+            continue
+        return chosen
+    raise AssertionError(f"no destination dtype accepted for shape {shape}")
+
+
+def _quietly(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Run *fn* under a budget, whichever one is available.
+
+    BudgetContexts do not nest, and these calls happen both inside a test
+    (where the ``budget`` fixture's context is already open) and during driver
+    resolution. Everything routed through here is setup — building an input,
+    finding out what shape an op answers with — and every one of those calls
+    is made OUTSIDE the measured window, so charging it to the test's own
+    budget changes no measurement.
+    """
+    if get_active_budget() is not None:
+        return fn(*args, **kwargs)
+    with fl.BudgetContext(flop_budget=10**16, quiet=True):
+        return fn(*args, **kwargs)
+
+
+@functools.cache
+def _drivers() -> dict[str, tuple[str, str]]:
+    """``{op: (recipe label, destination dtype)}`` for every drivable op.
+
+    Resolved once per process. Only the labels are cached — arrays are rebuilt
+    per test, so nothing carries budget or write-epoch state between tests.
+    """
+    resolved: dict[str, tuple[str, str]] = {}
+    for name in _DRIVEN_NAMES:
+        fn = _resolve(name)
+        if fn is None:
+            continue
+        for label, make in _RECIPES:
+            try:
+                args, kwargs = make()
+                natural = _quietly(fn, *args, **kwargs)
+            except Exception:
+                continue
+            if not isinstance(natural, np.ndarray):
+                continue
+            try:
+                args, kwargs = make()
+                # Defaults bind the loop variables into the closure. The
+                # call is immediate, but ruff cannot know that (B023).
+                dtype = _widest_accepted_dest(
+                    lambda d, fn=fn, args=args, kwargs=kwargs: fn(
+                        *args, out=d, **kwargs
+                    ),
+                    natural.shape,
+                    natural,
+                )
+            except AssertionError:
+                continue
+            resolved[name] = (label, dtype)
+            break
+    return resolved
+
+
+def _driven_call(name: str):
+    """``(fn, args, kwargs, shape, dtype)`` for driving *name* with an ``out=``."""
+    driver = _drivers().get(name)
+    if driver is None:
+        pytest.fail(
+            f"{name} accepts out= but no recipe in _RECIPES can call it. Add one, "
+            f"or add {name!r} to _NOT_DRIVEN with the reason it cannot be driven."
+        )
+    label, dtype = driver
+    fn = _resolve(name)
+    args, kwargs = _RECIPES_BY_LABEL[label]()
+    natural = _quietly(fn, *args, **kwargs)
+    return fn, args, kwargs, natural.shape, dtype
+
+
+def _same_contents(a, b) -> bool:
+    try:
+        return bool(np.array_equal(np.asarray(a), np.asarray(b), equal_nan=True))
+    except TypeError:  # dtypes with no NaN (int, bool, datetime)
+        return bool(np.array_equal(np.asarray(a), np.asarray(b)))
+
+
+# ---------------------------------------------------------------------------
+# The coverage net itself
+# ---------------------------------------------------------------------------
+
+
+def test_every_out_accepting_op_is_actually_driven():
+    """The list of ops under test is derived, and this is what makes it honest.
+
+    A hand-listed parametrize set is only as good as the author's memory of
+    the wrapper surface; this asserts the set is the whole surface.
+    """
+    missing = sorted(set(_DRIVEN_NAMES) - set(_drivers()))
+    assert not missing, (
+        f"{len(missing)} op(s) accept out= but no recipe drives them: {missing}. "
+        f"Add a recipe to _RECIPES, or an entry to _NOT_DRIVEN with a reason."
+    )
+    assert len(_drivers()) >= 150, (
+        f"only {len(_drivers())} ops driven — discovery has silently narrowed "
+        f"(it found {len(_DISCOVERED)} out=-accepting ops)"
+    )
+
+
+def test_the_not_driven_list_is_neither_stale_nor_a_silent_skip():
+    stale = sorted(set(_NOT_DRIVEN) - set(_DISCOVERED))
+    assert not stale, (
+        f"_NOT_DRIVEN names ops that no longer accept out= (or no longer "
+        f"exist): {stale} — remove them so the list keeps meaning something"
+    )
+    unexplained = sorted(n for n, why in _NOT_DRIVEN.items() if not why.strip())
+    assert not unexplained, f"_NOT_DRIVEN entries without a reason: {unexplained}"
+    overlap = sorted(set(_NOT_DRIVEN) & set(_drivers()))
+    assert not overlap, (
+        f"{overlap} are listed as undrivable but the generic driver drives "
+        f"them — delete the excuse"
+    )
+    # A written reason is a claim; each one has to be backed by a test that
+    # would fail if the claim stopped being true. Without this, "cannot be
+    # driven" degrades into "skipped, with prose".
+    demonstrated = set(_NUMPY_REFUSES_THE_CONTAINER) | set(_MULTI_OUTPUT_OPS)
+    undemonstrated = sorted(set(_NOT_DRIVEN) - demonstrated)
+    assert not undemonstrated, (
+        f"{undemonstrated} are excused from the generic driver with a reason "
+        f"that nothing asserts — add them to _NUMPY_REFUSES_THE_CONTAINER, or "
+        f"give them a test of their own"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_NUMPY_REFUSES_THE_CONTAINER))
+def test_the_ops_numpy_itself_refuses_a_container_for(name):
+    """The premise behind six ``_NOT_DRIVEN`` entries, asserted against numpy.
+
+    These take ``out=`` but not through the ufunc protocol: numpy wants the
+    array itself and refuses a tuple. Unwrapping one for them would make
+    flopscope more permissive than numpy, so there is no parity to assert —
+    and if numpy ever adopts the protocol here, this test says so.
+    """
+    call = _NUMPY_REFUSES_THE_CONTAINER[name]
+    dest = np.zeros(8)
+    call(dest)  # the bare array is the accepted spelling
+    with pytest.raises((TypeError, ValueError)):
+        call((dest,))
+
+
+@pytest.mark.parametrize("name", _DRIVEN_NAMES)
+def test_a_one_tuple_out_bills_exactly_like_a_bare_out(budget, name):
+    """Invariant (c), over the whole ``out=`` surface.
+
+    The guard's own tests going green is NOT evidence the under-bill closed: a
+    prototype had every wrapped-out test passing while
+    ``add(f32, 0.0, out=(f64,))`` still billed half price. What closes it is
+    the wide destination — see ``_DEST_DTYPES``.
+    """
+    fn, args, kwargs, shape, dtype = _driven_call(name)
+    bare_dest, tuple_dest = _dest(shape, dtype), _dest(shape, dtype)
+
+    bare_cost, bare_result = _billed(budget, fn, *args, out=bare_dest, **kwargs)
+    tuple_cost, tuple_result = _billed(budget, fn, *args, out=(tuple_dest,), **kwargs)
 
     assert tuple_cost == bare_cost, (
         f"{name}: out=(dest,) billed {tuple_cost} where out=dest billed "
         f"{bare_cost} — the destination's dtype is not reaching the rate"
     )
-
-
-#: The ops whose ``out=`` arrives inside **kwargs rather than as a declared
-#: parameter, which is how they escaped the normalization every sibling gets.
-#: ``take`` is the odd one out: it declares ``out``, strips it, and still
-#: refused ``out=(dest,)`` — the only op in the codebase inconsistent with its
-#: siblings on the one-tuple.
-_KWARGS_OUT_OPS = [
-    (
-        "concatenate",
-        lambda o: fnp.concatenate([_f32(64, 32), _f32(64, 32)], out=o),
-        lambda: fnp.zeros((128, 32), dtype="float32"),
-    ),
-    (
-        "stack",
-        lambda o: fnp.stack([_f32(64, 32), _f32(64, 32)], out=o),
-        lambda: fnp.zeros((2, 64, 32), dtype="float32"),
-    ),
-    (
-        "concat",
-        lambda o: fnp.concat([_f32(64, 32), _f32(64, 32)], out=o),
-        lambda: fnp.zeros((128, 32), dtype="float32"),
-    ),
-    (
-        "isnan",
-        lambda o: fnp.isnan(_f32(64, 32), out=o),
-        lambda: fnp.zeros((64, 32), dtype="bool"),
-    ),
-    (
-        "isinf",
-        lambda o: fnp.isinf(_f32(64, 32), out=o),
-        lambda: fnp.zeros((64, 32), dtype="bool"),
-    ),
-    (
-        "isfinite",
-        lambda o: fnp.isfinite(_f32(64, 32), out=o),
-        lambda: fnp.zeros((64, 32), dtype="bool"),
-    ),
-    (
-        "compress",
-        lambda o: fnp.compress(
-            np.array([True, False] * 32), _f32(64, 32), axis=0, out=o
-        ),
-        lambda: fnp.zeros((32, 32), dtype="float32"),
-    ),
-    (
-        "take",
-        lambda o: fnp.take(_f32(64, 32), np.arange(32), axis=0, out=o),
-        lambda: fnp.zeros((32, 32), dtype="float32"),
-    ),
-    (
-        "outer",
-        lambda o: fnp.outer(_f32(64), _f32(64), out=o),
-        lambda: fnp.zeros((64, 64), dtype="float32"),
-    ),
-]
-
-
-@pytest.mark.parametrize(
-    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
-)
-def test_a_kwargs_out_op_bills_a_one_tuple_like_a_bare_array(
-    budget, name, call, make_dest
-):
-    bare_cost, _ = _billed(budget, lambda: call(make_dest()))
-    tuple_cost, _ = _billed(budget, lambda: call((make_dest(),)))
-    assert tuple_cost == bare_cost, (
-        f"{name}: out=(dest,) billed {tuple_cost} where out=dest billed {bare_cost}"
+    assert bare_result is bare_dest, f"{name} did not hand back out=dest"
+    assert tuple_result is tuple_dest, f"{name} handed back the container, not dest"
+    assert _same_contents(bare_dest, tuple_dest), (
+        f"{name}: out=(dest,) left the destination holding something else — "
+        f"the result went into a temporary built from the container"
     )
 
 
-@pytest.mark.parametrize(
-    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
-)
-def test_a_kwargs_out_op_refuses_a_list_for_free(budget, name, call, make_dest):
-    # Built before the measurement: allocating the destination costs FLOPs of
-    # its own, and building it inside is how "refusal is free" measures the
-    # wrong thing. Every one of these charged in full before refusing.
-    dest = make_dest()
+@pytest.mark.parametrize("name", _DRIVEN_NAMES)
+def test_a_refused_out_form_costs_nothing(budget, name):
+    """Invariants (a) and (b), over the whole ``out=`` surface.
+
+    numpy accepts a list in none of its ``out=`` surfaces, so neither do we —
+    and the refusal has to happen before ``budget.deduct``, which is the part
+    that used to fail: the guard ran inside the deduct block, so the op billed
+    in full and then raised.
+    """
+    fn, args, kwargs, shape, dtype = _driven_call(name)
+    # Built BEFORE the measurement: allocating a destination costs FLOPs of
+    # its own, and building it inside is how "refusal is free" quietly
+    # measures the wrong thing.
+    dest = _dest(shape, dtype)
     before = budget.flops_used
+
     with pytest.raises(TypeError, match="out= must be an array"):
-        call([dest])
-    assert budget.flops_used == before, f"{name} was billed for refusing out=[dest]"
+        fn(*args, out=[dest], **kwargs)
+
+    assert budget.flops_used == before, (
+        f"{name} was billed {budget.flops_used - before} for refusing out=[dest]"
+    )
+    assert budget.flops_used >= before, "flops_used must never decrease"
+    assert not np.asarray(dest).any(), f"{name} wrote to dest while refusing it"
+
+
+# ---------------------------------------------------------------------------
+# The ufunc-method surface: np.add.outer / .reduce / .accumulate / .reduceat
+# ---------------------------------------------------------------------------
+#
+# Reached only through ``FlopscopeArray.__array_ufunc__``, so no attribute walk
+# over ``flopscope.numpy`` finds them and the module-level scan above is blind
+# to them: ``fnp.add`` is a plain function with no ``.reduce``. Four separate
+# ``_normalize_out`` sites live behind this surface, and deleting any of them
+# left every other test in the repository green.
+
+
+def _binary_ufuncs() -> list[tuple[str, np.ufunc]]:
+    found = []
+    for name, entry in REGISTRY.items():
+        if entry.get("module") != "numpy":
+            continue
+        ufunc = getattr(np, name, None)
+        if not isinstance(ufunc, np.ufunc) or ufunc.nin != 2 or ufunc.nout != 1:
+            continue
+        # matmul/vecdot/matvec/vecmat are gufuncs: numpy refuses these methods
+        # on any ufunc with a non-trivial core signature, so there is no call
+        # to make. Structural, not a judgement call.
+        if ufunc.signature is not None:
+            continue
+        found.append((name, ufunc))
+    return sorted(found)
+
+
+_UFUNC_METHODS = ("outer", "reduce", "accumulate", "reduceat")
+
+#: ``(ufunc, method)`` pairs numpy cannot resolve a loop for, with the reason.
+#: Asserted against numpy in test_the_ufunc_method_pairs_numpy_cannot_resolve.
+_NO_UFUNC_METHOD_LOOP: dict[tuple[str, str], str] = {
+    ("ldexp", "accumulate"): "ldexp is (float, int) -> float: no same-dtype loop",
+    ("ldexp", "reduceat"): "ldexp is (float, int) -> float: no same-dtype loop",
+}
+
+_UFUNC_METHOD_PAIRS = [
+    (name, method)
+    for name, _ in _binary_ufuncs()
+    for method in _UFUNC_METHODS
+    if (name, method) not in _NO_UFUNC_METHOD_LOOP
+]
+
+
+def _ufunc_method_call(ufunc: np.ufunc, method: str, x, y, out):
+    if method == "outer":
+        return ufunc.outer(x, y, out=out)
+    if method == "reduce":
+        return ufunc.reduce(x, out=out)
+    if method == "accumulate":
+        return ufunc.accumulate(x, out=out)
+    return ufunc.reduceat(x, [0, 4], out=out)
+
+
+@functools.cache
+def _ufunc_method_drivers() -> dict[tuple[str, str], tuple[str, str]]:
+    """``{(ufunc, method): (operand kind, destination dtype)}``."""
+    resolved: dict[tuple[str, str], tuple[str, str]] = {}
+    for name, ufunc in _binary_ufuncs():
+        for method in _UFUNC_METHODS:
+            if (name, method) in _NO_UFUNC_METHOD_LOOP:
+                continue
+            for kind in ("float", "int", "bool"):
+                x, y = _arr((8,), kind), _arr((8,), kind, 1)
+                try:
+                    natural = _quietly(_ufunc_method_call, ufunc, method, x, y, None)
+                except Exception:
+                    continue
+                if not isinstance(natural, np.ndarray):
+                    continue
+                try:
+                    dtype = _widest_accepted_dest(
+                        lambda d, u=ufunc, m=method, x=x, y=y: _ufunc_method_call(
+                            u, m, x, y, d
+                        ),
+                        natural.shape,
+                        natural,
+                    )
+                except AssertionError:
+                    continue
+                resolved[(name, method)] = (kind, dtype)
+                break
+    return resolved
+
+
+def _ufunc_method_setup(name: str, method: str):
+    driver = _ufunc_method_drivers().get((name, method))
+    if driver is None:
+        pytest.fail(
+            f"np.{name}.{method} takes out= but could not be driven. Either it "
+            f"stopped working, or it belongs in _NO_UFUNC_METHOD_LOOP with a reason."
+        )
+    kind, dtype = driver
+    ufunc = getattr(np, name)
+    x, y = _arr((8,), kind), _arr((8,), kind, 1)
+    natural = _quietly(_ufunc_method_call, ufunc, method, x, y, None)
+    return ufunc, x, y, natural.shape, dtype
+
+
+#: Reaching these methods means calling ``np.add.outer(...)`` on a flopscope
+#: array, which is exactly the spelling the auto-route notice exists to
+#: discourage. Here it is the surface under test, not a mistake.
+_AUTO_ROUTE_NOTICE = "ignore:np\\..* auto-routed to fnp"
+
+
+@pytest.mark.filterwarnings(_AUTO_ROUTE_NOTICE)
+@pytest.mark.parametrize("name,method", _UFUNC_METHOD_PAIRS)
+def test_a_ufunc_method_bills_a_one_tuple_like_a_bare_destination(budget, name, method):
+    ufunc, x, y, shape, dtype = _ufunc_method_setup(name, method)
+    bare_dest, tuple_dest = _dest(shape, dtype), _dest(shape, dtype)
+
+    bare_cost, bare_result = _billed(
+        budget, _ufunc_method_call, ufunc, method, x, y, bare_dest
+    )
+    tuple_cost, tuple_result = _billed(
+        budget, _ufunc_method_call, ufunc, method, x, y, (tuple_dest,)
+    )
+
+    assert tuple_cost == bare_cost, (
+        f"{name}.{method}: out=(dest,) billed {tuple_cost}, out=dest {bare_cost}"
+    )
+    assert bare_result is bare_dest and tuple_result is tuple_dest
+    assert _same_contents(bare_dest, tuple_dest)
+
+
+@pytest.mark.filterwarnings(_AUTO_ROUTE_NOTICE)
+@pytest.mark.parametrize("name,method", _UFUNC_METHOD_PAIRS)
+def test_a_ufunc_method_refuses_a_list_for_free(budget, name, method):
+    ufunc, x, y, shape, dtype = _ufunc_method_setup(name, method)
+    dest = _dest(shape, dtype)
+    before = budget.flops_used
+
+    with pytest.raises(TypeError, match="out= must be an array"):
+        _ufunc_method_call(ufunc, method, x, y, [dest])
+
+    assert budget.flops_used == before, (
+        f"{name}.{method} was billed for refusing out=[dest]"
+    )
+    assert not np.asarray(dest).any()
 
 
 @pytest.mark.parametrize(
-    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
+    "name,method", sorted(_NO_UFUNC_METHOD_LOOP), ids=lambda v: str(v)
 )
-def test_a_kwargs_out_op_accepts_a_flopscope_destination(budget, name, call, make_dest):
-    # The destination a participant actually holds is a FlopscopeArray. Every
-    # one of these forwarded it to numpy still wrapped, tripping the internal
-    # "missing _to_base_ndarray() strip" guard — after the deduct, so the
-    # caller paid in full and then got a RuntimeError.
-    dest = make_dest()
-    result = call(dest)
-    assert result is dest, f"{name} did not hand back the destination"
+def test_the_ufunc_method_pairs_numpy_cannot_resolve(name, method):
+    """The premise behind ``_NO_UFUNC_METHOD_LOOP``, asserted against numpy."""
+    ufunc = getattr(np, name)
+    x = np.linspace(0.25, 0.75, 8)
+    with pytest.raises(TypeError):
+        _ufunc_method_call(ufunc, method, x, x, None)
 
 
-@pytest.mark.parametrize(
-    "name,call,make_dest", _KWARGS_OUT_OPS, ids=[c[0] for c in _KWARGS_OUT_OPS]
-)
-def test_a_kwargs_out_op_treats_a_none_holding_tuple_as_no_destination(
-    budget, name, call, make_dest
-):
-    # out=(None,) is numpy's "allocate this slot for me", not a destination.
-    result = call((None,))
-    assert result is not None and result.dtype != np.dtype(object)
+# ---------------------------------------------------------------------------
+# Multi-output out= is a different protocol and must not be unwrapped
+# ---------------------------------------------------------------------------
+
+_MULTI_OUTPUT_OPS: dict[str, Callable[[Any], Any]] = {
+    "modf": lambda out: fnp.modf(_arr((8,)), out=out),
+    "frexp": lambda out: fnp.frexp(_arr((8,)), out=out),
+    "divmod": lambda out: fnp.divmod(_arr((8,)), _arr((8,), offset=1), out=out),
+}
+
+
+def _multi_output_dests(name: str):
+    natural = _quietly(_MULTI_OUTPUT_OPS[name], None)
+    return tuple(_dest(part.shape, str(part.dtype)) for part in natural)
+
+
+@pytest.mark.parametrize("name", sorted(_MULTI_OUTPUT_OPS))
+def test_a_multi_output_op_accepts_its_tuple_and_bills_it_like_no_out(budget, name):
+    call = _MULTI_OUTPUT_OPS[name]
+    dests = _multi_output_dests(name)
+
+    without_cost, _ = _billed(budget, call, None)
+    with_cost, result = _billed(budget, call, dests)
+
+    assert with_cost == without_cost, (
+        f"{name}: out=(d1, d2) billed {with_cost} where no destination bills "
+        f"{without_cost}"
+    )
+    assert tuple(result) == dests, f"{name} did not hand back the destinations"
+
+
+@pytest.mark.parametrize("name", sorted(_MULTI_OUTPUT_OPS))
+@pytest.mark.parametrize("form", ["bare", "one-tuple", "list"])
+def test_a_multi_output_op_refuses_a_single_destination_for_free(budget, name, form):
+    """A bare array names one destination; a two-output ufunc needs one per
+    output. numpy deprecated that spelling in 1.10 and made it a hard error in
+    gh-14682 — refusing it here is what makes it free rather than charged.
+    """
+    call = _MULTI_OUTPUT_OPS[name]
+    dests = _multi_output_dests(name)
+    bad = {"bare": dests[0], "one-tuple": (dests[0],), "list": list(dests)}[form]
+    expected = ValueError if form == "one-tuple" else TypeError
+    before = budget.flops_used
+
+    with pytest.raises(expected):
+        call(bad)
+
+    assert budget.flops_used == before, f"{name} was billed for refusing out={form}"
+
+
+# ---------------------------------------------------------------------------
+# Reductions take out= through TWO channels, and both need the guard
+# ---------------------------------------------------------------------------
+#
+# ``_counted_reduction``'s wrapper signature is ``(a, axis=None, *args,
+# **kwargs)``: ``out`` arrives either as a keyword or in a positional slot
+# whose index comes from numpy's own parameter list. They are separate
+# ``_normalize_out`` calls, and pinning one leaves the other free to rot —
+# the keyword one being the common spelling for sum/prod/cumsum/argmax.
+
+#: Reduction ops whose ``out=`` cannot be reached positionally, with the
+#: reason. Asserted from both sides below.
+_NO_POSITIONAL_OUT: dict[str, str] = {
+    "average": "takes no out= at all (weights-only signature)",
+    "count_nonzero": "takes no out= at all",
+    "cumulative_prod": "axis/dtype before out are keyword-only (array-API spelling)",
+    "cumulative_sum": "axis/dtype before out are keyword-only (array-API spelling)",
+    "percentile": "q has no default, so no positional prefix reaches out",
+    "quantile": "q has no default, so no positional prefix reaches out",
+    "nanpercentile": "q has no default, so no positional prefix reaches out",
+    "nanquantile": "q has no default, so no positional prefix reaches out",
+    "ptp": "flopscope's wrapper takes out= as a keyword only (numpy allows both)",
+}
+
+
+def _reduction_ops() -> list[str]:
+    return sorted(
+        name
+        for name, entry in REGISTRY.items()
+        if entry.get("category") == "counted_reduction"
+        and entry.get("module") == "numpy"
+        and callable(_resolve(name))
+    )
+
+
+def _positional_out_prefix(name: str) -> list[Any] | None:
+    """Defaults for the parameters between ``a`` and ``out``, or None."""
+    fn = _resolve(name)
+    try:
+        params = list(inspect.signature(fn).parameters.values())
+    except (TypeError, ValueError):
+        return None
+    names = [p.name for p in params]
+    if "out" not in names:
+        return None
+    index = names.index("out")
+    positional = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    if params[index].kind not in positional:
+        return None
+    prefix = params[1:index]
+    if any(p.kind not in positional for p in prefix):
+        return None
+    if any(p.default is inspect.Parameter.empty for p in prefix):
+        return None
+    return [p.default for p in prefix]
+
+
+_POSITIONAL_REDUCTIONS = [n for n in _reduction_ops() if n not in _NO_POSITIONAL_OUT]
+
+
+@pytest.mark.parametrize("name", _POSITIONAL_REDUCTIONS)
+def test_a_reduction_guards_both_its_out_channels(budget, name):
+    """All four spellings of the same destination must bill the same number."""
+    prefix = _positional_out_prefix(name)
+    assert prefix is not None, (
+        f"{name} has no positional out= slot — add it to _NO_POSITIONAL_OUT "
+        f"with the reason"
+    )
+    fn = _resolve(name)
+    a = _arr((6, 5))
+    natural = _quietly(fn, a)
+    shape = np.shape(natural)
+    dtype = _widest_accepted_dest(lambda d: fn(a, out=d), shape, natural)
+
+    costs = {}
+    for label, make_out, call in (
+        ("keyword", lambda d: d, lambda o: fn(a, out=o)),
+        ("keyword-tuple", lambda d: (d,), lambda o: fn(a, out=o)),
+        ("positional", lambda d: d, lambda o: fn(a, *prefix, o)),
+        ("positional-tuple", lambda d: (d,), lambda o: fn(a, *prefix, o)),
+    ):
+        dest = _dest(shape, dtype)
+        cost, result = _billed(budget, call, make_out(dest))
+        assert result is dest, f"{name}: the {label} channel did not return dest"
+        costs[label] = cost
+
+    assert len(set(costs.values())) == 1, (
+        f"{name}: the four out= spellings billed differently: {costs}"
+    )
+
+
+@pytest.mark.parametrize("name", _POSITIONAL_REDUCTIONS)
+@pytest.mark.parametrize("channel", ["keyword", "positional"])
+def test_a_reduction_refuses_a_list_for_free_on_both_channels(budget, name, channel):
+    prefix = _positional_out_prefix(name)
+    assert prefix is not None
+    fn = _resolve(name)
+    a = _arr((6, 5))
+    natural = _quietly(fn, a)
+    shape = np.shape(natural)
+    dtype = _widest_accepted_dest(lambda d: fn(a, out=d), shape, natural)
+    dest = _dest(shape, dtype)
+    before = budget.flops_used
+
+    with pytest.raises(TypeError, match="out= must be an array"):
+        if channel == "keyword":
+            fn(a, out=[dest])
+        else:
+            fn(a, *prefix, [dest])
+
+    assert budget.flops_used == before, (
+        f"{name} was billed for refusing a list on the {channel} channel"
+    )
+    assert not np.asarray(dest).any()
+
+
+def test_the_no_positional_out_list_is_neither_stale_nor_a_silent_skip():
+    reductions = set(_reduction_ops())
+    stale = sorted(set(_NO_POSITIONAL_OUT) - reductions)
+    assert not stale, f"_NO_POSITIONAL_OUT names non-reductions: {stale}"
+    unexplained = sorted(n for n, why in _NO_POSITIONAL_OUT.items() if not why.strip())
+    assert not unexplained, f"entries without a reason: {unexplained}"
+    # Every excuse must still be true: either the signature has no reachable
+    # positional slot, or the wrapper refuses one.
+    for name in sorted(_NO_POSITIONAL_OUT):
+        prefix = _positional_out_prefix(name)
+        if prefix is None:
+            continue
+        # The signature says a positional destination is reachable, so the
+        # excuse has to be the wrapper's: ptp advertises numpy's slot and
+        # accepts only two positional arguments. If that stops being true,
+        # the op belongs in the parametrized test instead of on this list.
+        fn = _resolve(name)
+        a = _arr((6, 5))
+        natural = _quietly(fn, a)
+        dest = _dest(np.shape(natural), str(np.asarray(natural).dtype))
+        with pytest.raises(TypeError):
+            _quietly(fn, a, *prefix, dest)
 
 
 # ---------------------------------------------------------------------------
@@ -387,18 +1071,6 @@ def test_outer_still_carries_a_real_symmetry_into_a_symmetric_destination(budget
     assert dest.symmetry is not None
 
 
-def test_a_one_tuple_out_bills_like_a_bare_out_through_the_positional_slot(budget):
-    # cumsum takes out= as its fourth POSITIONAL parameter, which reaches the
-    # billing fold by a different channel (out_dtype=) than the keyword path.
-    a = _f32(1000)
-
-    def run(make_out):
-        dest = fnp.zeros(1000, dtype="float64")
-        return _billed(budget, lambda: fnp.cumsum(a, None, None, make_out(dest)))[0]
-
-    assert run(lambda d: (d,)) == run(lambda d: d)
-
-
 # ---------------------------------------------------------------------------
 # The unwrapped destination is what comes back
 # ---------------------------------------------------------------------------
@@ -435,6 +1107,14 @@ def test_a_none_holding_tuple_allocates_instead_of_destroying_the_answer(budget)
     result = fnp.matvec(_f32(256, 256), _f32(256), out=(None,))
     assert result.shape == (256,)
     assert result.dtype != np.dtype(object)
+
+
+@pytest.mark.parametrize("name", _DRIVEN_NAMES)
+def test_a_none_holding_tuple_is_treated_as_no_destination(budget, name):
+    fn, args, kwargs, shape, _ = _driven_call(name)
+    result = fn(*args, out=(None,), **kwargs)
+    assert result is not None and np.shape(result) == shape
+    assert np.asarray(result).dtype != np.dtype(object)
 
 
 # ---------------------------------------------------------------------------
@@ -527,11 +1207,6 @@ def test_a_list_out_is_refused_and_costs_nothing(budget):
 
     assert budget.flops_used == before
     assert np.array_equal(np.asarray(dest), np.zeros(2))
-
-
-# ---------------------------------------------------------------------------
-# Multi-output out= is a different protocol and must not be unwrapped
-# ---------------------------------------------------------------------------
 
 
 def test_multi_output_out_tuples_are_left_alone(budget):

--- a/tests/test_out_arg_wrapped_destination.py
+++ b/tests/test_out_arg_wrapped_destination.py
@@ -1,18 +1,32 @@
-"""A wrapped ``out=`` destination must be refused, not silently mis-written.
+"""``out=`` containers: unwrap the one numpy accepts, refuse the rest for free.
 
-``out=[dest]`` — the destination wrapped in a container — used to be accepted by
-the einsum path: ``_np.asarray([dest])`` builds a NEW array from the container,
-so the copy landed in that temporary, ``dest`` kept its old contents, and the
-caller received the untouched wrapper back having been billed the full
-contraction. A plausible-looking array of the wrong values, at full price, is
-the worst failure class in a metering system.
+numpy's ufunc protocol lets a caller write ``np.multiply(a, b, out=(dest,))``
+as well as ``out=dest``; the two mean the same thing. flopscope has to see
+through that tuple for itself, because it reads ``out`` several times before
+numpy ever gets it — to pick the billing dtype, to check symmetry, and to
+decide what to hand back.
 
-numpy rejects a wrapped destination for ufuncs on its own, so this only ever bit
-the paths that copy into ``out`` themselves. The guard sits before billing, so a
-refused call costs nothing.
+A tuple slipping past those reads was not cosmetic. The destination's dtype
+stopped participating in the rate, so a contraction into a wider buffer billed
+as if the buffer were not there: ``matvec`` of float32 operands into a
+complex128 destination billed 130,816 instead of 1,047,552 — one eighth
+price, for a correctly computed and correctly written result.
+
+Worse on the einsum path, which never forwards ``out`` to numpy at all. There a
+container reached ``_np.asarray(container)``, which builds a NEW array, so the
+result landed in that temporary, the real destination kept its old contents,
+and the caller got the untouched container back having paid the full
+contraction. A plausible-looking array of the wrong values at full price is the
+worst failure class in a metering system.
+
+Lists stay refused, because numpy refuses them everywhere. Refusals happen
+before ``budget.deduct``, so they cost nothing — the property the whole fix
+turns on, and the one the earlier version of this guard did not have.
 """
 
 from __future__ import annotations
+
+import collections
 
 import numpy as np
 import pytest
@@ -23,21 +37,250 @@ import flopscope.numpy as fnp
 
 @pytest.fixture()
 def budget():
-    with fl.BudgetContext(flop_budget=10**12, quiet=True) as ctx:
+    with fl.BudgetContext(flop_budget=10**14, quiet=True) as ctx:
         yield ctx
 
 
-def test_einsum_wrapped_out_is_refused_and_costs_nothing(budget):
+def _rng():
+    return np.random.default_rng(20260727)
+
+
+def _f32(*shape):
+    # Asymmetric random data on purpose: a constant fill on a square shape
+    # picks up an inferred symmetry tag, which changes the accumulation cost
+    # and would pin symmetry-discounted numbers instead of the real ones.
+    return fnp.asarray(_rng().standard_normal(shape).astype("float32"))
+
+
+def _billed(ctx, fn):
+    before = ctx.flops_used
+    result = fn()
+    return ctx.flops_used - before, result
+
+
+# ---------------------------------------------------------------------------
+# The tuple bills exactly like the bare array — the point of the change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,call,make_dest",
+    [
+        (
+            "matvec",
+            lambda o: fnp.matvec(_f32(256, 256), _f32(256), out=o),
+            lambda: fnp.zeros(256, dtype="complex128"),
+        ),
+        (
+            "vecmat",
+            lambda o: fnp.vecmat(_f32(256), _f32(256, 256), out=o),
+            lambda: fnp.zeros(256, dtype="complex128"),
+        ),
+        (
+            "vecdot",
+            lambda o: fnp.vecdot(_f32(256), _f32(256), out=o),
+            lambda: fnp.zeros((), dtype="complex128"),
+        ),
+        (
+            "multiply",
+            lambda o: fnp.multiply(_f32(1000), _f32(1000), out=o),
+            lambda: fnp.zeros(1000, dtype="complex128"),
+        ),
+        (
+            "add",
+            lambda o: fnp.add(_f32(1000), 0.0, out=o),
+            lambda: fnp.zeros(1000, dtype="float64"),
+        ),
+        (
+            "clip",
+            lambda o: fnp.clip(_f32(1000), -1.0, 1.0, out=o),
+            lambda: fnp.zeros(1000, dtype="complex128"),
+        ),
+        (
+            "einsum",
+            lambda o: fnp.einsum("ij,jk->ik", _f32(64, 64), _f32(64, 32), out=o),
+            lambda: fnp.zeros((64, 32), dtype="complex128"),
+        ),
+        (
+            "fft.fft",
+            lambda o: fnp.fft.fft(_f32(64), out=o),
+            lambda: fnp.zeros(64, dtype="complex128"),
+        ),
+    ],
+)
+def test_a_one_tuple_out_bills_exactly_like_a_bare_out(budget, name, call, make_dest):
+    # The regression net. The guard's own tests going green is NOT evidence
+    # the under-bill closed: a prototype had every wrapped-out test passing
+    # while add(f32, 0.0, out=(f64,)) still billed half price.
+    bare_cost, _ = _billed(budget, lambda: call(make_dest()))
+    tuple_cost, _ = _billed(budget, lambda: call((make_dest(),)))
+
+    assert tuple_cost == bare_cost, (
+        f"{name}: out=(dest,) billed {tuple_cost} where out=dest billed "
+        f"{bare_cost} — the destination's dtype is not reaching the rate"
+    )
+
+
+def test_a_one_tuple_out_bills_like_a_bare_out_through_the_positional_slot(budget):
+    # cumsum takes out= as its fourth POSITIONAL parameter, which reaches the
+    # billing fold by a different channel (out_dtype=) than the keyword path.
+    a = _f32(1000)
+
+    def run(make_out):
+        dest = fnp.zeros(1000, dtype="float64")
+        return _billed(budget, lambda: fnp.cumsum(a, None, None, make_out(dest)))[0]
+
+    assert run(lambda d: (d,)) == run(lambda d: d)
+
+
+# ---------------------------------------------------------------------------
+# The unwrapped destination is what comes back
+# ---------------------------------------------------------------------------
+
+
+def test_a_one_tuple_out_returns_the_destination_not_the_container(budget):
+    dest = fnp.zeros(1000, dtype="complex128")
+    assert (
+        fnp.multiply(_f32(1000), _f32(1000), out=(dest,))  # pyright: ignore[reportArgumentType]
+        is dest
+    )
+
+    fft_dest = fnp.zeros(64, dtype="complex128")
+    assert fnp.fft.fft(_f32(64), out=(fft_dest,)) is fft_dest
+
+    ein_dest = fnp.zeros((64, 32), dtype="complex128")
+    result = fnp.einsum("ij,jk->ik", _f32(64, 64), _f32(64, 32), out=(ein_dest,))
+    assert result is ein_dest
+
+
+def test_a_routed_binary_returns_the_destinations_shape_not_the_containers(budget):
+    # matvec used to do `result = out` with out still the tuple, so the caller
+    # got back something of shape (1, 256) instead of (256,).
+    dest = fnp.zeros(256, dtype="complex128")
+    result = fnp.matvec(_f32(256, 256), _f32(256), out=(dest,))
+    assert result.shape == (256,)
+    assert result is dest
+
+
+def test_a_none_holding_tuple_allocates_instead_of_destroying_the_answer(budget):
+    # out=(None,) is numpy's "allocate this slot for me". The routed binaries
+    # used to treat the tuple as the destination and hand back a shape-(1,)
+    # object array — the answer silently gone, no exception, full price.
+    result = fnp.matvec(_f32(256, 256), _f32(256), out=(None,))
+    assert result.shape == (256,)
+    assert result.dtype != np.dtype(object)
+
+
+# ---------------------------------------------------------------------------
+# Everything else is refused, and refusal is free
+# ---------------------------------------------------------------------------
+
+_Pair = collections.namedtuple("_Pair", "first")
+
+
+class _TupleSubclass(tuple):
+    pass
+
+
+def _bad_forms(dest):
+    return {
+        "list": [dest],
+        "two-tuple": (dest, dest),
+        "nested-list": [[0.0, 0.0]],
+        "empty-tuple": (),
+        "string": "dest",
+        "memoryview": memoryview(np.zeros(2).tobytes()),
+        # numpy refuses both of these, so `type(out) is tuple` (not isinstance)
+        # is what keeps flopscope from being quietly more permissive.
+        "namedtuple": _Pair(dest),
+        "tuple-subclass": _TupleSubclass((dest,)),
+    }
+
+
+@pytest.mark.parametrize("form", sorted(_bad_forms(None)))
+def test_a_refused_out_form_costs_nothing_on_every_path(budget, form):
+    # Every array is built BEFORE the measurement starts. Constructing one
+    # costs FLOPs of its own, and building inside the measured region is how
+    # a "refusal is free" assertion quietly measures the wrong thing.
+    a2 = fnp.array([1.0, 2.0])
+    b2 = fnp.array([3.0, 4.0])
+    eye = fnp.array([[1.0, 0.0], [0.0, 1.0]])
+
+    cases = [
+        ("multiply", lambda o: fnp.multiply(a2, b2, out=o), fnp.zeros(2)),
+        ("matvec", lambda o: fnp.matvec(eye, a2, out=o), fnp.zeros(2)),
+        ("einsum", lambda o: fnp.einsum("i,i->i", a2, b2, out=o), fnp.zeros(2)),
+        ("cumsum-positional", lambda o: fnp.cumsum(a2, None, None, o), fnp.zeros(2)),
+    ]
+    for name, call, dest in cases:
+        bad = _bad_forms(dest)[form]
+        before = budget.flops_used
+        with pytest.raises(TypeError):
+            call(bad)
+        assert budget.flops_used == before, (
+            f"{name} was billed for refusing out={form}; a refusal must be free"
+        )
+        assert np.array_equal(np.asarray(dest), np.zeros(2)), (
+            f"{name} wrote to the destination while refusing out={form}"
+        )
+
+
+def test_einsum_refuses_the_container_forms_it_used_to_mis_write(budget):
+    # All of these were accepted, billed in full, and left dest untouched,
+    # because einsum copies into out itself rather than handing it to numpy.
     a = fnp.array([[1.0, 2.0], [3.0, 4.0]])
     b = fnp.array([[5.0, 6.0], [7.0, 8.0]])
-    dest = fnp.array([[0.0, 0.0], [0.0, 0.0]])
+    bad_forms = ([fnp.zeros((2, 2))], [fnp.zeros((2, 2)), fnp.zeros((2, 2))], ())
+
+    for bad in bad_forms:
+        dest_before = budget.flops_used
+        with pytest.raises(TypeError, match="out= must be an array"):
+            fnp.einsum("ij,jk->ik", a, b, out=bad)
+        assert budget.flops_used == dest_before
+
+
+def test_a_list_out_is_refused_and_costs_nothing(budget):
+    # numpy accepts a list in none of its out= surfaces, so neither do we.
+    # The cost assertion is the part that used to fail: the guard ran inside
+    # the deduct block, so multiply billed in full and then raised.
+    a = fnp.array([1.0, 2.0])
+    b = fnp.array([3.0, 4.0])
+    dest = fnp.array([0.0, 0.0])
     before = budget.flops_used
 
     with pytest.raises(TypeError, match="out= must be an array"):
-        fnp.einsum("ij,jk->ik", a, b, out=[dest])
+        fnp.multiply(a, b, out=[dest])  # pyright: ignore[reportArgumentType]
 
-    assert budget.flops_used == before, "a refused call must not be billed"
-    assert np.array_equal(np.asarray(dest), np.zeros((2, 2)))
+    assert budget.flops_used == before
+    assert np.array_equal(np.asarray(dest), np.zeros(2))
+
+
+# ---------------------------------------------------------------------------
+# Multi-output out= is a different protocol and must not be unwrapped
+# ---------------------------------------------------------------------------
+
+
+def test_multi_output_out_tuples_are_left_alone(budget):
+    frac = fnp.zeros(4)
+    whole = fnp.zeros(4)
+    result = fnp.modf(fnp.array([1.5, 2.25, -3.75, 0.5]), out=(frac, whole))
+
+    assert result[0] is frac and result[1] is whole
+    assert np.asarray(whole).tolist() == [1.0, 2.0, -3.0, 0.0]
+
+
+def test_a_wrong_length_multi_output_tuple_is_refused_for_free(budget):
+    src = fnp.array([1.5, 2.5])
+    dest = fnp.zeros(2)
+    before = budget.flops_used
+    with pytest.raises(TypeError, match="tuple of length 2"):
+        fnp.modf(src, out=(dest,))  # pyright: ignore[reportArgumentType]
+    assert budget.flops_used == before
+
+
+# ---------------------------------------------------------------------------
+# Nothing that already worked stops working
+# ---------------------------------------------------------------------------
 
 
 def test_einsum_with_a_real_out_still_works(budget):
@@ -53,18 +296,6 @@ def test_einsum_with_a_real_out_still_works(budget):
     assert result is dest, "out= must return the destination itself"
 
 
-@pytest.mark.parametrize("wrapper", [list, tuple])
-def test_pointwise_wrapped_out_is_refused(budget, wrapper):
-    a = fnp.array([1.0, 2.0])
-    b = fnp.array([3.0, 4.0])
-    dest = fnp.array([0.0, 0.0])
-
-    with pytest.raises(TypeError):
-        fnp.multiply(a, b, out=wrapper([dest]))
-
-    assert np.array_equal(np.asarray(dest), np.zeros(2))
-
-
 def test_out_still_works_on_the_routed_binaries(budget):
     """vecdot/matvec/vecmat expose out= publicly; they must keep working."""
     eye = fnp.array([[1.0, 0.0], [0.0, 1.0]])
@@ -75,6 +306,19 @@ def test_out_still_works_on_the_routed_binaries(budget):
 
     scalar_dest = fnp.array(0.0)
     assert float(np.asarray(fnp.vecdot(v, v, out=scalar_dest))) == 25.0
+
+
+def test_a_flopscope_array_inside_a_tuple_is_accepted(budget):
+    # The destination a participant actually holds is a FlopscopeArray, and
+    # wrapping one used to trip an internal strip check rather than working.
+    a = fnp.array([1.0, 2.0])
+    b = fnp.array([3.0, 4.0])
+    dest = fnp.zeros(2)
+
+    result = fnp.multiply(a, b, out=(dest,))  # pyright: ignore[reportArgumentType]
+
+    assert result is dest
+    assert np.asarray(dest).tolist() == [3.0, 8.0]
 
 
 def test_out_none_and_absent_are_unaffected(budget):

--- a/tests/test_overhead_coverage.py
+++ b/tests/test_overhead_coverage.py
@@ -76,6 +76,11 @@ def test_every_wrapper_with_budget_deduct_is_decorated():
                 # function call outside any wrapper) -- must not be wrapped
                 # a second time, same shape as _einsum_routed_binary above.
                 "_bill_save_egress",
+                # Shared body of isnan/isinf/isfinite (src/flopscope/_array_ops.py).
+                # The three public wrappers each carry @_counted_wrapper and do
+                # nothing but call this; wrapping it too would double-bracket
+                # every call. Same shape as _einsum_routed_binary above.
+                "_counted_predicate",
             ):
                 continue
             if not _has_counted_wrapper_decorator(fn):

--- a/tests/test_pointwise_coverage.py
+++ b/tests/test_pointwise_coverage.py
@@ -726,7 +726,7 @@ class TestMultiOutputOps:
         x = numpy.array([1.5, 2.7])
         single = numpy.zeros(2)
         with BudgetContext(flop_budget=10**6):
-            with pytest.raises(TypeError, match="length"):
+            with pytest.raises(TypeError, match="tuple of length 2"):
                 modf(x, out=(single,))  # pyright: ignore[reportArgumentType]
 
     def test_modf_invalid_out_type_raises(self):

--- a/tests/test_pointwise_coverage.py
+++ b/tests/test_pointwise_coverage.py
@@ -726,7 +726,7 @@ class TestMultiOutputOps:
         x = numpy.array([1.5, 2.7])
         single = numpy.zeros(2)
         with BudgetContext(flop_budget=10**6):
-            with pytest.raises(TypeError, match="tuple of length 2"):
+            with pytest.raises(ValueError, match="exactly one entry per ufunc output"):
                 modf(x, out=(single,))  # pyright: ignore[reportArgumentType]
 
     def test_modf_invalid_out_type_raises(self):

--- a/tests/test_symmetry_tag_forgery.py
+++ b/tests/test_symmetry_tag_forgery.py
@@ -198,3 +198,20 @@ def test_scratch_buffer_idiom_still_works():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+def test_ufunc_out_does_not_forge_tag_through_a_container():
+    """A tuple-wrapped destination must void the tag exactly as a bare one
+    does. It reaches _prepare_symmetric_out only once ``out`` is normalized;
+    before that the symmetry check was simply skipped for the container."""
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)),
+        lambda z: fnp.multiply(_asymmetric(), 1.0, out=(z,)),  # pyright: ignore[reportArgumentType]
+    )
+
+
+def test_contraction_out_does_not_forge_tag_through_a_container():
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)),
+        lambda z: fnp.einsum("ij,jk->ik", _asymmetric(), fnp.eye(N), out=(z,)),
+    )

--- a/tests/test_symmetry_tag_forgery.py
+++ b/tests/test_symmetry_tag_forgery.py
@@ -196,22 +196,85 @@ def test_scratch_buffer_idiom_still_works():
     assert np.allclose(np.asarray(arena), _asymmetric())
 
 
-if __name__ == "__main__":
-    raise SystemExit(pytest.main([__file__, "-v"]))
+# --- the same routes, with the destination inside a container ------------
+
+
+def _assert_the_write_landed_and_voided_the_tag(tagged, write, expected):
+    """Stricter than :func:`_assert_claim_does_not_survive`, on purpose.
+
+    That helper accepts a raised exception as a pass, which is the right
+    contract for it: for most of these routes, refusing the write and dropping
+    the claim are equally safe outcomes. It is the wrong contract for the
+    container tests. A container that is refused, or one whose write silently
+    lands in a temporary, produces no forgery to detect — so a test built on
+    that helper passes whether or not the guard exists, and one of the two
+    added with this fix never reached its assertion at all: einsum raises a
+    SymmetryError for the container and for the bare array alike, so it was
+    not testing the container.
+
+    Here the write must HAPPEN — asserted against the expected values, in the
+    tagged buffer — and the tag must then be gone. Both halves can fail:
+    unwrap the container into a temporary and the values assertion fails;
+    skip the symmetry check for containers and the tag assertion fails.
+    """
+    load_weights()
+    honest = _honest()
+
+    write(tagged)
+
+    written = np.asarray(tagged)
+    assert np.allclose(written, expected), (
+        "the write did not reach the tagged buffer — it landed in a temporary "
+        "built from the container, which is the silent-wrong-answer failure"
+    )
+    assert not np.allclose(written, written.T), (
+        "test bug: the write did not actually break symmetry"
+    )
+    assert getattr(tagged, "symmetry", None) is None, (
+        "the symmetry tag survived a write that invalidated it"
+    )
+    assert _probe(tagged) == honest, (
+        "asymmetric data still bills at the symmetric rate through a container"
+    )
 
 
 def test_ufunc_out_does_not_forge_tag_through_a_container():
-    """A tuple-wrapped destination must void the tag exactly as a bare one
-    does. It reaches _prepare_symmetric_out only once ``out`` is normalized;
-    before that the symmetry check was simply skipped for the container."""
-    _assert_claim_does_not_survive(
-        fnp.zeros((N, N)),
-        lambda z: fnp.multiply(_asymmetric(), 1.0, out=(z,)),  # pyright: ignore[reportArgumentType]
+    """A tuple-wrapped destination must void the tag exactly as a bare one does.
+
+    It reaches ``_prepare_symmetric_out`` only once ``out`` is normalized;
+    before that the symmetry check was simply skipped for the container, while
+    numpy wrote through the tuple perfectly happily — data in, claim intact.
+    """
+    tagged = fnp.zeros((N, N))
+    source = _asymmetric()
+    _assert_the_write_landed_and_voided_the_tag(
+        tagged,
+        lambda z: fnp.multiply(source, 1.0, out=(z,)),  # pyright: ignore[reportArgumentType]
+        expected=source,
     )
 
 
 def test_contraction_out_does_not_forge_tag_through_a_container():
-    _assert_claim_does_not_survive(
-        fnp.zeros((N, N)),
-        lambda z: fnp.einsum("ij,jk->ik", _asymmetric(), fnp.eye(N), out=(z,)),
+    """einsum is where a container is worst: it copies into ``out`` itself.
+
+    The destination here is an untagged ALIAS of the tagged buffer — the
+    spelling a caller reaches for when handing a scratch array to a routine —
+    so the write is not refused and the tag has to be voided by the write
+    itself. Unwrap the alias out of its tuple and everything works; leave the
+    tuple standing and ``_np.asarray(container)`` builds a new array, the
+    tagged buffer keeps its zeros AND its claim, and the caller pays full
+    price for a contraction they never receive.
+    """
+    tagged = fnp.zeros((N, N))
+    alias = fnp.asarray(tagged)
+    assert getattr(alias, "symmetry", None) is None, "the alias must be untagged"
+    source = _asymmetric()
+    _assert_the_write_landed_and_voided_the_tag(
+        tagged,
+        lambda _: fnp.einsum("ij,jk->ik", source, fnp.eye(N), out=(alias,)),
+        expected=source,
     )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What this does

Treats a `out=` container the way numpy does: unwrap the one it accepts, refuse the rest, and never bill a refusal.

numpy's ufunc protocol lets a caller write `np.multiply(a, b, out=(dest,))` as well as `out=dest` — the two mean the same thing. flopscope has to see through that tuple for itself, because it reads `out` several times before numpy ever gets it: to pick the billing dtype, to check symmetry, and to decide what to hand back.

## Why it matters

A tuple slipping past those reads is not cosmetic — the destination's dtype stops participating in the rate:

| call (float32 operands, complex128 destination) | `out=dest` | `out=(dest,)` |
|---|---|---|
| `matvec` / `vecmat`, N=256 | 1,047,552 | **130,816** |
| `vecdot`, N=256 | 4,092 | **511** |
| `multiply`, n=1000 | 12,000 | **1,000** |
| `clip`, n=1000 | 8,000 | **2,000** |
| `add` into float64 | 2,000 | **1,000** |

Every one of those wrote the destination correctly. `_einsum_routed_binary` (`matvec`/`vecmat`/`vecdot`) was not behind the earlier guard at all, so it was live on this branch as well as on main.

Separately, on the einsum path — which never forwards `out` to numpy — a container reached `_np.asarray(container)`, which builds a *new* buffer. The copy filled that temporary, the real destination kept its old contents, and the caller got the untouched container back having paid the full contraction.

**Exposure is local.** msgpack has no tuple form, so a wrapped `out=` arrives at the server as a list, which numpy refuses — remotely these produce an error, not an under-billed result. This is metering honesty for in-process use, not a graded-submission hole.

## How

`_normalize_out(out, op_name, nout=…)` at the top of every wrapper — above the billing gate, above the symmetry check, above `budget.deduct`. A length-`nout` tuple of ndarray-or-`None` becomes the bare array; for `nout > 1` the tuple *is* the protocol and passes through untouched; everything else raises having cost nothing.

Placement is half the fix. The previous commit put the guard inside `_call_with_optional_out`, which is downstream of both the deduct and the dtype fold — a prototype with that placement left `add(f32, 0.0, out=(f64,))` billing half price and returning the tuple while every wrapped-`out` test passed. It is also why refusals used to cost money (`multiply` 128, `cumsum` 126), so this branch's earlier claim that a refused call is free held only for einsum.

einsum keeps a strict array-only rule and loses its `_np.asarray(out)` call — guarding the input stops a container arriving, removing the materialization makes the class structurally impossible.

## Four things stop being wrong as a consequence

- the return value is the destination, not the container (`matvec` handed back shape `(1,256)`)
- `out=(None,)` allocates instead of silently destroying the answer
- `out=(FlopscopeArray,)` works instead of tripping an internal strip check
- symmetry validation is reached on a container for the first time

## Decisions worth challenging

- **Lists are refused.** numpy accepts a list in none of its `out=` surfaces, so accepting one would be inventing policy rather than matching numpy.
- **The 1-tuple is accepted uniformly, which is a deliberate superset of numpy.** numpy takes it only for ufuncs, gufuncs, `ufunc.outer` and `clip`; einsum, the reductions, `dot`, `take` and `trace` all refuse it. One rule beats a hand-kept per-op table that would rot — `np.clip` is a dispatcher that behaves like a ufunc, `np.matvec` is a real ufunc, the fft functions are gufunc-backed dispatchers. If we'd rather have strict parity the flip is mechanical: an `unwrap=False` flag at those sites.
- **The declared `out:` annotations still read `FlopscopeArray | None`.** Widening them cascades into generated API docs, so it is left for its own change.

## Deliberately out of scope

- einsum's write-back uses `casting="unsafe"` where numpy's einsum uses `safe`, so a float result into an int destination truncates and a complex result into a float destination drops the imaginary part, both where numpy raises. Same silent-wrong-number family, but fixing it starts raising on code that works today.
- Two pre-existing write-epoch gaps from #157: the positional-`out` reduction branch and the raw `ufunc.*` wrappers don't reach the `note_write` hook.

## Verification

- billing parity asserted per-op against the bare-`out` figure, including through the positional slot
- refusals asserted at zero cost across pointwise, routed-binary, einsum, positional-reduction and multi-output paths
- container variants added to the #159 anti-laundering and #157 anti-forgery suites
- the two `match="length"` multi-output tests tightened — they passed for the wrong reason under a naive unwrap
- suite: 5390 passed, no new failures; numpy-compat: 21,629 reports, 0 failed; ruff and pyright clean
