### PR TITLE
fix(billing): void symmetry tags when the buffer they describe is written

### DIFF
--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -650,6 +650,12 @@ def _get_flopscope_func(op_name: str):
     import flopscope.numpy as fnp
 
     parts = op_name.split(".")
+    # Only public names are callable ops. Without this the getattr walk reaches
+    # private helpers and the modules they import -- including internal
+    # symmetry-tag constructors, which mint a billing-relevant claim outside any
+    # counted wrapper, and re-exported third-party modules.
+    if any(part.startswith("_") for part in parts):
+        raise AttributeError(f"flopscope does not provide {op_name!r}")
     for base in (fnp, flops):
         obj = base
         try:
@@ -657,6 +663,12 @@ def _get_flopscope_func(op_name: str):
                 obj = getattr(obj, part)
         except AttributeError:
             continue
+        # Array types are not ops. Constructing one directly sidesteps the
+        # counted constructors -- SymmetricTensor in particular attaches a
+        # symmetry tag, which the cost model prices on, for free. RNG classes
+        # such as RandomState/SeedSequence stay reachable; they are ops.
+        if isinstance(obj, type) and issubclass(obj, np.ndarray):
+            raise AttributeError(f"flopscope does not provide {op_name!r}")
         return obj
     raise AttributeError(f"flopscope does not provide {op_name!r}")
 

--- a/flopscope-server/src/flopscope_server/_request_handler.py
+++ b/flopscope-server/src/flopscope_server/_request_handler.py
@@ -633,6 +633,23 @@ class RequestHandler:
 # ---------------------------------------------------------------------------
 
 
+# The registry is the generated list of counted ops. RNG constructors are not
+# registry entries but are part of the supported client surface (their sampling
+# methods are gated separately by _ALLOWED_GEN_METHODS/_ALLOWED_RS_METHODS).
+_RNG_CONSTRUCTORS = frozenset(
+    {"random.RandomState", "random.SeedSequence", "random.Generator"}
+)
+
+
+def _callable_ops() -> frozenset[str]:
+    from flopscope._registry import REGISTRY
+
+    return frozenset(REGISTRY) | _RNG_CONSTRUCTORS
+
+
+_CALLABLE_OPS = _callable_ops()
+
+
 def _get_flopscope_func(op_name: str):
     """Look up a flopscope op by dotted name (e.g. 'linalg.svd', 'stats.norm.pdf').
 
@@ -649,13 +666,15 @@ def _get_flopscope_func(op_name: str):
     """
     import flopscope.numpy as fnp
 
-    parts = op_name.split(".")
-    # Only public names are callable ops. Without this the getattr walk reaches
-    # private helpers and the modules they import -- including internal
-    # symmetry-tag constructors, which mint a billing-relevant claim outside any
-    # counted wrapper, and re-exported third-party modules.
-    if any(part.startswith("_") for part in parts):
+    # Resolve against the op registry rather than whatever the getattr walk can
+    # reach. Treating every public attribute as an op exposed process-global
+    # helpers -- `configure` alone lets a caller change symmetry budgets and the
+    # einsum path cache, which steers later cost decisions for the session --
+    # and internal symmetry-tag constructors, which mint a claim the cost model
+    # prices on without going through a counted wrapper.
+    if op_name not in _CALLABLE_OPS:
         raise AttributeError(f"flopscope does not provide {op_name!r}")
+    parts = op_name.split(".")
     for base in (fnp, flops):
         obj = base
         try:
@@ -663,12 +682,6 @@ def _get_flopscope_func(op_name: str):
                 obj = getattr(obj, part)
         except AttributeError:
             continue
-        # Array types are not ops. Constructing one directly sidesteps the
-        # counted constructors -- SymmetricTensor in particular attaches a
-        # symmetry tag, which the cost model prices on, for free. RNG classes
-        # such as RandomState/SeedSequence stay reachable; they are ops.
-        if isinstance(obj, type) and issubclass(obj, np.ndarray):
-            raise AttributeError(f"flopscope does not provide {op_name!r}")
         return obj
     raise AttributeError(f"flopscope does not provide {op_name!r}")
 

