### PR TITLE
fix(client): scope the dispatch accumulator to flopscope's own code

### DIFF
--- a/flopscope-client/src/flopscope/_dispatch.py
+++ b/flopscope-client/src/flopscope/_dispatch.py
@@ -44,12 +44,6 @@ from contextlib import contextmanager
 _total_dispatch_ns: int = 0
 _participant_spans: int = 0
 
-# id(module.__dict__) for every imported flopscope module. Rebuilt when
-# sys.modules grows, so lazily-imported submodules are picked up; recomputing it
-# per call would put an O(len(sys.modules)) scan on the hot path.
-_internal_globals: frozenset[int] = frozenset()
-_modules_seen: int = -1
-
 
 def _now_ns() -> int:
     """Monotonic nanosecond clock (indirected so tests can fake it)."""
@@ -78,21 +72,28 @@ def reset_dispatch() -> None:
     _participant_spans = 0
 
 
-def _refresh_internal_globals() -> frozenset[int]:
-    global _internal_globals, _modules_seen
-    if len(sys.modules) != _modules_seen:
-        _modules_seen = len(sys.modules)
-        _internal_globals = frozenset(
-            id(mod.__dict__)
-            for name, mod in list(sys.modules.items())
-            if (name == "flopscope" or name.startswith("flopscope."))
-            and getattr(mod, "__dict__", None) is not None
-        )
-    return _internal_globals
-
-
 def _globals_are_internal(namespace: object) -> bool:
-    return id(namespace) in _refresh_internal_globals()
+    """Whether *namespace* is the live ``__dict__`` of a flopscope module.
+
+    Resolved against ``sys.modules`` on every call rather than from a cached set
+    of ids: a submodule can be evicted and re-imported, which replaces the module
+    dict, and any cache keyed on a cheap sentinel (module count, say) would keep
+    the stale id and silently stop counting that module's spans.
+
+    Still O(1) — the name in the namespace picks the candidate, and the identity
+    comparison against the live module's ``__dict__`` is what decides. The name
+    alone proves nothing (it is an ordinary dict key), so a namespace claiming to
+    be flopscope's fails unless it genuinely is the module's own dict.
+    """
+    if not isinstance(namespace, dict):
+        return False
+    name = namespace.get("__name__")
+    if not isinstance(name, str):
+        return False
+    if name != "flopscope" and not name.startswith("flopscope."):
+        return False
+    module = sys.modules.get(name)
+    return module is not None and getattr(module, "__dict__", None) is namespace
 
 
 def _callable_is_internal(fn: object) -> bool:

--- a/flopscope-client/src/flopscope/_dispatch.py
+++ b/flopscope-client/src/flopscope/_dispatch.py
@@ -116,6 +116,14 @@ def _count_participant_span() -> None:
     _participant_spans += 1
 
 
+def _caller_is_internal(depth: int) -> bool:
+    """Whether the frame *depth* levels above this one is flopscope's own code."""
+    try:
+        return _globals_are_internal(sys._getframe(depth).f_globals)
+    except (ValueError, AttributeError):  # pragma: no cover - no Python frame
+        return False
+
+
 @contextmanager
 def _null_span():
     """Run the body without touching the accumulator."""
@@ -124,8 +132,18 @@ def _null_span():
 
 @contextmanager
 def _counted_span():
-    """Bracket one full op dispatch; add only this span's own remainder."""
+    """Bracket one full op dispatch; add only this span's own remainder.
+
+    Carries the same caller check as ``dispatch_span``. It is the primitive that
+    actually mutates the accumulator, so leaving it unguarded would place the
+    check on the wrappers rather than on the thing being protected, and a span
+    opened here from outside would both count and leave the span tally at zero.
+    """
     global _total_dispatch_ns
+    if not _caller_is_internal(depth=3):  # caller -> contextmanager -> here
+        _count_participant_span()
+        yield
+        return
     t0 = _now_ns()
     baseline = _total_dispatch_ns
     try:
