### PR TITLE
fix(billing): stop a non-numeric out= from laundering the arithmetic's rate

### DIFF
--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -57,6 +57,15 @@ def store_billing_dtypes(out) -> tuple:
     alone. A non-numeric *operand* really does describe the arithmetic --
     ``multiply(object_array, float64_array)`` runs NumPy's object loop and
     returns object -- and must keep resolving to the neutral rate.
+
+    Applied uniformly to every ``out=``, which slightly over-charges the one
+    case where the store *does* pick the loop: a ufunc forwards ``out=`` to
+    NumPy, so an object ``out`` really does run object arithmetic (measured
+    15.5x slower), where a contraction computes natively and only then copies
+    (1.00x). Billing those at the operand rate rather than the neutral one is
+    deliberate and matches how ``out=`` is already treated elsewhere -- see the
+    widest-participating-buffer note at the top of this module. The alternative
+    reopens a discount on a pathological call for no legitimate gain.
     """
     if not isinstance(out, _np.ndarray):
         return ()

--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -40,6 +40,29 @@ def billing_operand(orig, coerced):
     return coerced.dtype
 
 
+def _drop_non_numeric(dtypes: tuple) -> tuple:
+    """Ignore non-numeric contributions when anything numeric participates.
+
+    ``result_type`` resolves any mix containing a non-numeric kind *to* that
+    kind, which then bills at the neutral rate 1.0 and, for contractions, also
+    drops the complex factor. That is the intended answer only when the
+    arithmetic itself is non-numeric. It is the wrong answer when the
+    non-numeric dtype is merely where the result is stored -- an ``out=`` of
+    object or string dtype -- because the loop still runs at the operands'
+    precision. Dropping those contributions can only raise the resolved rate
+    (they carry the minimum rate), so this never discounts a call.
+    """
+    numeric = tuple(d for d in dtypes if _resolved_kind(d) not in _NON_NUMERIC_KINDS)
+    return numeric or dtypes
+
+
+def _resolved_kind(dtype_like) -> str:
+    try:
+        return _np.result_type(dtype_like).kind
+    except Exception:
+        return ""
+
+
 def resolve_billing_dtype(dtypes: tuple) -> _np.dtype | None:
     """Resolved calculation dtype, or None for a declared dtype-neutral call.
 