--- a/flopscope-server/tests/test_op_resolver_scope.py
+++ b/flopscope-server/tests/test_op_resolver_scope.py
@@ -1,0 +1,59 @@
+"""The op resolver must not expose flopscope's internals as callable ops.
+
+``_get_flopscope_func`` walks ``getattr`` over ``flopscope.numpy`` and then
+``flopscope``, so without a scope check any private helper reachable from those
+namespaces becomes a remotely callable op. That matters for billing: helpers
+such as ``_array_ops._wrap_constant_fill`` mint a symmetry tag -- a claim the
+cost model prices on -- without going through a counted wrapper, so a caller
+could tag arbitrary asymmetric data for 0 FLOPs and collect the symmetric-rate
+discount on everything downstream.
+"""
+
+import numpy as np
+import pytest
+from flopscope_server._request_handler import RequestHandler, _get_flopscope_func
+from flopscope_server._session import Session
+
+
+@pytest.fixture
+def handler():
+    session = Session(flop_budget=int(1e12))
+    yield RequestHandler(session)
+    if session.is_open:
+        session.close()
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        "_array_ops._wrap_constant_fill",  # 0-FLOP symmetry-tag mint
+        "_array_ops._np.matmul",  # raw numpy module
+        "_symmetry_utils.wrap_with_trusted_symmetry",
+        "SymmetricTensor",  # tag mint via the class itself
+    ],
+)
+def test_internal_names_are_not_callable_ops(op):
+    with pytest.raises(AttributeError):
+        _get_flopscope_func(op)
+
+
+def test_public_ops_still_resolve():
+    for op in ("matmul", "einsum", "linalg.inv", "fft.fft"):
+        assert callable(_get_flopscope_func(op))
+
+
+def test_tag_mint_op_is_refused_over_the_wire(handler):
+    a = np.random.default_rng(0).random((8, 8))
+    created = handler.handle(
+        {
+            "op": "create_from_data",
+            "data": a.tobytes(),
+            "shape": [8, 8],
+            "dtype": "float64",
+        }
+    )
+    handle = created["result"]["id"]
+    resp = handler.handle(
+        {"op": "_array_ops._wrap_constant_fill", "args": [{"__handle__": handle}]}
+    )
+    assert resp["status"] == "error"

--- a/flopscope-server/tests/test_op_resolver_scope.py
+++ b/flopscope-server/tests/test_op_resolver_scope.py
@@ -30,15 +30,31 @@ def handler():
         "_array_ops._np.matmul",  # raw numpy module
         "_symmetry_utils.wrap_with_trusted_symmetry",
         "SymmetricTensor",  # tag mint via the class itself
+        # Public, but not ops: configure mutates process-global settings that
+        # steer later cost decisions (symmetry budgets, einsum path cache).
+        "configure",
+        "BudgetContext",
     ],
 )
-def test_internal_names_are_not_callable_ops(op):
+def test_non_op_names_are_not_callable(op):
     with pytest.raises(AttributeError):
         _get_flopscope_func(op)
 
 
 def test_public_ops_still_resolve():
-    for op in ("matmul", "einsum", "linalg.inv", "fft.fft"):
+    for op in ("matmul", "einsum", "linalg.inv", "fft.fft", "random.default_rng"):
+        assert callable(_get_flopscope_func(op))
+
+
+def test_registered_symmetry_ops_still_resolve():
+    """as_symmetric and symmetrize are counted ops -- as_symmetric validates the
+    data and charges for it before tagging, so it is not a free mint."""
+    for op in ("as_symmetric", "symmetrize"):
+        assert callable(_get_flopscope_func(op))
+
+
+def test_rng_constructors_still_resolve():
+    for op in ("random.RandomState", "random.SeedSequence"):
         assert callable(_get_flopscope_func(op))
 
 

--- a/src/flopscope/_budget.py
+++ b/src/flopscope/_budget.py
@@ -9,6 +9,9 @@ import time
 import weakref
 from typing import Any, Literal, NamedTuple
 
+import numpy as _np
+
+from flopscope._write_epoch import note_write
 from flopscope.errors import BudgetExhaustedError
 
 
@@ -230,6 +233,21 @@ class _DeferredOpTimer:
         return False
 
 
+# numpy callables that write through their first argument rather than ``out=``.
+# Reaching one of these means the destination buffer's contents changed, so any
+# symmetry tag observing it must be voided -- see flopscope._write_epoch.
+_MUTATES_FIRST_ARG = frozenset(
+    {
+        _np.copyto,
+        _np.put,
+        _np.putmask,
+        _np.place,
+        _np.fill_diagonal,
+        _np.put_along_axis,
+    }
+)
+
+
 def _call_numpy(fn: Any, *args: Any, **kwargs: Any) -> Any:
     """Invoke a numpy callable, attributing only its wall time to backend time.
 
@@ -245,6 +263,11 @@ def _call_numpy(fn: Any, *args: Any, **kwargs: Any) -> Any:
     convention used by ``_call_with_optional_out``. Wrappers' explicit return
     annotations carry the public type contract.
     """
