### PR TITLE
perf(einsum): dispatch pairwise contraction steps through numpy's optimized path

### DIFF
--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -139,8 +139,15 @@ def _execute_pairwise(path_info, operands: list):
         # Pop operands in reverse sorted order (same as opt_einsum convention)
         inds = sorted(contract_inds, reverse=True)
         tensors = [ops.pop(i) for i in inds]
+        # Each step is a single pairwise contraction whose path was chosen
+        # (and billed) before execution, so numpy's per-call optimizer cannot
+        # change what is contracted — only route the step through
+        # tensordot/BLAS instead of the non-dispatching sum-of-products loop.
         result = _call_numpy(
-            _np.einsum, step.subscript, *[_to_base_ndarray(t) for t in tensors]
+            _np.einsum,
+            step.subscript,
+            *[_to_base_ndarray(t) for t in tensors],
+            optimize=True,
         )
         ops.append(result)
     return ops[0]

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -139,16 +139,19 @@ def _execute_pairwise(path_info, operands: list):
         # Pop operands in reverse sorted order (same as opt_einsum convention)
         inds = sorted(contract_inds, reverse=True)
         tensors = [ops.pop(i) for i in inds]
-        # Each step is a single pairwise contraction whose path was chosen
-        # (and billed) before execution, so numpy's per-call optimizer cannot
-        # change what is contracted — only route the step through
-        # tensordot/BLAS instead of the non-dispatching sum-of-products loop.
-        result = _call_numpy(
-            _np.einsum,
-            step.subscript,
-            *[_to_base_ndarray(t) for t in tensors],
-            optimize=True,
+        bases = [_to_base_ndarray(t) for t in tensors]
+        # The path was chosen (and billed) before execution, so optimized
+        # dispatch may only pick the step's kernel (tensordot/BLAS vs the
+        # non-dispatching sum-of-products loop), never re-plan it. That
+        # holds only for two-operand steps — numpy would decompose an
+        # n-ary step (from an explicit user path) into its own pairwise
+        # path — and only for non-object dtypes: the tensordot route
+        # changes object-element semantics (multiplication order and
+        # c_einsum's `0 + first_term` accumulator seeding).
+        use_optimize = len(bases) == 2 and all(
+            base.dtype != _np.object_ for base in bases
         )
+        result = _call_numpy(_np.einsum, step.subscript, *bases, optimize=use_optimize)
         ops.append(result)
     return ops[0]
 

--- a/tests/test_einsum_blas_dispatch.py
+++ b/tests/test_einsum_blas_dispatch.py
@@ -1,16 +1,20 @@
 """Einsum pairwise execution must go through numpy's optimized dispatch.
 
-``_execute_pairwise`` receives steps that are already single pairwise
-contractions — the path was chosen (and billed) before execution — so
-numpy's per-call optimizer cannot change *what* is contracted, only
-whether the step routes through tensordot/BLAS. These tests pin three
-properties of that arrangement:
+``_execute_pairwise`` receives steps whose path was chosen (and billed)
+before execution, so optimized dispatch may only change *how* a step
+executes, never what is contracted or what the caller observes beyond
+float summation order. These tests pin the properties of that
+arrangement:
 
-1. every executed step passes ``optimize=True`` to ``numpy.einsum``;
+1. every two-operand numeric step passes ``optimize=True`` to
+   ``numpy.einsum``, and runs at BLAS speed rather than at the speed of
+   numpy's non-dispatching sum-of-products loop;
 2. a multi-operand contraction still executes the billed path step by
-   step, never as one fused numpy call over all operands;
-3. a two-operand contraction runs at BLAS speed, not at the speed of
-   numpy's non-dispatching sum-of-products loop.
+   step, never as one fused numpy call over all operands — including a
+   user-pinned n-ary step, which numpy must not re-plan;
+3. object-dtype steps keep the plain-einsum element semantics
+   (multiplication order, accumulator seeding, scalar-output dtype);
+4. billed FLOPs and result values are unaffected by dispatch.
 """
 
 import time
@@ -19,6 +23,7 @@ import numpy as np
 
 import flopscope as flops
 import flopscope.numpy as fnp
+from flopscope._symmetric import SymmetricTensor
 
 
 def test_pairwise_steps_call_numpy_einsum_with_optimize(monkeypatch):
@@ -56,6 +61,113 @@ def test_pairwise_steps_call_numpy_einsum_with_optimize(monkeypatch):
 
     expected = np.einsum("ab,bc,cd,de->ae", *ops, optimize=True)
     np.testing.assert_allclose(np.asarray(result), expected, rtol=1e-12)
+
+
+def test_explicit_nary_path_step_executes_as_billed(monkeypatch):
+    # A caller may pin an n-ary step (all three operands contracted at
+    # once). numpy's optimizer would silently decompose it into its own
+    # pairwise path; execution must instead honor the step as billed.
+    rng = np.random.default_rng(2)
+    a = rng.standard_normal((6, 7))
+    b = rng.standard_normal((7, 8))
+    c = rng.standard_normal((8, 5))
+
+    real_einsum = np.einsum
+    calls = []
+
+    def spy(*args, **kwargs):
+        calls.append((len(args) - 1, kwargs.get("optimize", False)))
+        return real_einsum(*args, **kwargs)
+
+    monkeypatch.setattr(np, "einsum", spy)
+    with flops.BudgetContext(flop_budget=10**16, quiet=True):
+        result = fnp.einsum("ij,jk,kl->il", a, b, c, optimize=[(0, 1, 2)])
+
+    assert calls == [(3, False)]
+    np.testing.assert_allclose(
+        np.asarray(result),
+        real_einsum("ij,jk,kl->il", a, b, c),
+        rtol=1e-12,
+        atol=1e-10,
+    )
+
+
+class _NC:
+    """Object payload that records evaluation order (non-commutative)."""
+
+    def __init__(self, tag):
+        self.tag = tag
+
+    def __mul__(self, other):
+        return _NC(f"({self.tag}*{other.tag})")
+
+    def __add__(self, other):
+        return _NC(f"({self.tag}+{other.tag})")
+
+    def __radd__(self, other):
+        return _NC(f"({other}+{self.tag})")
+
+
+def test_object_dtype_steps_keep_plain_einsum_element_semantics(monkeypatch):
+    # The optimized route changes object-element semantics: tensordot
+    # flips per-term multiplication order and drops c_einsum's
+    # `0 + first_term` accumulator seeding. Object steps must stay on
+    # the plain path: the spy pins the dispatch, the `(0+` prefix on
+    # every accumulated element pins c_einsum's seeding semantics
+    # (the tensordot route never seeds with 0).
+    A = np.empty((2, 3), dtype=object)
+    B = np.empty((3, 2), dtype=object)
+    for i in range(2):
+        for j in range(3):
+            A[i, j] = _NC(f"a{i}{j}")
+    for i in range(3):
+        for j in range(2):
+            B[i, j] = _NC(f"b{i}{j}")
+
+    real_einsum = np.einsum
+    calls = []
+
+    def spy(*args, **kwargs):
+        calls.append(kwargs.get("optimize", False))
+        return real_einsum(*args, **kwargs)
+
+    monkeypatch.setattr(np, "einsum", spy)
+    with flops.BudgetContext(flop_budget=10**16, quiet=True):
+        got = fnp.einsum("ij,jk->ik", A, B)
+
+    assert calls == [False]
+    got = np.asarray(got)
+    assert got.dtype == np.object_
+    for element in got.flat:
+        # e.g. '(((0+(b00*a00))+(b10*a01))+(b20*a02))' — the '(0+' seed
+        # is only ever produced by c_einsum calling __radd__ with 0.
+        assert "(0+" in element.tag
+
+
+def test_object_scalar_output_dtype_matches_plain_einsum():
+    # Plain np.einsum returns a raw Python scalar for 'i,i->' on object
+    # input, which asarray coerces to int64; the optimized route would
+    # return a 0-d object array instead. Pin the plain behavior.
+    obj = np.array([2, 3, 4], dtype=object)
+    with flops.BudgetContext(flop_budget=10**16, quiet=True):
+        result = fnp.einsum("i,i->", obj, obj)
+    arr = np.asarray(result)
+    assert arr.dtype == np.int64
+    assert arr == 29
+
+
+def test_nonfinite_result_with_declared_symmetry_is_never_stamped():
+    # Symmetry validation skips non-finite results and must then refuse
+    # to stamp: an unverifiable claim never becomes a SymmetricTensor
+    # (which would grant downstream discounts). Summation order may
+    # decide *whether* an overflow-boundary result is finite, so this
+    # invariant is what keeps that dispatch-dependent — but always
+    # safe — rather than exploitable.
+    big = np.full((2, 8), 9.5e153)
+    with flops.BudgetContext(flop_budget=10**16, quiet=True):
+        result = fnp.einsum("ij,kj->ik", big, big, symmetry=(0, 1))
+    assert not np.all(np.isfinite(np.asarray(result)))
+    assert not isinstance(result, SymmetricTensor)
 
 
 def test_two_operand_einsum_reaches_blas_speed():

--- a/tests/test_einsum_blas_dispatch.py
+++ b/tests/test_einsum_blas_dispatch.py
@@ -1,0 +1,180 @@
+"""Einsum pairwise execution must go through numpy's optimized dispatch.
+
+``_execute_pairwise`` receives steps that are already single pairwise
+contractions — the path was chosen (and billed) before execution — so
+numpy's per-call optimizer cannot change *what* is contracted, only
+whether the step routes through tensordot/BLAS. These tests pin three
+properties of that arrangement:
+
+1. every executed step passes ``optimize=True`` to ``numpy.einsum``;
+2. a multi-operand contraction still executes the billed path step by
+   step, never as one fused numpy call over all operands;
+3. a two-operand contraction runs at BLAS speed, not at the speed of
+   numpy's non-dispatching sum-of-products loop.
+"""
+
+import time
+
+import numpy as np
+
+import flopscope as flops
+import flopscope.numpy as fnp
+
+
+def test_pairwise_steps_call_numpy_einsum_with_optimize(monkeypatch):
+    rng = np.random.default_rng(0)
+    ops = [
+        rng.standard_normal(shape) for shape in [(24, 28), (28, 20), (20, 36), (36, 16)]
+    ]
+    with flops.BudgetContext(flop_budget=10**16, quiet=True):
+        _, info = fnp.einsum_path("ab,bc,cd,de->ae", *ops)
+    expected_steps = [step.subscript for step in info.steps]
+    assert len(expected_steps) == 3
+
+    real_einsum = np.einsum
+    calls = []
+
+    def spy(*args, **kwargs):
+        calls.append(
+            (
+                args[0],
+                len(args) - 1,
+                kwargs.get("optimize", "MISSING"),
+            )
+        )
+        return real_einsum(*args, **kwargs)
+
+    monkeypatch.setattr(np, "einsum", spy)
+    with flops.BudgetContext(flop_budget=10**16, quiet=True):
+        result = fnp.einsum("ab,bc,cd,de->ae", *ops)
+
+    # The billed path is executed step by step, two operands at a time.
+    assert [call[0] for call in calls] == expected_steps
+    assert all(call[1] == 2 for call in calls)
+    # Each step goes through numpy's optimized (BLAS-capable) dispatch.
+    assert all(call[2] is True for call in calls)
+
+    expected = np.einsum("ab,bc,cd,de->ae", *ops, optimize=True)
+    np.testing.assert_allclose(np.asarray(result), expected, rtol=1e-12)
+
+
+def test_two_operand_einsum_reaches_blas_speed():
+    N = 896
+    rng = np.random.default_rng(1)
+    A = rng.random((N, N), dtype=np.float32)
+    B = rng.random((N, N), dtype=np.float32)
+
+    # Reference: numpy's non-dispatching loop on this machine, so the
+    # comparison is relative and survives slow or busy CI hosts.
+    plain = min(_timed(lambda: np.einsum("ij,jk->ik", A, B)) for _ in range(3))
+
+    # Warm the path cache so the timed runs measure execution only.
+    with flops.BudgetContext(flop_budget=10**18, quiet=True):
+        fnp.einsum("ij,jk->ik", A, B)
+
+    dispatched = []
+    for _ in range(3):
+        with flops.BudgetContext(flop_budget=10**18, quiet=True) as bc:
+            fnp.einsum("ij,jk->ik", A, B)
+        dispatched.append(bc.flopscope_backend_time_s)
+
+    assert min(dispatched) < plain / 3, (
+        f"fnp.einsum backend time {min(dispatched) * 1e3:.2f}ms is not "
+        f"meaningfully faster than numpy's non-BLAS loop "
+        f"({plain * 1e3:.2f}ms); the pairwise step is not dispatching "
+        f"through BLAS"
+    )
+
+
+def _timed(thunk):
+    t0 = time.perf_counter()
+    thunk()
+    return time.perf_counter() - t0
+
+
+def _bill(thunk):
+    with flops.BudgetContext(flop_budget=10**16, quiet=True) as bc:
+        thunk()
+    return bc.flops_used
+
+
+def test_billed_flops_unaffected_by_execution_dispatch():
+    # Regression pins: how a step executes (BLAS vs numpy's loop) must never
+    # move the analytical bill. All values predate the optimize=True dispatch.
+    rng = np.random.default_rng(42)
+    a = rng.standard_normal((64, 64))
+    b = rng.standard_normal((64, 64))
+    c = rng.standard_normal((48, 40))
+    d = rng.standard_normal((40, 56))
+    e = rng.standard_normal((56, 32))
+    ab = rng.standard_normal((4, 32, 32))
+    bb = rng.standard_normal((4, 32, 32))
+    s = rng.standard_normal((40, 40))
+    s = s + s.T
+    v = rng.standard_normal((40, 24))
+    p1 = rng.standard_normal((24, 28))
+    p2 = rng.standard_normal((28, 20))
+    p3 = rng.standard_normal((20, 36))
+    p4 = rng.standard_normal((36, 16))
+
+    assert _bill(lambda: fnp.einsum("ij,jk->ik", a, b)) == 520_192
+    assert _bill(lambda: fnp.einsum("ij,jk,kl->il", c, d, e)) == 263_424
+    assert (
+        _bill(lambda: fnp.einsum("ij,jk,kl->il", c, d, e, optimize=[(0, 1), (0, 1)]))
+        == 263_424
+    )
+    assert _bill(lambda: fnp.einsum("bij,bjk->bik", ab, bb)) == 258_048
+    assert (
+        _bill(
+            lambda: fnp.einsum("ij,jk->ik", flops.as_symmetric(s, symmetry=(0, 1)), v)
+        )
+        == 87_039
+    )
+    assert _bill(lambda: fnp.einsum("ab,bc,cd,de->ae", p1, p2, p3, p4)) == 61_312
+
+
+def test_results_match_numpy_reference_within_tolerance():
+    rng = np.random.default_rng(5)
+    f32 = [
+        rng.standard_normal((30, 40, 20)).astype(np.float32),
+        rng.standard_normal((40, 20, 24)).astype(np.float32),
+    ]
+    c128 = [
+        rng.standard_normal((48, 56)) + 1j * rng.standard_normal((48, 56)),
+        rng.standard_normal((56, 32)) + 1j * rng.standard_normal((56, 32)),
+    ]
+    cases = [
+        (
+            "ij,jk->ik",
+            [rng.standard_normal((80, 96)), rng.standard_normal((96, 64))],
+            1e-12,
+            1e-10,
+        ),
+        (
+            "bij,bjk->bik",
+            [rng.standard_normal((4, 48, 56)), rng.standard_normal((4, 56, 40))],
+            1e-12,
+            1e-10,
+        ),
+        (
+            "ij,jk,kl->il",
+            [
+                rng.standard_normal((32, 48)),
+                rng.standard_normal((48, 40)),
+                rng.standard_normal((40, 24)),
+            ],
+            1e-12,
+            1e-10,
+        ),
+        ("ijk,jkl->il", f32, 1e-5, 1e-4),
+        ("ij,jk->ik", c128, 1e-12, 1e-10),
+    ]
+    for subscripts, operands, rtol, atol in cases:
+        with flops.BudgetContext(flop_budget=10**16, quiet=True):
+            got = fnp.einsum(subscripts, *operands)
+        np.testing.assert_allclose(
+            np.asarray(got),
+            np.einsum(subscripts, *operands),
+            rtol=rtol,
+            atol=atol,
+        )


### PR DESCRIPTION
## What

`_execute_pairwise` now passes `optimize=True` to the per-step `np.einsum` call for **two-operand, non-object-dtype steps**. Without it, numpy executes every contraction step with its non-dispatching sum-of-products loop; with it, numpy routes GEMM-shaped steps through `tensordot` → BLAS.

Effect at N=1500 float32 `ij,jk->ik`: contraction backend time drops from ~208 ms to ~4.5 ms (~47x). The gap grows with size and dtype.

The gate exists because optimized dispatch must only pick a step's kernel, never re-plan or reinterpret it:

- **Two-operand steps only**: an n-ary step from an explicit user path (e.g. `optimize=[(0, 1, 2)]`) would be decomposed by numpy into its own pairwise path, executing something other than the step that was billed and reported. Those steps stay on the plain path. (Also addresses the Codex review note.)
- **Non-object dtypes only**: the tensordot route changes object-element semantics — per-term multiplication order flips and c_einsum's `0 + first_term` accumulator seeding disappears — and turns the raw-Python-scalar result of scalar-output subscripts (`'i,i->'`) into a 0-d object array. Object steps stay on the plain path, so object-dtype behavior is unchanged.

## Why this cannot move a bill

The contraction path is chosen by opt_einsum and billed **before** execution; each step handed to `_execute_pairwise` is a single contraction. For a two-operand step, numpy's per-call optimizer has no path decision left to make — it can only pick the execution kernel for the step it was given. Multi-operand fusion into one `np.einsum` call is explicitly *not* done; tests pin step-by-step execution of the billed path, including user-pinned n-ary steps.

Verified empirically: billed FLOPs are integer-identical before/after across 2-operand, 3-operand, batched, symmetric-operand (discount), explicit-path, trace, and mixed-dtype cases, including downstream ops consuming einsum results — plus a fuzz sweep of several hundred cases comparing bills under old and new execution in-process.

## Numerical tolerance (recorded per acceptance criteria)

BLAS changes float summation order, so results are not guaranteed bit-identical to previous builds:

- On this machine (macOS/arm64, Accelerate): real-dtype results (float32/float64, incl. batched and 3+-operand chains) measured **bitwise identical** to pre-change output at moderate-to-large sizes; tiny contractions (N=4/8) and complex128 differ with max relative deviation ~1e-15 and ~7e-15 respectively.
- Documented tolerance vs `np.einsum` reference, enforced by test: rtol=1e-12/atol=1e-10 for float64 and complex128; rtol=1e-5/atol=1e-4 for float32.
- Exact dtypes (bool/int/uint, incl. deliberate int8/uint8 wraparound and mixed promotions) are bit-identical with identical result dtypes; object dtype is excluded from optimized dispatch entirely, so its semantics are unchanged.
- float16 chains land *closer* to the float64 ground truth than before (the BLAS route accumulates at higher intermediate precision).
- Linux/OpenBLAS spot-check (numpy 2.2.6 wheel, scipy-openblas 0.3.29, aarch64 and x86_64 via Docker): `X·Xᵀ` gram outputs were bitwise symmetric in all 60 probes per arch (declared-symmetry validation cannot flip on non-finite-free data); plain-vs-optimized deviation was 0.0 on aarch64 and ≤1.9e-7 scaled (float32 ulp) on x86_64. Caveat: emulated x86_64 may select different OpenBLAS kernels than the deployment hardware.

## New tests (`tests/test_einsum_blas_dispatch.py`)

1. every executed two-operand numeric step passes `optimize=True` to `numpy.einsum` (spy);
2. a 4-operand contraction still executes the billed path step by step, never as one fused numpy call;
3. an explicit n-ary step (`optimize=[(0, 1, 2)]`) executes as one plain three-operand call — numpy must not re-plan it;
4. object-dtype steps stay on the plain path and keep c_einsum's accumulator-seeding semantics;
5. object scalar-output subscripts keep their legacy result dtype;
6. a non-finite result under declared symmetry is returned unstamped (validation skip never grants a symmetry tag);
7. two-operand einsum runs at BLAS speed, not sum-of-products speed (relative timing, robust to slow hosts);
8. billing pins for 2-op / 3-op / explicit-path / batched / symmetric-discount / 4-op (values captured pre-change);
9. results match the numpy reference within the tolerances above.

## Behavioral notes (measured, judged acceptable)

- **Result memory layout can change** for some subscripts: tensordot returns BLAS-layout arrays, so e.g. `ij,jk,kl->il` flipped C→F contiguous and `ji,kj->ik` F→C. Values bitwise identical, bills unchanged; numpy documents no contiguity guarantee for einsum results, and `matmul` already returns BLAS-layout output. Visible only to code inspecting `.flags`/strides.
- **Tiny-contraction per-call overhead**: numpy's per-call parse/plan roughly doubles tiny-case wall time (worst measured 2.62x, 20µs → 52µs on a 3-op chain at N=16). Crossover is N≈50; above it the win grows fast (N=256: 21.8x faster, N=512: 41.7x). The overhead lands in the backend-time bucket, which is not billed.
- **Peak transient memory** can rise for steps whose contraction axes tensordot cannot view-reshape (it materializes operand transposes before BLAS): measured 0.25 MiB → 11.2 MiB peak on 5.6 MiB operands for `'kij,jlk->il'`; GEMM-friendly layouts show no increase. Relevant to memory-capped environments.
- **Overflow-boundary values**: since partial-sum order changes, inputs whose intermediate sums straddle `inf` can produce a different inf/nan pattern than before. Symmetry validation already skips non-finite results and never stamps them (now pinned by test), so this only affects the values themselves.

## Verification

- Full suite: 5364 passed; the 5 pre-existing docs/ops-json failures and 3 scipy import errors are byte-identical to a clean tree before/after.
- `flopscope-server/tests`: 275 passed, 1 skipped.
- `flopscope-client/tests`: 1354 passed; 14 pre-existing local-server-startup errors identical on clean tree.
- `ruff check`, `ruff format --check`, `pyright src/flopscope tests`: diagnostics byte-identical to clean tree.
- Six-lens verification fan-out (dtype-preservation sweep, subscript-semantics fuzz, in-process billing A/B including downstream ops, `out=`/`symmetry=` interaction, small-case overhead, code review): billing integer-identical old-vs-new in every A/B case; behavioral divergences found are either fixed by the dispatch gate (object dtype, n-ary steps) or documented above.