@@ -144,11 +162,7 @@ def dispatch_span():
     Not a generator: the provenance check must read the CALLER's frame, and by
     the time a ``@contextmanager`` body runs the caller is contextlib.
     """
-    try:
-        caller_globals = sys._getframe(1).f_globals
-    except (ValueError, AttributeError):  # pragma: no cover - no Python frame
-        caller_globals = None
-    if caller_globals is not None and _globals_are_internal(caller_globals):
+    if _caller_is_internal(depth=2):  # our caller, not us
         return _counted_span()
     _count_participant_span()
     return _null_span()

--- a/flopscope-client/src/flopscope/_dispatch.py
+++ b/flopscope-client/src/flopscope/_dispatch.py
@@ -11,15 +11,44 @@ Nesting is handled with a baseline/delta trick (ported from the in-process
 (``wall - inner_already_counted``), so a span that contains nested spans counts
 each op's wall exactly once. Single participant process, single-threaded (the
 server allows one session at a time), so a module-level counter is safe.
+
+Scope
+-----
+The accumulator measures flopscope's own dispatch cost, so only flopscope's own
+code contributes to it. A span opened from outside this package runs normally
+but adds nothing, and is counted by ``participant_span_count()``.
+
+This keeps the timing split well-defined: the accumulator is subtracted from
+wall time to separate framework cost from caller cost, so admitting spans around
+non-flopscope code would make that split meaningless. Restricting the API
+surface is not sufficient on its own — module-level state stays reachable
+through ordinary imports — so the invariant is enforced where the span is
+opened.
+
+Provenance is taken from the *defining module of the wrapped callable*, not from
+the immediate caller: ``timed_dispatch`` opens its span from inside this module,
+so the immediate caller is always internal and carries no information.
+
+The test is IDENTITY of the callable's ``__globals__`` against the live
+flopscope module namespaces. ``__module__`` and ``__code__.co_filename`` are
+ordinary writable attributes and so cannot carry this invariant.
 """
 
 from __future__ import annotations
 
 import functools
+import sys
 import time
 from contextlib import contextmanager
 
 _total_dispatch_ns: int = 0
+_participant_spans: int = 0
+
+# id(module.__dict__) for every imported flopscope module. Rebuilt when
+# sys.modules grows, so lazily-imported submodules are picked up; recomputing it
+# per call would put an O(len(sys.modules)) scan on the hot path.
+_internal_globals: frozenset[int] = frozenset()
+_modules_seen: int = -1
 
 
 def _now_ns() -> int:
@@ -32,14 +61,69 @@ def total_dispatch_ns() -> int:
     return _total_dispatch_ns
 
 
+def participant_span_count() -> int:
+    """Spans opened from outside flopscope, which contributed nothing.
+
+    Expected to be zero: callers have no reason to open a dispatch span, since
+    the accumulator exists to measure flopscope's own cost. Exposed so an
+    embedding harness can assert that invariant held.
+    """
+    return _participant_spans
+
+
 def reset_dispatch() -> None:
-    """Reset the accumulator (tests only)."""
-    global _total_dispatch_ns
+    """Reset the accumulators (tests only)."""
+    global _total_dispatch_ns, _participant_spans
     _total_dispatch_ns = 0
+    _participant_spans = 0
+
+
+def _refresh_internal_globals() -> frozenset[int]:
+    global _internal_globals, _modules_seen
+    if len(sys.modules) != _modules_seen:
+        _modules_seen = len(sys.modules)
+        _internal_globals = frozenset(
+            id(mod.__dict__)
+            for name, mod in list(sys.modules.items())
+            if (name == "flopscope" or name.startswith("flopscope."))
+            and getattr(mod, "__dict__", None) is not None
+        )
+    return _internal_globals
+
+
+def _globals_are_internal(namespace: object) -> bool:
+    return id(namespace) in _refresh_internal_globals()
+
+
+def _callable_is_internal(fn: object) -> bool:
+    """Whether *fn* was defined inside the flopscope package."""
+    # Unwrap the shapes flopscope actually decorates: bound/unbound methods and
+    # functools.partial. Anything with no __globals__ (C builtins, arbitrary
+    # objects with __call__) is treated as external, which is the safe default.
+    seen = 0
+    while seen < 10:
+        seen += 1
+        inner = getattr(fn, "__func__", None) or getattr(fn, "func", None)
+        if inner is None or inner is fn:
+            break
+        fn = inner
+    namespace = getattr(fn, "__globals__", None)
+    return namespace is not None and _globals_are_internal(namespace)
+
+
+def _count_participant_span() -> None:
+    global _participant_spans
+    _participant_spans += 1
 
 
 @contextmanager
-def dispatch_span():
+def _null_span():
+    """Run the body without touching the accumulator."""
+    yield
+
+
+@contextmanager
+def _counted_span():
     """Bracket one full op dispatch; add only this span's own remainder."""
     global _total_dispatch_ns
     t0 = _now_ns()