+    out = kwargs.get("out")
+    if out is not None:
+        note_write(out)
+    if fn in _MUTATES_FIRST_ARG and args:
+        note_write(args[0])
     t0 = time.perf_counter()
     try:
         return fn(*args, **kwargs)

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -621,10 +621,15 @@ def einsum(
         maybe_check_nan_inf(out, "einsum")
         return out
 
-    if target_symmetry is not None:
-        _validate_result_symmetry(result, target_symmetry)
+    if target_symmetry is not None and _validate_result_symmetry(
+        result, target_symmetry
+    ):
         result = SymmetricTensor(_np.asarray(result), symmetry=target_symmetry)
     else:
+        # An unverified claim is not stamped. Validation is skipped for
+        # non-finite results, so tagging regardless would let a caller mint a
+        # symmetry claim on asymmetric data by poisoning one entry and then
+        # cleaning it up downstream.
         result = _asflopscope(_np.asarray(result))
 
     maybe_check_nan_inf(result, "einsum")

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -16,6 +16,7 @@ from flopscope._pointwise import _prepare_symmetric_out, _validate_result_symmet
 from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import normalize_symmetry_input, validate_symmetry_group
 from flopscope._validation import maybe_check_nan_inf, require_budget
+from flopscope._write_epoch import note_write
 
 
 def _dtype_of_ndarray_out(out: Any) -> _np.dtype | None:
@@ -618,6 +619,9 @@ def einsum(
     if out is not None:
         _validate_result_symmetry(result, target_symmetry)
         _np.copyto(_np.asarray(out), _np.asarray(result), casting="unsafe")
+        # Internal copy, so _call_numpy's hook never sees it: record the write
+        # or a tag on out's buffer (or on an alias of it) would survive.
+        note_write(out)
         maybe_check_nan_inf(out, "einsum")
         return out
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -384,8 +384,10 @@ def _call_with_optional_out(np_func, *args, out=None, supports_out=False, **kwar
         return _call_numpy(np_func, *args, out=out_stripped, **kwargs)
     result = _call_numpy(np_func, *args, **kwargs)
     # Fallback copy when np_func doesn't natively support out=. This is
-    # flopscope's overhead, NOT routed through _call_numpy.
+    # flopscope's overhead, NOT routed through _call_numpy -- so the write has
+    # to be recorded here, or a tag on `out`'s buffer would outlive its data.
     _np.copyto(out_stripped, _np.asarray(result), casting="unsafe")  # type: ignore[arg-type]
+    note_write(out)
     return out
 
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -51,6 +51,7 @@ from flopscope._symmetry_utils import (
     unique_elements_for_shape,
 )
 from flopscope._validation import maybe_check_nan_inf, require_budget
+from flopscope._write_epoch import note_write
 from flopscope.errors import (
     CostFallbackWarning,
     SymmetryError,
@@ -241,21 +242,29 @@ def _prepare_symmetric_out(out, target_symmetry):
     return target_symmetry
 
 
-def _validate_result_symmetry(result, symmetry):
+def _validate_result_symmetry(result, symmetry) -> bool:
+    """Raise if ``result`` contradicts ``symmetry``; report whether it was checked.
+
+    The return value is the caller's licence to stamp ``symmetry`` onto a
+    buffer: it is ``True`` only when the data was actually verified against the
+    group. Callers that cannot verify must not re-stamp, otherwise an
+    unverifiable result launders a tag onto asymmetric data.
+    """
     if symmetry is None:
-        return
+        return False
     result_arr = _np.asarray(result)
     # Skip numerical validation when the result has non-finite entries:
     # np.allclose treats inf-inf=nan as not-close, which would raise a
     # false SymmetryError. The symmetry was already enforced structurally
     # by the (symmetric) inputs; numerical checks on inf/nan are meaningless.
     if not _np.all(_np.isfinite(result_arr)):
-        return
+        return False
     if not _check_generators(result_arr, symmetry):
         axes = symmetry.axes
         if axes is None:
             axes = tuple(range(symmetry.degree))
         raise SymmetryError(axes=tuple(axes), max_deviation=float("inf"))
+    return True
 
 
 def _is_oversized_for_cost_model(group):
@@ -424,8 +433,14 @@ def _wrap_result(result, *, out=None, symmetry=None):
             _validate_result_symmetry(result, symmetry)
             return out
         effective_symmetry = _prepare_symmetric_out(out, symmetry)
-        _validate_result_symmetry(result, effective_symmetry)
+        verified = _validate_result_symmetry(result, effective_symmetry)
         _np.copyto(_np.asarray(out), _np.asarray(result), casting="unsafe")
+        # This copy is flopscope-internal and so bypasses _call_numpy's hook.
+        # Whatever ``out`` claimed before describes data that is now gone; the
+        # claim only comes back if this result was verified against the group.
+        note_write(out)
+        if verified:
+            out._symmetry = effective_symmetry
         return out
     if symmetry is not None:
         return SymmetricTensor(_np.asarray(result), symmetry=symmetry)
@@ -2904,8 +2919,9 @@ def _einsum_routed_binary(
         maybe_check_nan_inf(result, op_name)
     if out is not None:
         result = out
-    if info.output_symmetry is not None:
-        _validate_result_symmetry(result, info.output_symmetry)
+    if info.output_symmetry is not None and _validate_result_symmetry(
+        result, info.output_symmetry
+    ):
         return SymmetricTensor(_np.asarray(result), symmetry=info.output_symmetry)
     return _asflopscope(result) if inputs_were_whest else result
 

--- a/src/flopscope/_symmetric.py
+++ b/src/flopscope/_symmetric.py
@@ -18,6 +18,7 @@ from flopscope._symmetry_utils import (
     validate_symmetry_group,
 )
 from flopscope._validation import require_budget
+from flopscope._write_epoch import epoch_of
 from flopscope.errors import SymmetryError
 
 # ---------------------------------------------------------------------------
@@ -603,7 +604,11 @@ class SymmetricTensor(FlopscopeArray):
     Do not instantiate directly; use :func:`as_symmetric`.
     """
 
-    __slots__ = ("_symmetry", "_symmetry_inferred")
+    __slots__ = (
+        "_symmetry_raw",
+        "_symmetry_inferred",
+        "_symmetry_epoch",
+    )
 
     def __new__(
         cls,
@@ -619,6 +624,26 @@ class SymmetricTensor(FlopscopeArray):
     def __array_finalize__(self, obj: object) -> None:
         self._symmetry = None
         self._symmetry_inferred = False
+
+    # The tag is a billing claim about buffer contents, so it is stamped with
+    # the buffer's write count and voided once that count moves. Gating the
+    # storage rather than the public ``symmetry`` property covers the internal
+    # ``self._symmetry`` reads too, so a voided tag cannot be laundered back
+    # out through ``copy()``, ``.T``, slicing or a pickle round-trip.
+    @property
+    def _symmetry(self):
+        raw = self._symmetry_raw
+        if raw is None:
+            return None
+        if epoch_of(self) != self._symmetry_epoch:
+            self._symmetry_raw = None  # latch: a voided claim never returns
+            return None
+        return raw
+
+    @_symmetry.setter
+    def _symmetry(self, value) -> None:
+        self._symmetry_raw = value
+        self._symmetry_epoch = 0 if value is None else epoch_of(self)
 
     def __array_wrap__(self, out_arr, context=None, return_scalar=False):
         result = super().__array_wrap__(out_arr, context, return_scalar)

--- a/src/flopscope/_write_epoch.py
+++ b/src/flopscope/_write_epoch.py
@@ -1,0 +1,82 @@
+"""Buffer write epochs -- the mechanism that voids a symmetry tag when its data changes.
+
+A symmetry tag is a billing claim about buffer contents. It is validated once,
+by :func:`flopscope.as_symmetric` or inferred from shape on a constant fill,
+and from then on the cost model trusts it and never re-reads the data. Any
+write into the buffer therefore invalidates the claim -- including a write made
+through an *untagged* alias, because ``as_symmetric`` returns a view and
+``asarray``/``ravel`` hand back untagged aliases of a tagged buffer.
+
+The aliases of a buffer cannot be enumerated from the buffer, so tags are not
+cleared eagerly on write. Instead each tag records the buffer's write count at
+the moment it was stamped, and reads void the tag when the counts diverge.
+Every alias shares one counter because they share one ``.base`` chain root,
+which is what lets a write through an untagged alias void a tag it cannot see.
+
+Counters exist only for buffers that have actually been written and are dropped
+when the buffer dies, so the table stays proportional to live written buffers
+rather than to all arrays.
+"""
+
+from __future__ import annotations
+
+import weakref
+
+import numpy as _np
+
+_EPOCHS: dict[int, int] = {}
+_ROOTS: dict[int, weakref.ref] = {}
+
+
+def buffer_root(arr):
+    """Return the array that owns ``arr``'s memory, following the view chain.
+
+    The walk stops at the last ndarray, so the root is always weak-referenceable
+    even when the chain bottoms out in a non-array exporter such as ``bytes``.
+    """
+    base = getattr(arr, "base", None)
+    while isinstance(base, _np.ndarray):
+        arr = base
+        base = getattr(arr, "base", None)
+    return arr
+
+
+def epoch_of(arr) -> int:
+    """Number of recorded writes to ``arr``'s buffer.
+
+    Returns 0 for a buffer that has never been written. The identity check
+    against the stored weakref means a recycled ``id`` reads as 0 rather than
+    inheriting a dead buffer's count.
+    """
+    root = buffer_root(arr)
+    ref = _ROOTS.get(id(root))
+    if ref is None or ref() is not root:
+        return 0
+    return _EPOCHS.get(id(root), 0)
+
+
+def note_write(target) -> None:
+    """Record that ``target``'s buffer was written, voiding tags that observe it.
+
+    Accepts the shapes an ``out=`` argument can take, including the tuple form
+    used by multi-output ufuncs, and ignores non-arrays.
+    """
+    if isinstance(target, (tuple, list)):
+        for item in target:
+            note_write(item)
+        return
+    if not isinstance(target, _np.ndarray):
+        return
+    root = buffer_root(target)
+    key = id(root)
+    ref = _ROOTS.get(key)
+    if ref is None or ref() is not root:
+        # First write to this buffer (or a recycled id): start a fresh count.
+        def _drop(_dead, key=key):
+            _EPOCHS.pop(key, None)
+            _ROOTS.pop(key, None)
+
+        _ROOTS[key] = weakref.ref(root, _drop)
+        _EPOCHS[key] = 1
+        return
+    _EPOCHS[key] = _EPOCHS.get(key, 0) + 1

--- a/src/flopscope/_write_epoch.py
+++ b/src/flopscope/_write_epoch.py
@@ -31,14 +31,20 @@ _ROOTS: dict[int, weakref.ref] = {}
 def buffer_root(arr):
     """Return the array that owns ``arr``'s memory, following the view chain.
 
-    The walk stops at the last ndarray, so the root is always weak-referenceable
-    even when the chain bottoms out in a non-array exporter such as ``bytes``.
+    The walk continues through non-array links and keeps the last ndarray it
+    saw. Some views interpose a non-array object -- ``as_strided`` inserts a
+    private shim -- and stopping there would treat the view as its own root, so
+    a write through it would not reach the tags on the real buffer. Keeping the
+    last ndarray also means the root is always weak-referenceable, even when the
+    chain bottoms out in an exporter such as ``bytes``.
     """
+    root = arr
     base = getattr(arr, "base", None)
-    while isinstance(base, _np.ndarray):
-        arr = base
-        base = getattr(arr, "base", None)
-    return arr
+    while base is not None:
+        if isinstance(base, _np.ndarray):
+            root = base
+        base = getattr(base, "base", None)
+    return root
 
 
 def epoch_of(arr) -> int:

--- a/src/flopscope/_write_epoch.py
+++ b/src/flopscope/_write_epoch.py
@@ -24,8 +24,10 @@ import weakref
 
 import numpy as _np
 
-_EPOCHS: dict[int, int] = {}
-_ROOTS: dict[int, weakref.ref] = {}
+_ExtentKey = tuple[int, int]
+
+_EPOCHS: dict[_ExtentKey, int] = {}
+_ROOTS: dict[_ExtentKey, weakref.ref] = {}
 
 
 def buffer_root(arr):
@@ -47,18 +49,24 @@ def buffer_root(arr):
     return root
 
 
-def epoch_of(arr) -> int:
-    """Number of recorded writes to ``arr``'s buffer.
+def _extent_key(root) -> _ExtentKey:
+    """Identify the memory a root array covers, not the array object itself.
 
-    Returns 0 for a buffer that has never been written. The identity check
-    against the stored weakref means a recycled ``id`` reads as 0 rather than
-    inheriting a dead buffer's count.
+    Arrays built independently over one exporter -- two ``frombuffer`` calls on
+    the same ``bytearray``, say -- each end their view chain at a different
+    ndarray, so object identity would give them separate counters and a write
+    through one would not reach tags on the other. Their address and extent are
+    shared, which is the property that actually matters here.
     """
-    root = buffer_root(arr)
-    ref = _ROOTS.get(id(root))
-    if ref is None or ref() is not root:
-        return 0
-    return _EPOCHS.get(id(root), 0)
+    try:
+        return (root.__array_interface__["data"][0], root.nbytes)
+    except (AttributeError, TypeError, KeyError):
+        return (id(root), -1)
+
+
+def epoch_of(arr) -> int:
+    """Number of recorded writes to ``arr``'s buffer. 0 if never written."""
+    return _EPOCHS.get(_extent_key(buffer_root(arr)), 0)
 
 
 def note_write(target) -> None:
@@ -74,15 +82,18 @@ def note_write(target) -> None:
     if not isinstance(target, _np.ndarray):
         return
     root = buffer_root(target)
-    key = id(root)
-    ref = _ROOTS.get(key)
-    if ref is None or ref() is not root:
-        # First write to this buffer (or a recycled id): start a fresh count.
+    key = _extent_key(root)
+    _EPOCHS[key] = _EPOCHS.get(key, 0) + 1
+    if key not in _ROOTS:
+        # Drop the count once the buffer we first saw at this extent goes away,
+        # so the table tracks live buffers. Losing a count can only make a
+        # stamped epoch stop matching, which voids a tag rather than reviving
+        # one -- the safe direction if the address is later reused.
         def _drop(_dead, key=key):
             _EPOCHS.pop(key, None)
             _ROOTS.pop(key, None)
 
-        _ROOTS[key] = weakref.ref(root, _drop)
-        _EPOCHS[key] = 1
-        return
-    _EPOCHS[key] = _EPOCHS.get(key, 0) + 1
+        try:
+            _ROOTS[key] = weakref.ref(root, _drop)
+        except TypeError:  # pragma: no cover - ndarrays are weak-referenceable
+            pass

--- a/src/flopscope/numpy/random/_counted_classes.py
+++ b/src/flopscope/numpy/random/_counted_classes.py
@@ -18,6 +18,7 @@ from flopscope._budget import _counted_wrapper
 from flopscope._ndarray import _asflopscope, _to_base_ndarray
 from flopscope._registry import REGISTRY
 from flopscope._validation import require_budget
+from flopscope._write_epoch import note_write
 from flopscope.errors import UnsupportedFunctionError
 from flopscope.numpy.random._cost_formulas import COST_FORMULAS
 
@@ -64,6 +65,13 @@ def _make_counted_method(
             )
         else:
             call_args = args
+        # numpy is called directly here rather than through _call_numpy, so the
+        # write hook there does not see these destinations.
+        out = kwargs.get("out")
+        if out is not None:
+            note_write(out)
+        if method_name == "shuffle" and args:
+            note_write(args[0])
         result = base_method(plain, *call_args, **kwargs)
         cost = formula(args, kwargs, result)
         if method_name in _movement_methods:

--- a/tests/test_symmetry_tag_forgery.py
+++ b/tests/test_symmetry_tag_forgery.py
@@ -129,6 +129,18 @@ def test_write_through_untagged_parent_does_not_forge_tag():
     _assert_claim_does_not_survive(tagged, lambda _: fnp.copyto(parent, _asymmetric()))
 
 
+def test_write_through_a_shim_interposed_view_does_not_forge_tag():
+    """as_strided interposes a non-array object in the view chain, so the root
+    walk has to see through it to reach the tags on the real buffer."""
+    load_weights()
+    parent = _symmetric()
+    tagged = f.as_symmetric(parent, symmetry=(0, 1))
+    strided = np.lib.stride_tricks.as_strided(
+        np.asarray(tagged), shape=(N, N), strides=np.asarray(tagged).strides
+    )
+    _assert_claim_does_not_survive(tagged, lambda _: fnp.copyto(strided, _asymmetric()))
+
+
 def test_write_through_untagged_alias_does_not_forge_tag():
     """fnp.asarray/ravel hand back untagged aliases of a tagged buffer."""
     load_weights()

--- a/tests/test_symmetry_tag_forgery.py
+++ b/tests/test_symmetry_tag_forgery.py
@@ -1,0 +1,188 @@
+"""Regression pins: a symmetry tag must not survive a write that invalidates it.
+
+A symmetry tag is a billing-critical claim about buffer contents. The cost
+model grants a ``k!``-scale discount on the strength of the tag alone and
+never re-reads the data, and tags are validated once, at creation
+(``flops.as_symmetric``) or inferred for free from shape on a constant fill
+(``fnp.zeros`` and friends). So every route that writes into a tagged buffer --
+or into any buffer a tagged array aliases -- must either refuse the write or
+drop the claim. Otherwise a caller obtains a symmetric-rate discount on
+asymmetric data, with numerically correct results and nothing to signal the
+discrepancy.
+
+Each test performs a write that makes the data asymmetric and then asserts the
+invariant directly: either the write raised, or the array no longer buys the
+discount. Both outcomes are acceptable; keeping the discount is not.
+"""
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+from flopscope._weights import load_weights
+
+N = 32
+
+
+def _billed(fn):
+    with f.BudgetContext(flop_budget=10**18, quiet=True) as b:
+        fn()
+        return b.flops_used
+
+
+def _asymmetric(n=N, seed=0):
+    rng = np.random.default_rng(seed)
+    return rng.random((n, n))
+
+
+def _symmetric(n=N):
+    a = _asymmetric(n)
+    return a + a.T
+
+
+def _probe(arr):
+    """Contraction whose price depends only on the operands' symmetry tags."""
+    return _billed(lambda: fnp.einsum("ij,ij->", arr, arr))
+
+
+def _honest():
+    return _probe(_asymmetric())
+
+
+def _assert_claim_does_not_survive(tagged, write):
+    """The invariant: no route yields asymmetric data that still bills symmetric."""
+    load_weights()
+    honest = _honest()
+    try:
+        write(tagged)
+    except Exception:
+        return  # write refused -- the claim was protected
+    assert not np.allclose(np.asarray(tagged), np.asarray(tagged).T), (
+        "test bug: the write did not actually break symmetry"
+    )
+    assert _probe(tagged) == honest
+
+
+# --- free inferred tags from constant-fill constructors ------------------
+
+
+def test_put_does_not_forge_tag():
+    _assert_claim_does_not_survive(fnp.zeros((N, N)), lambda z: fnp.put(z, [1], [99.0]))
+
+
+def test_fill_diagonal_keeps_symmetry_but_never_forges():
+    z = fnp.zeros((N, N))
+    load_weights()
+    fnp.fill_diagonal(z, 3.0)
+    # A diagonal write preserves symmetry, so the discount stays legitimate.
+    assert np.allclose(np.asarray(z), np.asarray(z).T)
+
+
+def test_copyto_does_not_forge_tag():
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)), lambda z: fnp.copyto(z, _asymmetric())
+    )
+
+
+def test_ufunc_out_does_not_forge_tag():
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)), lambda z: fnp.multiply(_asymmetric(), 1.0, out=z)
+    )
+
+
+def test_putmask_does_not_forge_tag():
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)),
+        lambda z: fnp.putmask(z, np.ones((N, N), dtype=bool), _asymmetric()),
+    )
+
+
+def test_place_does_not_forge_tag():
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)),
+        lambda z: fnp.place(z, np.ones((N, N), dtype=bool), _asymmetric().ravel()),
+    )
+
+
+def test_contraction_out_does_not_forge_tag():
+    """vecdot/matvec/vecmat route through _einsum_routed_binary, which has no guard."""
+    # Distinct operands, so the contraction result is genuinely asymmetric --
+    # vecdot of an array against itself yields a symmetric Gram matrix and
+    # would not exercise the forgery at all.
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)),
+        lambda z: fnp.vecdot(
+            _asymmetric(seed=1)[:, None, :], _asymmetric(seed=2)[None, :, :], out=z
+        ),
+    )
+
+
+# --- paid hard tags from as_symmetric, reached through aliases -----------
+
+
+def test_write_through_untagged_parent_does_not_forge_tag():
+    """as_symmetric returns a VIEW, so the parent aliases the tagged buffer."""
+    load_weights()
+    parent = _symmetric()
+    tagged = f.as_symmetric(parent, symmetry=(0, 1))
+    _assert_claim_does_not_survive(tagged, lambda _: fnp.copyto(parent, _asymmetric()))
+
+
+def test_write_through_untagged_alias_does_not_forge_tag():
+    """fnp.asarray/ravel hand back untagged aliases of a tagged buffer."""
+    load_weights()
+    tagged = fnp.zeros((N, N))
+    alias = fnp.asarray(tagged)
+    _assert_claim_does_not_survive(tagged, lambda _: fnp.copyto(alias, _asymmetric()))
+
+
+def test_rng_out_does_not_forge_tag():
+    """RNG methods call numpy directly, bypassing the shared out= write hook."""
+    load_weights()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        z = fnp.zeros((N, N))
+        fnp.random.default_rng(0).random(out=z)
+        assert z.symmetry is None
+
+
+def test_unverified_symmetry_claim_is_not_minted():
+    """Validation is skipped for non-finite results, so no tag may be stamped."""
+    load_weights()
+    poisoned = _asymmetric()
+    poisoned[0, 1] = np.inf
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        r = fnp.einsum("ij,jk->ik", poisoned, _asymmetric(seed=3), symmetry=(0, 1))
+        assert getattr(r, "symmetry", None) is None
+
+
+def test_tag_inherited_by_a_constant_fill_still_voids_on_write():
+    """``zeros_like`` keeps a propagated trusted tag (pinned elsewhere); the
+    epoch is what makes that safe once the fresh buffer is written."""
+    load_weights()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        tagged = f.as_symmetric(_symmetric(), symmetry=(0, 1))
+        arena = fnp.zeros_like(tagged)
+        fnp.copyto(arena, _asymmetric())
+        assert arena.symmetry is None
+
+
+# --- the discount must still work when it is honestly earned -------------
+
+
+def test_genuinely_symmetric_data_still_earns_the_discount():
+    load_weights()
+    tagged = f.as_symmetric(_symmetric(), symmetry=(0, 1))
+    assert _probe(tagged) < _honest()
+
+
+def test_scratch_buffer_idiom_still_works():
+    """arena = fnp.zeros(...) then writing into it must keep working."""
+    load_weights()
+    arena = fnp.zeros((N, N))
+    fnp.copyto(arena, _asymmetric())
+    assert np.allclose(np.asarray(arena), _asymmetric())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_symmetry_tag_forgery.py
+++ b/tests/test_symmetry_tag_forgery.py
@@ -143,7 +143,7 @@ def test_rng_out_does_not_forge_tag():
     with f.BudgetContext(flop_budget=10**18, quiet=True):
         z = fnp.zeros((N, N))
         fnp.random.default_rng(0).random(out=z)