@@ -51,6 +74,7 @@ def resolve_billing_dtype(dtypes: tuple) -> _np.dtype | None:
     """
     if not dtypes:
         return None
+    dtypes = _drop_non_numeric(dtypes)
     try:
         return _np.result_type(*dtypes)
     except _np.exceptions.DTypePromotionError:
@@ -59,13 +83,22 @@ def resolve_billing_dtype(dtypes: tuple) -> _np.dtype | None:
 
 
 # Non-numeric dtype kinds: object (O), str (U), bytes (S), void/structured (V),
-# datetime64 (M), timedelta64 (m). These are not floating-point arithmetic, so
-# no precision-packing exploit is possible through them -- they bill at the
-# neutral rate 1.0 instead of failing closed. (Their wall time is covered by
-# the residual-time penalty.) The fail-closed rule targets NUMERIC dtypes
-# absent from the supported table -- future types numpy or an extension
-# package might introduce; every known numpy numeric dtype (including the
-# extended-precision longdouble family) carries an explicit rate.
+# datetime64 (M), timedelta64 (m). As OPERANDS these are not floating-point
+# arithmetic, so no precision-packing exploit is possible through them -- they
+# bill at the neutral rate 1.0 instead of failing closed, and their wall time is
+# covered by the residual-time penalty.
+#
+# That reasoning covers operands only. A non-numeric dtype arriving as ``out=``
+# describes where the result is stored, not how it was computed: the loop still
+# runs at the operands' precision, at native speed, so neither the neutral rate
+# nor the residual penalty applies to it. ``_drop_non_numeric`` therefore keeps
+# such a dtype out of the resolution -- otherwise it would drag the rate (and,
+# for contractions, the complex factor) down to 1.0.
+#
+# The fail-closed rule targets NUMERIC dtypes absent from the supported table --
+# future types numpy or an extension package might introduce; every known numpy
+# numeric dtype (including the extended-precision longdouble family) carries an
+# explicit rate.
 _NON_NUMERIC_KINDS = frozenset("OUSVMm")
 
 

--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -40,27 +40,27 @@ def billing_operand(orig, coerced):
     return coerced.dtype
 
 
-def _drop_non_numeric(dtypes: tuple) -> tuple:
-    """Ignore non-numeric contributions when anything numeric participates.
+def store_billing_dtypes(out) -> tuple:
+    """What an ``out=`` buffer contributes to the billing resolution.
+
+    Its dtype, except when that dtype is non-numeric -- then nothing.
 
     ``result_type`` resolves any mix containing a non-numeric kind *to* that
-    kind, which then bills at the neutral rate 1.0 and, for contractions, also
-    drops the complex factor. That is the intended answer only when the
-    arithmetic itself is non-numeric. It is the wrong answer when the
-    non-numeric dtype is merely where the result is stored -- an ``out=`` of
-    object or string dtype -- because the loop still runs at the operands'
-    precision. Dropping those contributions can only raise the resolved rate
-    (they carry the minimum rate), so this never discounts a call.
+    kind, which bills at the neutral rate 1.0 and, for contractions, also drops
+    the complex factor. That is right when the arithmetic itself is
+    non-numeric, and wrong when the non-numeric dtype only says where the
+    result is *stored*: a contraction with an object ``out=`` still runs its
+    loop at the operands' precision and at native speed, so letting the store
+    set the price hands back the whole difference.
+
+    Filtering here rather than inside ``resolve_billing_dtype`` keeps operands
+    alone. A non-numeric *operand* really does describe the arithmetic --
+    ``multiply(object_array, float64_array)`` runs NumPy's object loop and
+    returns object -- and must keep resolving to the neutral rate.
     """
-    numeric = tuple(d for d in dtypes if _resolved_kind(d) not in _NON_NUMERIC_KINDS)
-    return numeric or dtypes
-
-
-def _resolved_kind(dtype_like) -> str:
-    try:
-        return _np.result_type(dtype_like).kind
-    except Exception:
-        return ""
+    if not isinstance(out, _np.ndarray):
+        return ()
+    return () if out.dtype.kind in _NON_NUMERIC_KINDS else (out.dtype,)
 
 
 def resolve_billing_dtype(dtypes: tuple) -> _np.dtype | None:
@@ -74,7 +74,6 @@ def resolve_billing_dtype(dtypes: tuple) -> _np.dtype | None:
     """
     if not dtypes:
         return None
-    dtypes = _drop_non_numeric(dtypes)
     try:
         return _np.result_type(*dtypes)
     except _np.exceptions.DTypePromotionError:
@@ -91,8 +90,9 @@ def resolve_billing_dtype(dtypes: tuple) -> _np.dtype | None:
 # That reasoning covers operands only. A non-numeric dtype arriving as ``out=``
 # describes where the result is stored, not how it was computed: the loop still
 # runs at the operands' precision, at native speed, so neither the neutral rate
-# nor the residual penalty applies to it. ``_drop_non_numeric`` therefore keeps
-# such a dtype out of the resolution -- otherwise it would drag the rate (and,
+# nor the residual penalty applies to it. ``store_billing_dtypes`` therefore keeps
+# such a dtype out of the resolution when it arrives as ``out=`` -- otherwise it
+# would drag the rate (and,
 # for contractions, the complex factor) down to 1.0.
 #
 # The fail-closed rule targets NUMERIC dtypes absent from the supported table --

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -10,6 +10,7 @@ import numpy as _np
 
 from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._config import get_setting
+from flopscope._dtype_billing import resolve_billing_dtype
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._perm_group import SymmetryGroup
 from flopscope._pointwise import _prepare_symmetric_out, _validate_result_symmetry
@@ -596,7 +597,7 @@ def einsum(
     out_dtype = _dtype_of_ndarray_out(out)
     if out_dtype is not None:
         billing_dtypes += (out_dtype,)
-    resolved = _np.result_type(*billing_dtypes) if billing_dtypes else None
+    resolved = resolve_billing_dtype(billing_dtypes)
     complex_override = contraction_complex_override(accumulation_cost, resolved)
 
     with budget.deduct(

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -10,7 +10,7 @@ import numpy as _np
 
 from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._config import get_setting
-from flopscope._dtype_billing import resolve_billing_dtype
+from flopscope._dtype_billing import resolve_billing_dtype, store_billing_dtypes
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._perm_group import SymmetryGroup
 from flopscope._pointwise import _prepare_symmetric_out, _validate_result_symmetry
@@ -18,18 +18,6 @@ from flopscope._symmetric import SymmetricTensor
 from flopscope._symmetry_utils import normalize_symmetry_input, validate_symmetry_group
 from flopscope._validation import maybe_check_nan_inf, require_budget
 from flopscope._write_epoch import note_write
-
-
-def _dtype_of_ndarray_out(out: Any) -> _np.dtype | None:
-    """``out.dtype`` when ``out`` is an ndarray, else ``None``.
-
-    Kept as a helper (rather than an inline ``isinstance(out, _np.ndarray)``
-    check) because ``out`` is typed ``Any`` at its call sites; an inline
-    ``isinstance`` there leaks a narrowed-``out`` union into pyright's
-    control-flow analysis of the rest of the function, tripping
-    ``reportReturnType`` on an unrelated later ``return out``.
-    """
-    return out.dtype if isinstance(out, _np.ndarray) else None
 
 
 def _identity_pattern(operands):
@@ -594,9 +582,7 @@ def einsum(
         o if isinstance(o, _np.ndarray) else _np.asarray(o) for o in operands
     ]
     billing_dtypes = tuple(a.dtype for a in operand_arrays)
-    out_dtype = _dtype_of_ndarray_out(out)
-    if out_dtype is not None:
-        billing_dtypes += (out_dtype,)
+    billing_dtypes += store_billing_dtypes(out)
     resolved = resolve_billing_dtype(billing_dtypes)
     complex_override = contraction_complex_override(accumulation_cost, resolved)
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -655,8 +655,7 @@ def _counted_unary_multi(np_func, op_name: str):
             billing_dtypes = (x.dtype,)
             if out is not None:
                 for o in out:
-                    if isinstance(o, _np.ndarray):
-                        billing_dtypes += (o.dtype,)
+                    billing_dtypes += store_billing_dtypes(o)
         if op_name in _UNARY_FLOAT_LOOP_OPS:
             resolved = resolve_billing_dtype(billing_dtypes)
             if resolved is not None:
@@ -851,8 +850,7 @@ def _counted_binary_multi(np_func, op_name: str):
             billing_dtypes = (billing_operand(x_orig, x), billing_operand(y_orig, y))
             if out is not None:
                 for o in out:
-                    if isinstance(o, _np.ndarray):
-                        billing_dtypes += (o.dtype,)
+                    billing_dtypes += store_billing_dtypes(o)
         with budget.deduct(
             op_name,
             flop_cost=cost,

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -2896,7 +2896,7 @@ def _einsum_routed_binary(
     billing_dtypes = (a.dtype, b.dtype)
     if isinstance(out, _np.ndarray):
         billing_dtypes += (out.dtype,)
-    resolved = _np.result_type(*billing_dtypes)
+    resolved = resolve_billing_dtype(billing_dtypes)
     complex_override = contraction_complex_override(info.accumulation, resolved)
     if out is not None:
         call_kwargs = {**call_kwargs, "out": _to_base_ndarray(out)}
@@ -3182,7 +3182,7 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
         canonical_subs = info.canonical_subscripts
         out_sym = info.output_symmetry  # scalar output — always None
         billing_dtypes = (a.dtype, b.dtype)
-        resolved = _np.result_type(*billing_dtypes)
+        resolved = resolve_billing_dtype(billing_dtypes)
         complex_override = contraction_complex_override(info.accumulation, resolved)
         with budget.deduct(
             "tensordot",
@@ -3291,7 +3291,7 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes: Any = 2) -> FlopscopeArray:
             cost = _symmetry_adjusted_cost(dense, output_shape, out_sym)
             canonical_subs = None
     billing_dtypes = (a.dtype, b.dtype)
-    resolved = _np.result_type(*billing_dtypes)
+    resolved = resolve_billing_dtype(billing_dtypes)
     # accumulation_for_billing is None for the oversized-symmetry / rank>52
     # branches above, which never reach _resolve_cost_and_output_symmetry and
     # so have no AccumulationCost to draw an exact override from; leave
@@ -3342,7 +3342,7 @@ def vdot(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     cost = info.accumulation.total
     canonical_subs = info.canonical_subscripts
     billing_dtypes = (a.dtype, b.dtype)
-    resolved = _np.result_type(*billing_dtypes)
+    resolved = resolve_billing_dtype(billing_dtypes)
     complex_override = contraction_complex_override(info.accumulation, resolved)
     with budget.deduct(
         "vdot",

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -23,6 +23,7 @@ from flopscope._dtype_billing import (
     mean_compute_dtype,
     reduction_billing_dtype,
     resolve_billing_dtype,
+    store_billing_dtypes,
     sum_accumulator_dtype,
     unary_float_loop_dtype,
 )
@@ -529,7 +530,7 @@ def _counted_unary(np_func, op_name: str):
         else:
             billing_dtypes = (x.dtype,)
             if isinstance(out, _np.ndarray):
-                billing_dtypes += (out.dtype,)
+                billing_dtypes += store_billing_dtypes(out)
         if op_name in _UNARY_FLOAT_LOOP_OPS:
             resolved = resolve_billing_dtype(billing_dtypes)
             if resolved is not None:
@@ -587,7 +588,7 @@ def _free_unary(np_func, op_name: str):
         if kwargs.get("dtype") is not None:
             billing_dtypes += (_np.dtype(kwargs["dtype"]),)
         if isinstance(out, _np.ndarray):
-            billing_dtypes += (out.dtype,)
+            billing_dtypes += store_billing_dtypes(out)
         with budget.deduct(
             op_name,
             flop_cost=0,
@@ -730,7 +731,7 @@ def _counted_binary(np_func, op_name: str):
         else:
             billing_dtypes = (billing_operand(x_orig, x), billing_operand(y_orig, y))
             if isinstance(out, _np.ndarray):
-                billing_dtypes += (out.dtype,)
+                billing_dtypes += store_billing_dtypes(out)
         if op_name in _BINARY_FLOAT_LOOP_OPS:
             resolved = resolve_billing_dtype(billing_dtypes)
             if resolved is not None:
@@ -1008,7 +1009,7 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
             ),
         )
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         f"{ufunc.__name__}.outer",
         flop_cost=cost,
@@ -1171,7 +1172,7 @@ def _counted_ufunc_reduceat(ufunc, a, indices, *, axis=0, out=None, **kwargs):
         ),
     )
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         f"{ufunc.__name__}.reduceat",
         flop_cost=cost,
@@ -1525,7 +1526,7 @@ def around(
     cost = pointwise_cost(a.shape, symmetry=symmetry)
     billing_dtypes: tuple = (a.dtype,)
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "around",
         flop_cost=cost,
@@ -1635,7 +1636,7 @@ def round(
     cost = pointwise_cost(a.shape, symmetry=symmetry)
     billing_dtypes: tuple = (a.dtype,)
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "round",
         flop_cost=cost,
@@ -1922,7 +1923,7 @@ def clip(
     _prepare_symmetric_out(out, symmetry)
     cost = _builtins.max(n_bounds, 1) * pointwise_cost(output_shape, symmetry=symmetry)
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "clip",
         flop_cost=cost,
@@ -2391,7 +2392,7 @@ def median(
     # otherwise -- the same rule as mean/var/std's compute dtype.
     billing_dtypes: tuple = (mean_compute_dtype(a.dtype),)
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "median",
         flop_cost=cost,
@@ -2463,7 +2464,7 @@ def nanmedian(
     # the input's own float precision otherwise.
     billing_dtypes: tuple = (mean_compute_dtype(a.dtype),)
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "nanmedian",
         flop_cost=cost,
@@ -2550,7 +2551,7 @@ def nanpercentile(
     # float32 `a`) still raises the bill to match numpy's actual widening.
     billing_dtypes: tuple = (mean_compute_dtype(a.dtype), billing_operand(q, q_arr))
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "nanpercentile",
         flop_cost=cost,
@@ -2627,7 +2628,7 @@ def nanquantile(
     out_stripped = _to_base_ndarray(out) if out is not None else None
     billing_dtypes: tuple = (a.dtype, billing_operand(q, q_arr))
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "nanquantile",
         flop_cost=cost,
@@ -2709,7 +2710,7 @@ def percentile(
     # bool `a` always computes in float64, regardless of q's own dtype.
     billing_dtypes: tuple = (mean_compute_dtype(a.dtype), billing_operand(q, q_arr))
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "percentile",
         flop_cost=cost,
@@ -2786,7 +2787,7 @@ def quantile(
     out_stripped = _to_base_ndarray(out) if out is not None else None
     billing_dtypes: tuple = (a.dtype, billing_operand(q, q_arr))
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "quantile",
         flop_cost=cost,
@@ -2895,7 +2896,7 @@ def _einsum_routed_binary(
     )
     billing_dtypes = (a.dtype, b.dtype)
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     resolved = resolve_billing_dtype(billing_dtypes)
     complex_override = contraction_complex_override(info.accumulation, resolved)
     if out is not None:
@@ -3063,7 +3064,7 @@ def outer(
         output_sym = _prepare_symmetric_out(out, output_sym)
     billing_dtypes: tuple = (a.dtype, b.dtype)
     if isinstance(out, _np.ndarray):
-        billing_dtypes += (out.dtype,)
+        billing_dtypes += store_billing_dtypes(out)
     with budget.deduct(
         "outer",
         flop_cost=cost,

--- a/tests/test_nonnumeric_out_billing.py
+++ b/tests/test_nonnumeric_out_billing.py
@@ -101,6 +101,22 @@ def test_numeric_widening_out_still_bills_wider():
     assert via_out == via_astype == 2000
 
 
+@pytest.mark.parametrize("other", ["float64", "complex128"])
+def test_mixed_nonnumeric_operand_still_bills_neutral(other):
+    """A non-numeric *operand* describes the arithmetic even when a numeric
+    operand is alongside it: numpy runs its object loop and returns object.
+    Filtering it out would price the object loop at the numeric rate -- and at
+    the complex factor too, for a complex partner."""
+    load_weights()
+    n = 8
+    o = np.array(np.random.default_rng(0).random((n, n)), dtype=object)
+    partner = np.ones((n, n), dtype=other)
+    both_object = _billed(lambda: fnp.multiply(o, o))
+    mixed = _billed(lambda: fnp.multiply(o, partner))
+    assert np.asarray(fnp.multiply(o, partner)).dtype == object
+    assert mixed == both_object
+
+
 def test_nonnumeric_operands_still_bill_neutral():
     """The 1.0 neutral rate is still correct when the operands themselves are
     non-numeric -- that arithmetic really is interpreted Python."""

--- a/tests/test_nonnumeric_out_billing.py
+++ b/tests/test_nonnumeric_out_billing.py
@@ -101,6 +101,18 @@ def test_numeric_widening_out_still_bills_wider():
     assert via_out == via_astype == 2000
 
 
+@pytest.mark.parametrize("op", ["divmod", "modf", "frexp"])
+def test_multi_output_nonnumeric_out_does_not_discount(op):
+    """The multi-output ufuncs fold each out= element's dtype separately."""
+    load_weights()
+    a = np.random.default_rng(0).random((32, 32)) + 1.0
+    args = (a, a + 1.0) if op == "divmod" else (a,)
+    fn = getattr(fnp, op)
+    honest = _billed(lambda: fn(*args))
+    outs = (np.empty((32, 32), dtype=object), np.empty((32, 32), dtype=object))
+    assert _billed(lambda: fn(*args, out=outs)) == honest
+
+
 @pytest.mark.parametrize("other", ["float64", "complex128"])
 def test_mixed_nonnumeric_operand_still_bills_neutral(other):
     """A non-numeric *operand* describes the arithmetic even when a numeric

--- a/tests/test_nonnumeric_out_billing.py
+++ b/tests/test_nonnumeric_out_billing.py
@@ -1,0 +1,111 @@
+"""A non-numeric ``out=`` must not launder the arithmetic's billing rate.
+
+The billed rate is meant to track the arithmetic a call actually performs.
+Non-numeric kinds (object, str, bytes, void, datetime, timedelta) bill at the
+neutral rate 1.0, which is right when they are the *operands* -- object
+arithmetic is interpreted Python, so there is no precision-packing to exploit
+and the wall time shows up as residual anyway.
+
+It is wrong when the non-numeric dtype arrives as ``out=``. Contractions
+compute in the operands' dtypes and only then store into ``out``, so the
+arithmetic stays native-speed while the stored kind drags the resolved billing
+dtype down -- dropping both the dtype rate and the complex factor. These tests
+pin that ``out=`` can only widen the bill, never launder it.
+"""
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+from flopscope._weights import load_weights
+
+N = 24
+
+
+def _billed(fn):
+    with f.BudgetContext(flop_budget=10**18, quiet=True) as b:
+        fn()
+        return b.flops_used
+
+
+def _complex_pair(n=N):
+    rng = np.random.default_rng(0)
+    a = (rng.random((n, n)) + 1j * rng.random((n, n))).astype(np.complex128)
+    b = (rng.random((n, n)) + 1j * rng.random((n, n))).astype(np.complex128)
+    return a, b
+
+
+def _real_pair(n=N):
+    rng = np.random.default_rng(1)
+    return rng.random((n, n)), rng.random((n, n))
+
+
+@pytest.mark.parametrize("out_dtype", ["object", "U64", "S64", "U32", "S16"])
+def test_einsum_nonnumeric_out_does_not_discount_complex(out_dtype):
+    load_weights()
+    a, b = _complex_pair()
+    honest = _billed(lambda: fnp.einsum("ij,jk->ik", a, b))
+    out = np.empty((N, N), dtype=out_dtype)
+    laundered = _billed(lambda: fnp.einsum("ij,jk->ik", a, b, out=out))
+    assert laundered == honest
+
+
+@pytest.mark.parametrize("out_dtype", ["object", "U64", "S64"])
+def test_einsum_nonnumeric_out_does_not_discount_float64(out_dtype):
+    load_weights()
+    a, b = _real_pair()
+    honest = _billed(lambda: fnp.einsum("ij,jk->ik", a, b))
+    out = np.empty((N, N), dtype=out_dtype)
+    assert _billed(lambda: fnp.einsum("ij,jk->ik", a, b, out=out)) == honest
+
+
+def test_contraction_helper_nonnumeric_out_does_not_discount():
+    """vecdot/matvec/vecmat route through _einsum_routed_binary, a second
+    place that folds out's dtype into the billing resolution."""
+    load_weights()
+    a, b = _complex_pair()
+    honest = _billed(lambda: fnp.vecdot(a, b))
+    out = np.empty(N, dtype=object)
+    assert _billed(lambda: fnp.vecdot(a, b, out=out)) == honest
+
+
+def test_ufunc_nonnumeric_out_does_not_discount():
+    load_weights()
+    a, b = _complex_pair()
+    honest = _billed(lambda: fnp.multiply(a, b))
+    out = np.empty((N, N), dtype=object)
+    assert (
+        _billed(
+            lambda: fnp.multiply(a, b, out=out)  # pyright: ignore[reportArgumentType]
+        )
+        >= honest
+    )
+
+
+# --- the widest-buffer doctrine for NUMERIC out= must survive -------------
+
+
+def test_numeric_widening_out_still_bills_wider():
+    """PR #151 doctrine: a wider out= bills the wider rate, at astype parity."""
+    load_weights()
+    a32 = np.ones(1000, dtype=np.float32)
+    via_out = _billed(
+        lambda: fnp.add(
+            a32,
+            0.0,
+            out=np.empty(1000, np.float64),  # pyright: ignore[reportArgumentType]
+        )
+    )
+    via_astype = _billed(lambda: fnp.astype(a32, np.float64))
+    assert via_out == via_astype == 2000
+
+
+def test_nonnumeric_operands_still_bill_neutral():
+    """The 1.0 neutral rate is still correct when the operands themselves are
+    non-numeric -- that arithmetic really is interpreted Python."""
+    load_weights()
+    o = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=object)
+    neutral = _billed(lambda: fnp.multiply(o, o))
+    same_shape_f64 = _billed(lambda: fnp.multiply(np.ones((2, 2)), np.ones((2, 2))))
+    assert neutral < same_shape_f64  # f64 rate is 2.0, object stays 1.0