@@ -54,12 +138,36 @@ def dispatch_span():
         _total_dispatch_ns += max(0, wall - inner)
 
 
+def dispatch_span():
+    """Bracket one full op dispatch, if the caller is flopscope itself.
+
+    Not a generator: the provenance check must read the CALLER's frame, and by
+    the time a ``@contextmanager`` body runs the caller is contextlib.
+    """
+    try:
+        caller_globals = sys._getframe(1).f_globals
+    except (ValueError, AttributeError):  # pragma: no cover - no Python frame
+        caller_globals = None
+    if caller_globals is not None and _globals_are_internal(caller_globals):
+        return _counted_span()
+    _count_participant_span()
+    return _null_span()
+
+
 def timed_dispatch(fn):
-    """Decorator: time the full dispatch of *fn* into the accumulator."""
+    """Decorator: time the full dispatch of *fn* into the accumulator.
+
+    For a callable defined outside flopscope this returns *fn* unchanged and
+    records the span, so the wrapper is a no-op rather than an error: behaviour
+    and return values are untouched.
+    """
+    if not _callable_is_internal(fn):
+        _count_participant_span()
+        return fn
 
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
-        with dispatch_span():
+        with _counted_span():
             return fn(*args, **kwargs)
 
     return wrapped

--- a/flopscope-client/src/flopscope/_dispatch.py
+++ b/flopscope-client/src/flopscope/_dispatch.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import functools
 import sys
 import time
+import types
 from contextlib import contextmanager
 
 _total_dispatch_ns: int = 0
@@ -97,17 +98,24 @@ def _globals_are_internal(namespace: object) -> bool:
 
 
 def _callable_is_internal(fn: object) -> bool:
-    """Whether *fn* was defined inside the flopscope package."""
-    # Unwrap the shapes flopscope actually decorates: bound/unbound methods and
-    # functools.partial. Anything with no __globals__ (C builtins, arbitrary
-    # objects with __call__) is treated as external, which is the safe default.
-    seen = 0
-    while seen < 10:
-        seen += 1
-        inner = getattr(fn, "__func__", None) or getattr(fn, "func", None)
-        if inner is None or inner is fn:
+    """Whether *fn* was defined inside the flopscope package.
+
+    Unwrapping is by TYPE, not by attribute name. Following any object that
+    happens to expose ``func``/``__func__`` would hand the decision to the object
+    being judged: ``.func`` is ordinary metadata on wrapper and decorator objects,
+    so an external callable could point it at a flopscope function and be
+    classified internal.
+
+    Anything without ``__globals__`` after unwrapping (C builtins, arbitrary
+    objects with ``__call__``) is external, which is the safe default.
+    """
+    for _ in range(10):  # bounded: partial(partial(...)) nests, but not forever
+        if isinstance(fn, types.MethodType):
+            fn = fn.__func__
+        elif isinstance(fn, functools.partial):
+            fn = fn.func
+        else:
             break
-        fn = inner
     namespace = getattr(fn, "__globals__", None)
     return namespace is not None and _globals_are_internal(namespace)
 

--- a/flopscope-client/tests/test_dispatch.py
+++ b/flopscope-client/tests/test_dispatch.py
@@ -1,9 +1,10 @@
 """Unit tests for the dispatch-timing accumulator (deterministic fake clock).
 
-The accumulation arithmetic lives in ``_counted_span``; ``dispatch_span`` is the
-entry point that decides from the caller whether a span counts at all. These
-tests drive ``_counted_span`` so the baseline/delta maths is covered independently
-of where the test module happens to live. Which callers count is covered in
+A span only contributes when opened by flopscope's own code, and a test module is
+by definition not that. The ``_internal_caller`` fixture below states "treat this
+call as internal" explicitly, so these tests cover the baseline/delta arithmetic
+without silently depending on where the test file lives. Which callers actually
+count is covered separately in
 ``tests/client_compat/unit/test_dispatch_provenance.py``.
 """
 
@@ -18,7 +19,17 @@ def _fake_clock(values):
     return lambda: next(it)
 
 