-        assert z.symmetry is None
+        assert getattr(z, "symmetry", None) is None
 
 
 def test_unverified_symmetry_claim_is_not_minted():
@@ -164,7 +164,7 @@ def test_tag_inherited_by_a_constant_fill_still_voids_on_write():
         tagged = f.as_symmetric(_symmetric(), symmetry=(0, 1))
         arena = fnp.zeros_like(tagged)
         fnp.copyto(arena, _asymmetric())
-        assert arena.symmetry is None
+        assert getattr(arena, "symmetry", None) is None
 
 
 # --- the discount must still work when it is honestly earned -------------


### PR DESCRIPTION
## The problem

A symmetry tag is a **billing claim about buffer contents**. The cost model grants a `k!`-scale discount on the strength of the tag alone and never re-reads the data; tags are validated once, at creation. Nothing invalidated a tag when the data underneath it changed.

So: take a free tagged buffer (`fnp.zeros` on a square shape is a `SymmetricTensor` at 0 FLOPs), write arbitrary asymmetric data into it, and collect the symmetric rate on everything downstream. Results stay numerically correct, so nothing signals the discrepancy.

Measured on `main`, 32×32 float64:

| | honest | forged |
|---|---:|---:|
| `einsum('ij,ij->')` | 4094 | **2110** |
| `linalg.inv`, n=1024 | 4,294,967,296 | **2,863,311,530** |