### PR DESCRIPTION
## The problem

`np.result_type` resolves any mix containing a non-numeric kind *to* that kind, and non-numeric kinds bill at the neutral rate 1.0. Folding `out=` into that resolution let the **storage** dtype decide the price of the **arithmetic** — a contraction computes in its operands' dtypes and only then stores into `out`, so the loop kept running at full native speed while the bill collapsed.

Measured at N=512, complex128 `einsum('ij,jk->ik')`:

| | billed | backend |
|---|---:|---:|
| honest | 2,146,435,072 | 282 ms |
| `out=` object array | **268,173,312** | 275 ms |

An exact **8×** discount at the same wall time, with values recoverable to `8.6e-13` for a further `4*numel`. Two factors fell together: the dtype rate 2.0 → 1.0, and the complex factor 4.0078 → 1.0 once the resolved kind was no longer `'c'`. float64 operands gave 2× by the rate alone. Also reachable with `U32`/`U64`/`S16`/`S64` out dtypes.

It was reachable from the sandbox: the client's 14-dtype allowlist guards dtype *label objects*, but a raw string walks past it — `dtype=object` raises, `dtype='object'` does not.

## The fix

The resolution now drops non-numeric contributions whenever anything numeric participates.

Non-numeric **operands** are unaffected. With nothing numeric to keep, the filter is a no-op and object arithmetic still bills at 1.0 — which is right, because that really is interpreted Python and its wall time lands in residual. The filter can only ever *raise* a resolved rate, since non-numeric kinds carry the minimum, so no call gets cheaper as a result of this change.