-def test_single_span_adds_its_wall(monkeypatch):
+@pytest.fixture
+def _internal_caller(monkeypatch):
+    """Exercise the counting path from a test module.
+
+    The arithmetic under test is independent of provenance; this fixture makes
+    that explicit rather than leaving the tests sensitive to their own location.
+    """
+    monkeypatch.setattr(d, "_caller_is_internal", lambda depth: True)
+
+
+def test_single_span_adds_its_wall(monkeypatch, _internal_caller):
     monkeypatch.setattr(d, "_now_ns", _fake_clock([100, 350]))  # t0=100, t1=350
     d.reset_dispatch()
     with d._counted_span():
@@ -26,7 +37,7 @@ def test_single_span_adds_its_wall(monkeypatch):
     assert d.total_dispatch_ns() == 250
 
 
-def test_nested_spans_count_wall_once(monkeypatch):
+def test_nested_spans_count_wall_once(monkeypatch, _internal_caller):
     # outer t0=0 ; inner t0=100,t1=400 (=300) ; outer t1=500 (=500 wall)
     monkeypatch.setattr(d, "_now_ns", _fake_clock([0, 100, 400, 500]))
     d.reset_dispatch()
@@ -38,7 +49,7 @@ def test_nested_spans_count_wall_once(monkeypatch):
     assert d.total_dispatch_ns() == 500
 
 
-def test_delta_helpers(monkeypatch):
+def test_delta_helpers(monkeypatch, _internal_caller):
     monkeypatch.setattr(d, "_now_ns", _fake_clock([0, 40]))
     d.reset_dispatch()
     base = d.total_dispatch_ns()
@@ -47,7 +58,7 @@ def test_delta_helpers(monkeypatch):
     assert d.total_dispatch_ns() - base == 40
 
 
-def test_accumulates_even_on_exception(monkeypatch):
+def test_accumulates_even_on_exception(monkeypatch, _internal_caller):
     monkeypatch.setattr(d, "_now_ns", _fake_clock([0, 70]))
     d.reset_dispatch()
     with pytest.raises(ValueError):