`linalg.inv` at n=1024 nets **1.43 GFLOP saved per call against a 272 GFLOP budget**, repeatable without limit — the tag lives on the buffer, so one setup discounts unlimited reuse, and it propagates through derived arrays. Reachable end-to-end through the real client against a real server, and needing no adversarial intent: `fnp.vecdot(a, a, out=fnp.zeros((n,n)))` is an ordinary accumulator idiom that silently produces a mis-tagged handle.

The cheapest entry was `fnp.put(Z, [1], [99.0])` — **2 FLOPs**.

## The fix

Tags carry the buffer's write count and void themselves once it moves.

Aliases of a buffer cannot be enumerated from the buffer, so the check is lazy rather than eager: **every alias shares one counter because they share one `.base` chain root.** That is what closes writes made through an *untagged* alias — `as_symmetric` returns a view, and `asarray`/`ravel` hand back untagged aliases — which no guard on tagged arrays could reach. This was the constraint that ruled out the obvious designs.

Gating the *storage* rather than the public `symmetry` property also covers the internal `self._symmetry` reads, so a voided tag cannot be laundered back out through `copy()`, `.T`, slicing or a pickle round-trip.

Also closed, each verified as a working forgery beforehand:

- **Writes reaching numpy outside `_call_numpy`** — the two internal `copyto` calls in `_pointwise`, einsum's `out=` copy, and the RNG methods, which call numpy directly. `_prepare_symmetric_out`'s documented "downgrade" of an inferred tag never actually cleared it; it does now.
- **Unverified claims were minted.** `_validate_result_symmetry` skips numerical checks on non-finite results, so a caller could poison one entry, receive a *hard* tag on asymmetric data, and clean the poison up downstream. It now reports whether it verified, and callers stamp only when it did.
- **The server op resolver** walked `getattr` unrestricted over `flopscope.numpy` then `flopscope`, exposing private helpers and re-exported modules as callable ops. `_array_ops._wrap_constant_fill` minted an S2 tag on arbitrary data for **0 FLOPs** — immune to write tracking, since no write occurs. Only public names resolve now, and array types are not ops.

