### PR TITLE
fix(billing): ufunc.at bills written cells; mask_indices callback bills to residual

### DIFF
--- a/src/flopscope/_array_ops.py
+++ b/src/flopscope/_array_ops.py
@@ -2891,7 +2891,13 @@ def mask_indices(*args, **kwargs):
         args[1] = _strip_mask_func(args[1])
     elif "mask_func" in kwargs:
         kwargs["mask_func"] = _strip_mask_func(kwargs["mask_func"])
-    result = _np.mask_indices(*args, **kwargs)
+    # ``mask_func`` is participant code: route it through ``_call_user_code`` so
+    # its runtime books to residual, exactly as ``fromfunction`` / ``fromiter`` /
+    # ``apply_along_axis`` / ``apply_over_axes`` / ``piecewise`` already do.
+    # Calling ``_np.mask_indices`` bare left the callback's entire wall time in
+    # ``flopscope_overhead_time_s``, which is excluded from effective compute --
+    # i.e. arbitrary user computation ran free of charge on both axes.
+    result = _call_user_code(budget, _np.mask_indices, *args, **kwargs)
     cost = max(sum(int(r.size) for r in result), 1)
     with budget.deduct(
         # dtype-neutral (dtypes=()): index bookkeeping, same convention as

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -1172,6 +1172,68 @@ def _counted_ufunc_reduceat(ufunc, a, indices, *, axis=0, out=None, **kwargs):
     return _wrap_result(result, out=out, symmetry=None)
 
 
+def _ufunc_at_touched_cells(a, indices) -> int:
+    """Number of array cells ``ufunc.at(a, indices, ...)`` actually operates on.
+
+    ``ufunc.at`` applies the ufunc once per *selected cell*, not once per index.
+    An index expression selects along the LEADING axes it consumes; every
+    remaining (trailing) axis is swept in full. Costing by ``size(indices)``
+    alone therefore under-bills by ``prod(a.shape[consumed:])`` -- unbounded in
+    the trailing dimensions, e.g. a length-1 index into an ``(1, n, k, m)``
+    destination performs ``n*k*m`` operations for a bill of 1.
+
+    Rules, mirroring numpy's own indexing semantics:
+
+    * a tuple index consumes one leading axis per non-``newaxis`` entry, and
+      its array-like entries broadcast together;
+    * a single array-like index consumes exactly one axis;
+    * ``slice`` / ``Ellipsis`` entries select along their axis without
+      broadcasting, so they contribute that axis' length;
+    * anything unrecognised falls back to ``a.size`` (fail closed -- the old
+      upper bound), never to 1.
+    """
+    shape = getattr(a, "shape", None)
+    if shape is None:
+        return 1
+    total = int(_np.prod(shape)) if len(shape) else 1
+
+    entries = indices if isinstance(indices, tuple) else (indices,)
+    index_shapes: list = []
+    consumed = 0
+    for entry in entries:
+        if entry is None:  # np.newaxis consumes no source axis
+            continue
+        if consumed >= len(shape):
+            return _builtins.max(total, 1)
+        if entry is Ellipsis:
+            # Ellipsis may span several axes; fail closed rather than guess.
+            return _builtins.max(total, 1)
+        if isinstance(entry, slice):
+            index_shapes.append((len(range(*entry.indices(shape[consumed]))),))
+        elif isinstance(entry, (int, _np.integer)):
+            index_shapes.append(())
+        elif isinstance(entry, _np.ndarray):
+            index_shapes.append(entry.shape)
+        elif isinstance(entry, (list, tuple)):
+            try:
+                index_shapes.append(_np.asarray(entry).shape)
+            except Exception:  # pragma: no cover - exotic nested sequences
+                return _builtins.max(total, 1)
+        else:
+            return _builtins.max(total, 1)
+        consumed += 1
+
+    if consumed == 0:
+        return _builtins.max(total, 1)
+    try:
+        selected = int(_np.prod(_np.broadcast_shapes(*index_shapes))) if index_shapes else 1
+    except ValueError:  # pragma: no cover - numpy raises on the call itself
+        return _builtins.max(total, 1)
+
+    trailing = int(_np.prod(shape[consumed:])) if consumed < len(shape) else 1
+    return _builtins.max(selected * trailing, 1)
+
+
 @_counted_wrapper
 def _counted_ufunc_at(ufunc, a, indices, *args, **kwargs):
     """Cost-tracked ``ufunc.at(a, indices[, values])`` (in-place fancy index).
@@ -1205,14 +1267,7 @@ def _counted_ufunc_at(ufunc, a, indices, *args, **kwargs):
     indices_stripped = (
         _to_base_ndarray(indices) if isinstance(indices, _np.ndarray) else indices
     )
-    if isinstance(indices, _np.ndarray):
-        n_ops = _builtins.max(int(_np.size(indices)), 1)
-    elif hasattr(a, "size"):
-        # Conservative for non-array index forms (slice / Ellipsis): use
-        # the input size as an upper bound on the touched cells.
-        n_ops = _builtins.max(int(a.size), 1)
-    else:
-        n_ops = 1
+    n_ops = _ufunc_at_touched_cells(a, indices)
     # Strip any flopscope-typed positional values too.
     stripped_args = tuple(
         _to_base_ndarray(v) if isinstance(v, _np.ndarray) else v for v in args

--- a/tests/test_accounting_escapes.py
+++ b/tests/test_accounting_escapes.py
@@ -1,0 +1,134 @@
+"""Regression tests for three accounting escapes (see PR description).
+
+Each test asserts an INVARIANT rather than a magic number, so they keep their
+value as the cost model evolves:
+
+1. ``ufunc.at`` must bill per element WRITTEN, not per index supplied, so it
+   agrees with the equivalent elementwise op on the same element count.
+2. Every wrapper that invokes participant code must route it through
+   ``_call_user_code``, so the callback's wall time books to residual rather
+   than to the free ``flopscope_overhead_time_s`` bucket.
+
+NOT included, deliberately: single-operand ``einsum`` ('ij->ij', 'ij->ji')
+billing 0. That looks like an under-bill but is INTENTIONAL and locked by
+``test_complex_einsum_transpose_charges_zero`` and
+``test_empty_symmetric_contraction_does_not_refund_budget``; clamping it to 1
+breaks both. Left alone.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+import flopscope
+import flopscope.numpy as fnp
+
+
+def _billed(fn):
+    with flopscope.BudgetContext(flop_budget=10**15, quiet=True) as ctx:
+        before = ctx.flops_used
+        fn()
+        return ctx.flops_used - before
+
+
+# --------------------------------------------------------------------------
+# 1. ufunc.at bills the cells it writes
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("shape", [(1, 4096), (1, 64, 64), (1, 16, 16, 16)])
+def test_ufunc_at_bills_written_cells_not_index_count(shape):
+    """A length-1 index into an N-d array writes prod(shape[1:]) cells."""
+    dst = fnp.asarray(np.zeros(shape, np.float32))
+    vals = fnp.asarray(np.random.randn(*shape[1:]).astype(np.float32))
+    idx = np.array([0], np.intp)
+
+    at_cost = _billed(lambda: np.add.at(dst, idx, vals[None]))
+    written = int(np.prod(shape[1:]))
+    equivalent = _billed(lambda: fnp.add(fnp.asarray(np.zeros(shape[1:], np.float32)), vals))
+
+    assert at_cost == written, f"add.at billed {at_cost}, wrote {written} cells"
+    assert at_cost == equivalent, "add.at must agree with the equivalent fnp.add"
+
+
+def test_ufunc_at_scatter_bills_every_accumulate():
+    """Repeated fancy indices each perform an operation; tuple form included."""
+    n_idx = 50_000
+    dst = fnp.asarray(np.zeros((1000, 1), np.float32))
+    vals = fnp.asarray(np.random.randn(n_idx).astype(np.float32))
+    rows = fnp.asarray(np.random.randint(0, 1000, n_idx).astype(np.intp))
+    cols = fnp.asarray(np.zeros(n_idx, np.intp))
+
+    tuple_cost = _billed(lambda: np.add.at(dst, (rows, cols), vals))
+    assert tuple_cost == n_idx, (
+        f"tuple-index scatter billed {tuple_cost} for {n_idx} accumulates "
+        "(the old `a.size` upper bound is NOT conservative for repeated indices)"
+    )
+
+    list_cost = _billed(
+        lambda: np.add.at(dst, ([0] * 1000, [0] * 1000), fnp.asarray(np.zeros(1000, np.float32)))
+    )
+    assert list_cost == 1000, f"list-index scatter billed {list_cost} for 1000 accumulates"
+
+
+def test_ufunc_at_matmul_route_is_not_cheaper_than_matmul():
+    """The composed at-matmul must not undercut the honest contraction."""
+    k = 32
+    X = fnp.asarray(np.random.randn(k, k).astype(np.float32))
+    W = fnp.asarray(np.random.randn(k, k).astype(np.float32))
+    honest = _billed(lambda: fnp.matmul(X, W))
+
+    one = np.array([0], np.intp)
+
+    def at_route():
+        D = fnp.asarray(np.zeros((1, k, k, k), np.float32))
+        np.add.at(D, one, W[None, None, :, :])
+        np.multiply.at(D, one, X[None, :, :, None])
+        V = D[0]
+        m = k
+        while m > 1:
+            h = m // 2
+            np.add.at(V[:, :h, :][None], one, V[:, h : 2 * h, :][None])
+            V = V[:, :h, :]
+            m = h
+
+    assert _billed(at_route) >= honest, "at-composed matmul must not be cheaper than matmul"
+
+
+# --------------------------------------------------------------------------
+# 2. participant callbacks bill to residual, not to free overhead
+# --------------------------------------------------------------------------
+
+CALLBACK_WRAPPERS = [
+    ("mask_indices", lambda cb: fnp.mask_indices(4, cb)),
+    ("fromfunction", lambda cb: fnp.fromfunction(cb, (4, 4))),
+    ("apply_along_axis", lambda cb: fnp.apply_along_axis(
+        cb, 0, fnp.asarray(np.zeros((4, 4), np.float32)))),
+]
+
+
+@pytest.mark.parametrize("name,invoke", CALLBACK_WRAPPERS, ids=[n for n, _ in CALLBACK_WRAPPERS])
+def test_callback_time_books_to_residual(name, invoke):
+    """User-code wall time must not land in the free overhead bucket."""
+    sleep_s = 0.20
+
+    def callback(*args, **kwargs):
+        time.sleep(sleep_s)
+        if name == "mask_indices":
+            return np.zeros((4, 4), bool)
+        if name == "apply_along_axis":
+            return np.float32(0.0)
+        return np.zeros(np.shape(args[0]), np.float32) if args else np.zeros((4, 4), np.float32)
+
+    with flopscope.BudgetContext(flop_budget=10**15, quiet=True) as ctx:
+        invoke(callback)
+    summary = ctx.summary_dict()
+    residual = float(summary.get("residual_wall_time_s") or 0.0)
+    overhead = float(summary.get("flopscope_overhead_time_s") or 0.0)
+
+    assert residual >= 0.8 * sleep_s, (
+        f"{name}: callback slept {sleep_s}s but only {residual:.3f}s billed as residual "
+        f"({overhead:.3f}s went to the free overhead bucket)"
+    )


### PR DESCRIPTION
# PR draft — flopscope: two accounting escapes (`ufunc.at` mispricing, `mask_indices` free callback)

Branch `fix/accounting-escapes`, based on `origin/main` @ `63a6121c` (v0.9.1).
Patch is in the worktree at
`/private/tmp/.../scratchpad/fs-pr` (`git diff origin/main`).

**Diffstat:** `src/flopscope/_array_ops.py` +8/−2, `src/flopscope/_pointwise.py`
+71/−7, `tests/test_accounting_escapes.py` +134 (new). No public API change, no
behaviour change for correctly-priced code.

---

## Title

fix(billing): `ufunc.at` bills written cells, not index count; `mask_indices`
callback bills to residual

## Summary

Two ways participant code can run real computation that the meter does not see.
Both were found while auditing the WhestBench Phase-1 cost model, and both are
reachable through flopscope's own public counted API — no `.view(ndarray)`, no
raw-NumPy laundering, no protocol tricks. Reported and fixed together because
they are the same class as the already-closed `a.nonzero()` (`10ffe7ae`) and
callback (`1fca7ebb`, `16f4424d`) fixes.

### 1. `ufunc.at` charged per index, not per element written

`_counted_ufunc_at` set `n_ops = size(indices)` with no factor for the trailing
axes the index does not consume. `ufunc.at` applies the ufunc once per *selected
cell*, and an index expression selects along the leading axes only — every
remaining axis is swept in full. A length-1 index into an `(1, n, k, m)`
destination therefore performs `n·k·m` operations for a bill of **1**.

The second branch is worse in practice because it is the *idiomatic* form: tuple
and list indices are not `ndarray`, so they fell through to `n_ops = a.size`,
commented as "a conservative upper bound." That is true for a slice and **false
for repeated fancy indices** — i.e. exactly the scatter-accumulate case.

Measured on v0.9.1 before the fix:

| call | billed | real element-ops | ratio |
|---|---|---|---|
| `np.add.at(dst(1, 1e7), [0], vals)` | 1 | 10,000,000 | 1e-7 |
| `np.maximum.at(dst(1, 1e7), [0], 0.0)` (a ReLU) | 1 | 10,000,000 | 1e-7 |
| `np.add.at(dst(1000,1), (rows, cols), vals)`, 1e6 indices | 1,000 | 1,000,000 | 1e-3 |

These compose: an exact 256×256 @ 256×256 matmul costs **10 billed FLOPs**
(2 + log₂ 256) against an honest 33,488,896, with max relative error 6e-7 — and
a full 32-layer forward pass follows. Verified end-to-end through the WhestBench
harness: an estimator using this route reported **452× fewer counted FLOPs while
computing 4× more samples** and scoring 2.56× better, 0 failures.

**Fix.** New `_ufunc_at_touched_cells(a, indices)` resolves every index form
(int / list / tuple / slice / ndarray / `newaxis`) to
`prod(broadcast_index_shape) × prod(a.shape[consumed:])`, and **fails closed to
`a.size`** — never to 1 — for `Ellipsis` and anything unrecognised.

### 2. `mask_indices` ran its callback outside `_call_user_code`

`fnp.mask_indices(n, mask_func)` invoked `_np.mask_indices(*args)` bare inside
`@_counted_wrapper` (`_array_ops.py:2894`), so the callback's entire wall time
was classified as `flopscope_overhead_time_s` — which is excluded from effective
compute. Every sibling wrapper already does this correctly: `fromfunction`,
`fromiter`, `apply_along_axis`, `apply_over_axes`, `piecewise` all route through
`_call_user_code`.

This matters more than the FLOP count. The residual bucket is the backstop that
prices any computation flopscope cannot count; moving callback time into
overhead removes that backstop entirely. Measured through the harness with
identical arithmetic in both arms (`final_layer_mse` ratio 1.000000):

| arm | billed FLOPs | residual | effective compute | multiplier |
|---|---|---|---|---|
| raw work at top level | 2,113,792 | 0.681 s | 6.81e10 | 0.245 |
| identical work inside `mask_indices` | 2,113,793 | 0.045 s | 4.54e9 | **0.100** (floor) |

15× lower effective compute, 2.44× better score, same numbers out. Because the
multiplier pins at the floor, additional samples are then free, so the advantage
grows until the wall-clock limit binds.

**Fix.** One line: `_call_user_code(budget, _np.mask_indices, *args, **kwargs)`.

## Tests

`tests/test_accounting_escapes.py` (8 tests) asserts invariants, not magic
numbers, so they survive cost-model changes:

* `ufunc.at` bills exactly the cells written, and **agrees with the equivalent
  `fnp.add`** on the same element count (parametrised over 2-D/3-D/4-D);
* repeated-index scatter bills every accumulate, in both tuple and list form;
* the composed at-matmul is **never cheaper than `fnp.matmul`** — this is the
  invariant that actually closes the exploit, independent of the formula;
* callback wall time books to residual, parametrised over `mask_indices`,
  `fromfunction`, `apply_along_axis` — so the next wrapper that forgets
  `_call_user_code` fails CI.

**Suite status:** `5332 passed, 5 failed, 3 errors` — byte-identical failure set
to unpatched `origin/main` (`5324 passed, 5 failed, 3 errors`). All pre-existing
and environmental: docs generation, `ops.json` sync, and three scipy
`ImportError`s. **Zero regressions; +8 passing tests.**

## Deliberately NOT changed

Single-operand `einsum` (`'ij->ij'`, `'ij->ji'`, `'ii->i'`) bills 0 for a
materialised copy. I initially patched this and reverted: it is **intentional**
and locked by `test_complex_einsum_transpose_charges_zero` and
`test_empty_symmetric_contraction_does_not_refund_budget`. Noted in the test
module so the next auditor doesn't repeat the mistake. Flagging only in case the
zero-charge for `'ii->i'` (a genuine gather, which `take` charges 4/element for)
is worth a separate look.

## Related, not fixed here

Found in the same audit, each needing its own discussion:

* **Thread-local budget.** `get_active_budget()` reads a `threading.local()`, so
  counted ops on a spawned thread bill 0 to the scored context and can never
  raise `BudgetExhaustedError`. Fixing properly means a `ContextVar` plus an
  owning-thread check — behavioural, so not bundled here.
* **Object-dtype ufuncs.** `_dtype_billing.py:61-75` bills kind `'O'` at the
  neutral rate 1.0 and states in-source that "their wall time is covered by the
  residual-time penalty" — it is not; it lands in backend. Measured 2.7e11 real
  FLOPs for 1 billed FLOP. Suggest failing closed on `'O'`, or routing NumPy's
  object loop through `_call_user_code` (it *is* user code).
* **`einsum(optimize='optimal')` path search** is pure Python inside
  `_counted_wrapper`, so its runtime is free overhead: 12 operands buys 13.5 s
  for 1,118 billed FLOPs.
* **`np.copyto` fails open** — dispatch returns `NotImplemented` and NumPy runs
  the default implementation anyway, so it bills 0 despite a `counted_custom`
  registry entry. A CI invariant asserting *every* counted registry entry with a
  live NumPy callable is in the dispatch map or passthrough set would catch this
  and any future recurrence.
* **`SymmetricTensor.__new__` is public and validates nothing**, so a false
  symmetry claim yields up to a 1/|G| discount on pointwise/reductions
  (contractions are unaffected — those correctly re-derive).

Happy to split any of these into follow-up PRs.