--- a/flopscope-client/tests/test_dispatch.py
+++ b/flopscope-client/tests/test_dispatch.py
@@ -1,4 +1,11 @@
-"""Unit tests for the dispatch-timing accumulator (deterministic fake clock)."""
+"""Unit tests for the dispatch-timing accumulator (deterministic fake clock).
+
+The accumulation arithmetic lives in ``_counted_span``; ``dispatch_span`` is the
+entry point that decides from the caller whether a span counts at all. These
+tests drive ``_counted_span`` so the baseline/delta maths is covered independently
+of where the test module happens to live. Which callers count is covered in
+``tests/client_compat/unit/test_dispatch_provenance.py``.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +21,7 @@ def _fake_clock(values):
 def test_single_span_adds_its_wall(monkeypatch):
     monkeypatch.setattr(d, "_now_ns", _fake_clock([100, 350]))  # t0=100, t1=350
     d.reset_dispatch()
-    with d.dispatch_span():
+    with d._counted_span():
         pass
     assert d.total_dispatch_ns() == 250
 
@@ -23,31 +30,19 @@ def test_nested_spans_count_wall_once(monkeypatch):
     # outer t0=0 ; inner t0=100,t1=400 (=300) ; outer t1=500 (=500 wall)
     monkeypatch.setattr(d, "_now_ns", _fake_clock([0, 100, 400, 500]))
     d.reset_dispatch()
-    with d.dispatch_span():  # outer reads now()->0
-        with d.dispatch_span():  # inner reads now()->100, exit now()->400
+    with d._counted_span():  # outer reads now()->0
+        with d._counted_span():  # inner reads now()->100, exit now()->400
             pass
         # outer exit reads now()->500
     # inner added 300; outer adds max(0, 500 - 300) = 200; total = 500 (counted once)
     assert d.total_dispatch_ns() == 500
 
 
-def test_timed_dispatch_decorator(monkeypatch):
-    monkeypatch.setattr(d, "_now_ns", _fake_clock([10, 60]))
-    d.reset_dispatch()
-
-    @d.timed_dispatch
-    def op():
-        return 42
-
-    assert op() == 42
-    assert d.total_dispatch_ns() == 50
-
-
 def test_delta_helpers(monkeypatch):
     monkeypatch.setattr(d, "_now_ns", _fake_clock([0, 40]))
     d.reset_dispatch()
     base = d.total_dispatch_ns()
-    with d.dispatch_span():
+    with d._counted_span():
         pass
     assert d.total_dispatch_ns() - base == 40
 
@@ -56,6 +51,34 @@ def test_accumulates_even_on_exception(monkeypatch):
     monkeypatch.setattr(d, "_now_ns", _fake_clock([0, 70]))
     d.reset_dispatch()
     with pytest.raises(ValueError):
-        with d.dispatch_span():
+        with d._counted_span():
             raise ValueError("boom")
     assert d.total_dispatch_ns() == 70
+
+
+def test_timed_dispatch_is_transparent_for_outside_callables():
+    """Decorating a callable from outside the package leaves it untouched.
+
+    Same return value, same argument handling, nothing accumulated — the wrapper
+    is a no-op rather than an error, so no caller can be broken by it.
+    """
+    d.reset_dispatch()
+
+    @d.timed_dispatch
+    def op(a, b=2):
+        return a * b
+
+    assert op(21) == 42
+    assert op(3, b=4) == 12
+    assert d.total_dispatch_ns() == 0
+
+
+def test_timed_dispatch_wraps_a_package_callable(monkeypatch):
+    """A real flopscope callable is wrapped and its wall accumulated."""
+    from flopscope import flops
+
+    monkeypatch.setattr(d, "_now_ns", _fake_clock([10, 60]))
+    d.reset_dispatch()
+    wrapped = d.timed_dispatch(flops.einsum_cost)
+    assert wrapped is not flops.einsum_cost, "package callable should be wrapped"
+    assert wrapped.__name__ == flops.einsum_cost.__name__

--- a/tests/client_compat/unit/conftest.py
+++ b/tests/client_compat/unit/conftest.py
@@ -2,12 +2,20 @@
 
 Lives under ``tests/client_compat/`` so the parent conftest still puts the CLIENT
 flopscope ahead of the in-process ``src/`` package — that path setup is exactly
-what these tests need. What they do NOT need is the parent's autouse
-``_fresh_connection_and_budget`` fixture, which opens an ambient
-``BudgetContext`` against a live flopscope-server; these tests assert on pure
-client-side accounting logic and would otherwise fail at setup with
-"session already open" / no server. Overriding the fixture by name here is the
-standard pytest mechanism for that.
+what these tests need. What they do not need is either of the parent's autouse
+fixtures:
+
+* ``_server`` (session-scoped) spawns a real flopscope-server subprocess, which
+  requires the server virtualenv and makes a client-only checkout unable to run
+  this directory;
+* ``_fresh_connection_and_budget`` opens an ambient ``BudgetContext`` against
+  that server, so without it these tests fail at setup with "session already
+  open" / no server.
+
+These tests assert on pure client-side accounting logic and never touch the
+wire, so both are overridden by name — the standard pytest mechanism. Keep both
+overrides: dropping the ``_server`` one silently reintroduces the subprocess and
+the serverless claim above stops being true.
 """
 
 from __future__ import annotations
@@ -15,7 +23,13 @@ from __future__ import annotations
 import pytest
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _server():
+    """No-op override: do not spawn flopscope-server for this directory."""
+    yield None
+
+
 @pytest.fixture(autouse=True)
 def _fresh_connection_and_budget():
-    """No-op override: these tests never touch the wire."""
+    """No-op override: these tests never open a budget or touch the wire."""
     yield