## Scope decisions

**Constant-fill constructors keep inferring symmetry.** A zeros array genuinely *is* symmetric; the claim is only false after a write, and the epoch covers that. Removing the inference would be an uncompensated pricing change.

**`zeros_like` keeps propagating a trusted tag**, as pinned by `test_symmetric_free_ops`. I changed this initially and reverted it — the pin is deliberate ("propagated explicit symmetry must not be marked inferred") and the security value is nil once writes void tags.

**Raw numpy through the resolver does *not* bypass billing.** Worth stating because it looks alarming: `_array_ops._np.matmul` resolves to the real numpy ufunc, but `__array_ufunc__`/`__array_function__` route it back through the counted wrappers — measured identical at 66,977,792 FLOPs. The resolver is still narrowed, for the tag-mint reason above.

## Verification

New pins in `tests/test_symmetry_tag_forgery.py` assert the invariant directly — *either the write is refused, or the array no longer buys the discount* — so they hold regardless of which mechanism closes a route. All 8 original routes failed before the change and pass after.

Two controls guard against over-fixing: genuinely symmetric data must still earn the discount, and the `arena = fnp.zeros(...)` scratch-buffer idiom must keep working. Both pass.

- main suite: **5338 passed**, 5 pre-existing failures (docs/ops-json generation, unrelated — confirmed identical on a clean tree)
- server: **271 passed**
- client: **1370 passed**, 3 xfailed
- `ruff check` / `ruff format` clean

## Not included

The non-numeric `out=` dtype launder (`fnp.einsum(..., out=<object array>)` underbills complex128 by 8×) is a separate defect in the same neighbourhood and wants its own PR.