Four contraction sites resolved the dtype with a direct `np.result_type` rather than `resolve_billing_dtype`, which is why fixing the rate alone left the complex cases still discounted — they were feeding the unfiltered dtype to `contraction_complex_override`. They now go through the shared resolver.

## Scope note

The comment justifying the 1.0 neutral rate reasoned about operands ("no precision-packing exploit is possible through them", "their wall time is covered by the residual-time penalty") and was being applied to `out=`, where neither premise holds. It now states which case it covers and why the other differs.

I did **not** reject non-numeric `out=` outright. Billing it correctly is the smaller change and keeps a legitimate numpy pattern working; the client boundary separately restricts what can cross the wire.

## Verification

New pins in `tests/test_nonnumeric_out_billing.py` cover einsum (complex and float64) across five out dtypes, the `_einsum_routed_binary` path via `vecdot`, and the ufunc path. Two controls guard against over-correcting: the PR #151 widest-buffer doctrine for **numeric** `out=` still holds at exact `astype` parity, and non-numeric **operands** still bill neutral.

- main suite: **5351 passed**, 5 pre-existing failures (docs/ops-json generation, identical on a clean tree)
- server: **275 passed**; client: **1370 passed**, 3 xfailed
- `ruff check` / `ruff format` / `pyright` clean

Original repro now bills 2,146,435,072 with and without `out=object` — ratio 1.00×.