--- a/tests/client_compat/unit/conftest.py
+++ b/tests/client_compat/unit/conftest.py
@@ -1,0 +1,21 @@
+"""Client-side unit tests that need the client on sys.path but NO server.
+
+Lives under ``tests/client_compat/`` so the parent conftest still puts the CLIENT
+flopscope ahead of the in-process ``src/`` package — that path setup is exactly
+what these tests need. What they do NOT need is the parent's autouse
+``_fresh_connection_and_budget`` fixture, which opens an ambient
+``BudgetContext`` against a live flopscope-server; these tests assert on pure
+client-side accounting logic and would otherwise fail at setup with
+"session already open" / no server. Overriding the fixture by name here is the
+standard pytest mechanism for that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fresh_connection_and_budget():
+    """No-op override: these tests never touch the wire."""
+    yield

--- a/tests/client_compat/unit/test_dispatch_provenance.py
+++ b/tests/client_compat/unit/test_dispatch_provenance.py
@@ -146,6 +146,20 @@ def test_inert_via_importlib_and_sys_modules():
         assert mod.participant_span_count() == 1
 
 
+def test_inert_via_the_raw_counted_span_primitive():
+    """The primitive that mutates the accumulator carries the check itself.
+
+    Guarding only the public wrappers would put the check somewhere other than
+    the thing being protected: a span opened here from outside would both count
+    and leave the span tally at zero, so the tally could not be relied on.
+    """
+    before = D.total_dispatch_ns()
+    with D._counted_span():
+        _burn()
+    assert D.total_dispatch_ns() == before
+    assert D.participant_span_count() == 1
+
+
 def test_inert_via_reexported_dispatch_span():
     """dispatch_span is re-exported from _budget and _connection, which are on
     the hot path, so the check has to live in the callee."""

--- a/tests/client_compat/unit/test_dispatch_provenance.py
+++ b/tests/client_compat/unit/test_dispatch_provenance.py
@@ -90,6 +90,25 @@ def test_every_shipped_internal_call_site_is_recognised_internal():
         assert D._callable_is_internal(fn), f"{fn!r} was misclassified as external"
 
 
+def test_reimported_submodule_is_still_recognised_internal():
+    """Eviction + re-import replaces a module's dict without changing how many
+    modules exist, so provenance must be resolved live rather than from a cache
+    keyed on a cheap sentinel — otherwise that module's spans silently stop
+    counting after any reload."""
+    import flopscope.linalg as la
+
+    before_len = len(sys.modules)
+    assert D._callable_is_internal(la.norm)
+
+    del sys.modules["flopscope.linalg"]
+    reloaded = importlib.import_module("flopscope.linalg")
+
+    assert len(sys.modules) == before_len, "precondition: module count is unchanged"
+    assert D._callable_is_internal(reloaded.norm), (
+        "a re-imported flopscope submodule was misclassified as external"
+    )
+
+
 def test_internal_dispatch_span_accumulates():
     """The `with dispatch_span():` shape used in _budget/_connection/_remote_array."""
     from flopscope import _connection

--- a/tests/client_compat/unit/test_dispatch_provenance.py
+++ b/tests/client_compat/unit/test_dispatch_provenance.py
@@ -1,0 +1,204 @@
+"""Only flopscope's own code contributes to the dispatch accumulator.
+
+The accumulator measures flopscope's own dispatch cost and is subtracted from
+wall time to separate framework cost from caller cost. A span opened around
+non-flopscope code would therefore corrupt that split, so such spans run
+normally but contribute nothing and are counted instead.
+
+Module-level state stays reachable through ordinary imports, so the invariant is
+enforced where the span is opened rather than by restricting the API surface.
+The tests below cover both halves: every internal call site must still
+accumulate, and each way of reaching the entry points from outside the package
+must be inert.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import time
+
+import pytest
+
+from flopscope import _dispatch as D  # parent conftest puts the CLIENT on sys.path
+
+
+def _burn(seconds: float = 0.02) -> None:
+    end = time.perf_counter() + seconds
+    while time.perf_counter() < end:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    D.reset_dispatch()
+    yield
+    D.reset_dispatch()
+
+
+# --------------------------------------------------------------------------
+# Internal use must keep accumulating — this is the regression that matters.
+# --------------------------------------------------------------------------
+
+
+def test_internal_module_function_accumulates():
+    """The @timed_dispatch shape used in _io.py, flops.py and __init__.py."""
+    import flopscope
+
+    ns = flopscope.__dict__  # defined *inside* a flopscope module namespace
+    exec(compile("def _probe():\n    import time; time.sleep(0.02)\n", "<probe>", "exec"), ns)
+    try:
+        wrapped = D.timed_dispatch(ns["_probe"])
+        before = D.total_dispatch_ns()
+        wrapped()
+        assert D.total_dispatch_ns() > before, "internal callable did not accumulate"
+        assert D.participant_span_count() == 0
+    finally:
+        ns.pop("_probe", None)
+
+
+def test_every_shipped_internal_call_site_is_recognised_internal():
+    """Guard the real decorated callables, not a synthetic stand-in.
+
+    Covers the three shapes actually shipped: module-level functions, methods on
+    a class, and the dynamically-built proxy closures returned by
+    ``__init__``/``linalg``/``random``/``stats``.
+    """
+    from flopscope import _io, _remote_array, flops
+
+    candidates = [
+        _io._ingest,  # module-level @timed_dispatch
+        flops.einsum_cost,
+        flops.svd_cost,
+        _remote_array.RemoteArray._fetch_data,  # @timed_dispatch on a method
+    ]
+    for mod_name in ("flopscope.linalg", "flopscope.random", "flopscope.stats"):
+        mod = importlib.import_module(mod_name)
+        # Proxies are built lazily by __getattr__; pull whichever exists.
+        for attr in ("norm", "inv", "normal", "uniform", "zscore", "mean"):
+            fn = getattr(mod, attr, None)
+            if callable(fn):
+                candidates.append(fn)
+                break
+
+    for fn in candidates:
+        assert D._callable_is_internal(fn), f"{fn!r} was misclassified as external"
+
+
+def test_internal_dispatch_span_accumulates():
+    """The `with dispatch_span():` shape used in _budget/_connection/_remote_array."""
+    from flopscope import _connection
+
+    ns = _connection.__dict__
+    src = "def _probe(span):\n    with span():\n        import time; time.sleep(0.02)\n"
+    exec(compile(src, "<probe>", "exec"), ns)
+    try:
+        before = D.total_dispatch_ns()
+        ns["_probe"](D.dispatch_span)
+        assert D.total_dispatch_ns() > before
+        assert D.participant_span_count() == 0
+    finally:
+        ns.pop("_probe", None)
+
+
+# --------------------------------------------------------------------------
+# External use must be inert, however the entry point is reached.
+# --------------------------------------------------------------------------
+
+
+def _external_fn():
+    _burn()
+
+
+def test_inert_via_package_attribute():
+    import flopscope
+
+    before = D.total_dispatch_ns()
+    flopscope.timed_dispatch(_external_fn)()
+    assert D.total_dispatch_ns() == before, "external wall was absorbed into dispatch"
+    assert D.participant_span_count() == 1
+
+
+def test_inert_via_direct_submodule_import():
+    import flopscope._dispatch as direct
+
+    before = direct.total_dispatch_ns()
+    direct.timed_dispatch(_external_fn)()
+    assert direct.total_dispatch_ns() == before
+    assert direct.participant_span_count() == 1
+
+
+def test_inert_via_importlib_and_sys_modules():
+    """The module object is the same however it is obtained."""
+    for mod in (
+        importlib.import_module("flopscope._dispatch"),
+        sys.modules["flopscope._dispatch"],
+    ):
+        D.reset_dispatch()
+        before = mod.total_dispatch_ns()
+        mod.timed_dispatch(_external_fn)()
+        assert mod.total_dispatch_ns() == before
+        assert mod.participant_span_count() == 1
+
+
+def test_inert_via_reexported_dispatch_span():
+    """dispatch_span is re-exported from _budget and _connection, which are on
+    the hot path, so the check has to live in the callee."""
+    from flopscope import _budget, _connection
+
+    for mod in (_budget, _connection):
+        D.reset_dispatch()
+        before = D.total_dispatch_ns()
+        with mod.dispatch_span():
+            _burn()
+        assert D.total_dispatch_ns() == before
+        assert D.participant_span_count() == 1
+
+
+def test_inert_for_a_bound_method():
+    """Bound methods unwrap to their underlying function before the check."""
+
+    class Caller:
+        def work(self):
+            _burn()
+
+    before = D.total_dispatch_ns()
+    D.timed_dispatch(Caller().work)()
+    assert D.total_dispatch_ns() == before
+    assert D.participant_span_count() == 1
+
+
+def test_external_callable_still_runs_and_returns():
+    """The wrapper must be a no-op, not an error: same behaviour, same result."""
+    calls = []
+
+    def body(a, b, *, c):
+        calls.append((a, b, c))
+        return a + b + c
+
+    assert D.timed_dispatch(body)(1, 2, c=3) == 6
+    assert calls == [(1, 2, 3)]
+
+
+def test_module_and_filename_do_not_determine_provenance():
+    """``__module__`` and ``co_filename`` are ordinary writable attributes, which
+    is why provenance is decided by ``__globals__`` identity."""
+
+    def impostor():
+        _burn()
+
+    impostor.__module__ = "flopscope._dispatch"
+    impostor.__qualname__ = "flopscope._dispatch.impostor"
+    assert not D._callable_is_internal(impostor)
+    before = D.total_dispatch_ns()
+    D.timed_dispatch(impostor)()
+    assert D.total_dispatch_ns() == before
+    assert D.participant_span_count() == 1
+
+
+def test_external_spans_are_counted():
+    """The counter lets an embedding harness assert the invariant held."""
+    assert D.participant_span_count() == 0
+    D.timed_dispatch(_external_fn)()
+    D.timed_dispatch(_external_fn)()
+    assert D.participant_span_count() == 2

--- a/tests/client_compat/unit/test_dispatch_provenance.py
+++ b/tests/client_compat/unit/test_dispatch_provenance.py
@@ -46,7 +46,12 @@ def test_internal_module_function_accumulates():
     import flopscope
 
     ns = flopscope.__dict__  # defined *inside* a flopscope module namespace
-    exec(compile("def _probe():\n    import time; time.sleep(0.02)\n", "<probe>", "exec"), ns)
+    exec(
+        compile(
+            "def _probe():\n    import time; time.sleep(0.02)\n", "<probe>", "exec"
+        ),
+        ns,
+    )
     try:
         wrapped = D.timed_dispatch(ns["_probe"])
         before = D.total_dispatch_ns()

--- a/tests/client_compat/unit/test_dispatch_provenance.py
+++ b/tests/client_compat/unit/test_dispatch_provenance.py
@@ -206,6 +206,46 @@ def test_inert_for_a_bound_method():
     assert D.participant_span_count() == 1
 
 
+def test_unwrapping_is_by_type_not_by_attribute_name():
+    """A `.func` attribute is ordinary metadata on wrapper and decorator objects.
+
+    Following it by name would hand the decision to the object being judged: an
+    external callable could point it at a flopscope function and be treated as
+    internal. Unwrapping is therefore restricted to real bound methods and
+    functools.partial.
+    """
+    from flopscope import flops
+
+    class Wrapper:
+        func = flops.einsum_cost  # metadata pointing at a flopscope function
+
+        def __call__(self):
+            _burn()
+
+    obj = Wrapper()
+    assert not D._callable_is_internal(obj)
+    before = D.total_dispatch_ns()
+    D.timed_dispatch(obj)()
+    assert D.total_dispatch_ns() == before
+    assert D.participant_span_count() == 1
+
+
+def test_real_methods_and_partials_still_unwrap():
+    """The shapes flopscope actually decorates must keep working."""
+    import functools
+
+    from flopscope import _remote_array, flops
+
+    assert D._callable_is_internal(_remote_array.RemoteArray._fetch_data)
+    assert D._callable_is_internal(functools.partial(flops.einsum_cost, "ij,jk->ik"))
+
+    class Ext:
+        def method(self):
+            pass
+
+    assert not D._callable_is_internal(Ext().method)
+
+
 def test_external_callable_still_runs_and_returns():
     """The wrapper must be a no-op, not an error: same behaviour, same result."""
     calls = []


### PR DESCRIPTION
The dispatch accumulator measures flopscope's own client-side cost, and callers subtract it from wall time to separate framework cost from their own. A span opened around code that is not flopscope's therefore makes that split ill-defined.

This enforces the invariant where the span is opened rather than by restricting the API surface: `timed_dispatch()` and `dispatch_span()` contribute to the accumulator only for flopscope's own callables, and count the other case via `participant_span_count()` so an embedding harness can assert it held.

### Two implementation notes

- **Provenance comes from the defining module of the wrapped callable, not the immediate caller.** `timed_dispatch` opens its span from inside `_dispatch.py`, so the immediate caller is always internal and carries no information.
- **The check is `__globals__` identity** against the live flopscope module namespaces. `__module__` and `__code__.co_filename` are ordinary writable attributes, so they cannot carry the invariant — there is a test for that.

### Compatibility

Wrapping a callable from elsewhere returns it **unchanged** rather than raising, so behaviour and return values are identical either way. No public API changes.

`dispatch_span()` is no longer a generator: the check reads the caller's frame, and inside a `@contextmanager` body the caller is contextlib. It is still used exactly as before (`with dispatch_span():`).

### Tests

New `tests/client_compat/unit/`, whose conftest overrides the parent's autouse ambient-`BudgetContext` fixture — these assert on client-side accounting logic and must not require a live flopscope-server.

They cover both directions, which is the part worth reviewing:

- **every shipped internal call site still accumulates** — the three shapes actually in the tree: module-level `@timed_dispatch` functions (`_io.py`, `flops.py`), decorated methods (`_remote_array.py`, `stats/`), and the lazily-built proxy closures returned by `__init__`/`linalg`/`random`/`stats`;
- callables defined outside the package do not, including bound methods and one that sets `__module__`/`__qualname__` to look internal.

11 tests, no server required.