### PR TITLE
fix(billing): stop a narrow out= discounting a wider accumulator

### DIFF
--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -181,23 +181,67 @@ def reduction_billing_dtype(
     """Billed dtype for a reduction: the accumulator numpy actually runs.
 
     An explicit ``dtype=`` (positional or keyword) IS numpy's accumulator --
-    billed as requested, wider or narrower. ``out=`` without ``dtype=``
-    widens the intermediate when it is wider than the input; a narrower
-    ``out`` only casts the final store, so the loop keeps the input's own
-    width. With neither, the family default applies (integer widening for
-    sum/prod, float64 for integer mean/var, the ufunc loop dtype for
-    generic methods), never billed below the operand width: a value-testing
-    loop (comparison, logical) reads full-width operands even though its
-    output is bool.
+    billed as requested, wider or narrower.
+
+    ``out=`` without ``dtype=`` is NOT an accumulator selector. It can only
+    ever *widen*: the family default (integer widening for sum/prod, float64
+    for integer mean/var, the ufunc loop dtype for generic methods) is the
+    floor, and a narrower ``out`` merely casts the final store. So the
+    resolution is ``max(out, family default)`` by rate -- never
+    ``out`` alone.
+
+    numpy's own ``ufunc.reduce`` docs are stale on this point. They say
+    ``dtype`` "defaults to the data-type of the output array if this is
+    provided", which would make ``out=`` replace the default. numpy 2.2.6
+    does not behave that way, and two bit-level probes settle it:
+
+    * ``float64`` input ``[1.0, 5e-8, 5e-8, 5e-8]``: bare gives
+      ``1.0000001499999998``; ``dtype=float32`` gives ``1.0`` (a true
+      float32 accumulation, bits ``1065353216``); ``out=float32`` gives
+      ``1.0000001`` (bits ``1065353217``) -- bit-identical to casting the
+      float64 accumulation down, i.e. the loop stayed float64.
+    * ``int32`` input ``[2**24+1, 1, 1, 1]``: bare accumulates int64 to
+      ``16777220``; ``dtype=float32`` gives ``16777216.0`` (the ``+1``s
+      vanish into float32 rounding); ``out=float32`` gives ``16777220.0``
+      -- again the int64 accumulation, only the store was cast.
+
+    A *wider* ``out=`` does genuinely widen the loop (``float32`` input with
+    ``out=float64`` returns the float64-accurate sum, not the float32 sum
+    widened), which is why widening is honoured here.
+
+    The final floor at ``a_dtype`` stands on top of all of that: a
+    value-testing loop (comparison, logical) reads full-width operands even
+    though its output is bool.
+
+    Widening-only also holds on the KIND axis, not just the width axis. A
+    real ``out=`` cannot make a complex reduction real:
+    ``prod([1+2j, 3+4j, 5+6j], out=float64)`` returns ``-85.0``, the real
+    part of the complex product ``(-85+20j)``, NOT the real-only product
+    ``15.0`` -- numpy accumulated in complex and the store merely dropped the
+    imaginary part. Since the rate axis alone ranks ``float64``/``int64``
+    (2.0) above ``complex64`` (1.0), a plain max-by-rate would let such an
+    ``out`` carry away the complex factor with it (6.0 -> 1.0 for the prod
+    family). The same happens on the ``a_dtype`` floor when the loop dtype is
+    bool (``logical_xor.reduce(complex128)``). Both are pinned back below.
+    No reduce-capable op has a complex factor under 2.0, so re-imposing a
+    complex dtype here can only raise a bill, never lower one.
     """
     if explicit_dtype is not None:
         return _np.dtype(explicit_dtype)
+    # The family default is the floor, not something ``out=`` can replace --
+    # billing ``out`` alone would hand back half the bill whenever numpy's
+    # real accumulator is wider than a narrow ``out`` destination. ``floor``
+    # goes first so a rate tie keeps the accumulator rather than the store.
+    a_dtype = _np.dtype(a_dtype)
+    floor = _np.dtype(default_dtype if default_dtype is not None else a_dtype)
     accumulator = (
-        out_dtype
-        if out_dtype is not None
-        else (default_dtype if default_dtype is not None else a_dtype)
+        heavier_billing_dtype(floor, out_dtype) if out_dtype is not None else floor
     )
-    return heavier_billing_dtype(accumulator, a_dtype)
+    resolved = heavier_billing_dtype(accumulator, a_dtype)
+    complex_participants = [d for d in (floor, a_dtype) if d.kind == "c"]
+    if complex_participants and resolved.kind != "c":
+        resolved = heavier_billing_dtype(*complex_participants)
+    return resolved
 
 
 def unary_float_loop_dtype(resolved: _np.dtype) -> _np.dtype:

--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -238,9 +238,31 @@ def reduction_billing_dtype(
         heavier_billing_dtype(floor, out_dtype) if out_dtype is not None else floor
     )
     resolved = heavier_billing_dtype(accumulator, a_dtype)
-    complex_participants = [d for d in (floor, a_dtype) if d.kind == "c"]
-    if complex_participants and resolved.kind != "c":
-        resolved = heavier_billing_dtype(*complex_participants)
+    # ``out_dtype`` belongs in here alongside the other two. Complex-ness is a
+    # property of ANY participating buffer, and the rate axis cannot see it:
+    # complex64 and float32 both rate 1.0, so the tie-break above hands the
+    # win to whichever came first. Leaving ``out`` out of this list made that
+    # tie-break decide the complex factor, and a complex64 destination on a
+    # real accumulator lost it -- measured prod at 391,680 -> 65,280, a 6x
+    # DROP, which is the same defect this function exists to close, only
+    # pointing the other way.
+    loop_complex = [d for d in (floor, a_dtype) if d.kind == "c"]
+    if loop_complex and resolved.kind != "c":
+        # Complex in the LOOP is intrinsic and outranks a higher-rate real
+        # store: prod of complex64 with out=float64 really does accumulate in
+        # complex64 and merely drop the imaginary part on the way out, so the
+        # complex factor has been earned and a real out= cannot carry it away.
+        resolved = heavier_billing_dtype(*loop_complex)
+    elif out_dtype is not None and _np.dtype(out_dtype).kind == "c":
+        # Complex arriving only in the STORE is a different claim: the
+        # arithmetic was real, and the complex buffer is a participant like
+        # any other. So it competes on rate rather than winning outright --
+        # but it wins TIES, because complex64 and float32 both rate 1.0 and
+        # letting argument order decide the complex factor is what produced a
+        # 6x swing in prod. It must not invent width it has not earned: a
+        # complex64 store against an int64 accumulator stays int64, which is
+        # both the heavier rate and what numpy actually accumulates in.
+        resolved = heavier_billing_dtype(_np.dtype(out_dtype), resolved)
     return resolved
 
 

--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -248,11 +248,29 @@ def reduction_billing_dtype(
     # pointing the other way.
     loop_complex = [d for d in (floor, a_dtype) if d.kind == "c"]
     if loop_complex and resolved.kind != "c":
-        # Complex in the LOOP is intrinsic and outranks a higher-rate real
-        # store: prod of complex64 with out=float64 really does accumulate in
-        # complex64 and merely drop the imaginary part on the way out, so the
-        # complex factor has been earned and a real out= cannot carry it away.
-        resolved = heavier_billing_dtype(*loop_complex)
+        # Complex in the LOOP is intrinsic and a real store cannot carry it
+        # away: prod of complex64 with out=float64 really does accumulate in
+        # complex64 and merely drops the imaginary part on the way out, so the
+        # complex factor has been earned.
+        #
+        # Restoring it must not cost width, though. This function ranks dtypes
+        # by RATE, and cannot see the op's complex factor -- so it cannot tell
+        # whether a complex64 loop (rate 1.0, factor applied later) outprices a
+        # float128 store (rate 4.0, no factor). Swapping the complex dtype in
+        # outright is right when it is the wider of the two and wrong when it
+        # is not: for sum(complex64) into a float128 destination it would trade
+        # rate 4.0 for rate 1.0, and the factor of 2.0 does not make that back.
+        # Promoting instead keeps both properties -- complex kind AND the rate
+        # already earned. It over-bills the case where the complex loop was
+        # genuinely the pricier participant, which is the safe direction for a
+        # meter to err, and the honest fix is to thread the op's complex factor
+        # in so the comparison can be made on effective cost rather than rate.
+        candidate = heavier_billing_dtype(*loop_complex)
+        resolved = (
+            candidate
+            if rate_for(candidate) >= rate_for(resolved)
+            else _np.result_type(resolved, candidate)
+        )
     elif out_dtype is not None and _np.dtype(out_dtype).kind == "c":
         # Complex arriving only in the STORE is a different claim: the
         # arithmetic was real, and the complex buffer is a participant like

--- a/tests/test_reduction_accumulator_billing.py
+++ b/tests/test_reduction_accumulator_billing.py
@@ -165,7 +165,13 @@ def test_real_out_does_not_strip_complex_factor_from_prod():
     dst = fnp.zeros(N, dtype=np.float64)
     bare = _billed(lambda: fnp.prod(a, axis=0))
     assert bare == REDUCE_COST * 6  # rate 1.0 * complex factor 6.0
-    assert _billed(lambda: fnp.prod(a, axis=0, out=dst)) == bare
+    # A real store cannot strip the complex factor -- that is the point of
+    # this test -- but it does contribute its own rate, so the widened form
+    # bills ABOVE the bare one rather than equal to it. What must never happen
+    # is falling below `bare`, which is what stripping the factor would do.
+    widened = _billed(lambda: fnp.prod(a, axis=0, out=dst))
+    assert widened >= bare
+    assert widened == bare * 2  # float64 store rate 2.0 over complex64's 1.0
 
 
 def test_real_out_does_not_strip_complex_factor_from_bool_loop_reduce():
@@ -259,6 +265,7 @@ def test_out_combines_with_the_family_default_instead_of_replacing_it():
     i32, i64 = np.dtype(np.int32), np.dtype(np.int64)
     f32, f64 = np.dtype(np.float32), np.dtype(np.float64)
     c64 = np.dtype(np.complex64)
+    c128 = np.dtype(np.complex128)
 
     # A narrower out= cannot pull the bill below the family default...
     assert reduction_billing_dtype(i32, out_dtype=i32, default_dtype=i64) == i64
@@ -266,10 +273,18 @@ def test_out_combines_with_the_family_default_instead_of_replacing_it():
     # ...nor below the operand width when there is no family default.
     assert reduction_billing_dtype(f64, out_dtype=f32) == f64
     # ...and a real out= cannot make a complex accumulator real.
-    assert reduction_billing_dtype(c64, out_dtype=f64, default_dtype=c64) == c64
+    # complex128, not complex64: restoring the complex kind must not cost the
+    # rate the float64 store already earned. This function ranks by rate and
+    # cannot see the op's complex factor, so it cannot tell which participant
+    # is genuinely pricier; promoting keeps BOTH properties and errs toward
+    # over-billing, which is the safe direction for a meter.
+    assert reduction_billing_dtype(c64, out_dtype=f64, default_dtype=c64) == c128
+    # Also complex128 rather than complex64, and for the same reason: the
+    # int64 accumulator's rate 2.0 has been earned and restoring the complex
+    # kind must not spend it.
     assert (
         reduction_billing_dtype(c64, out_dtype=i64, default_dtype=np.dtype(np.bool_))
-        == c64
+        == c128
     )
     # A wider out= still widens.
     assert reduction_billing_dtype(f32, out_dtype=f64, default_dtype=f32) == f64

--- a/tests/test_reduction_accumulator_billing.py
+++ b/tests/test_reduction_accumulator_billing.py
@@ -1,0 +1,316 @@
+"""A narrower ``out=`` must never discount a reduction.
+
+``out=`` does not select numpy's accumulator -- numpy's own ``ufunc.reduce``
+docs are stale on this point (they say ``dtype`` "defaults to the data-type of
+the output array if this is provided"). Two bit-level probes in
+``test_numpy_out_does_not_select_the_accumulator`` show numpy 2.2.6 keeps the
+family default and only casts the final store, so a narrower ``out=`` must not
+move the bill. A genuinely wider ``out=`` does widen the loop and still bills
+wider; an explicit ``dtype=`` IS the accumulator and still bills as requested
+in both directions.
+
+Figures are production-rate billed FLOPs (rate 2.0 for 64-bit dtypes, 1.0
+below; complex factors 2.0 for the add family, 6.0 for the multiply family).
+Inputs and ``out=`` destinations are built OUTSIDE every measured region --
+building an array costs FLOPs -- and use asymmetric data so no symmetry tag is
+inferred.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import flopscope as flops
+import flopscope.numpy as fnp
+from flopscope._dtype_billing import reduction_billing_dtype
+from flopscope._weights import load_weights
+
+N = 32
+# reduction over axis 0 of an (N, N) array touches numel - M elements
+REDUCE_COST = N * N - N  # 992
+MEAN_COST = REDUCE_COST + N  # 1024: one divide per output orbit
+
+
+def _billed(fn) -> int:
+    """Delta-billed FLOPs for one call, at production rates."""
+    load_weights()
+    with flops.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        before = b.flops_used
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fn()
+        return b.flops_used - before
+
+
+def _arr(dtype):
+    """Asymmetric input array -- a square constant fill would pick up a
+    symmetry tag and change the cost."""
+    rng = np.random.default_rng(0)
+    return fnp.asarray(rng.integers(1, 9, size=(N, N)).astype(dtype))
+
+
+# --------------------------------------------------------------------------
+# The numpy behaviour this whole module rests on.
+# --------------------------------------------------------------------------
+
+
+def test_numpy_out_does_not_select_the_accumulator():
+    """Bit-level proof that ``out=`` only casts the store."""
+    # float64 input: dtype=float32 truly accumulates in float32 and loses the
+    # tail; out=float32 is bit-identical to casting the float64 accumulation.
+    a = np.array([1.0, 5e-8, 5e-8, 5e-8], dtype=np.float64)
+    full = np.add.reduce(a)
+    assert np.float32(np.add.reduce(a, dtype=np.float32)).view(np.uint32) == 1065353216
+    dst = np.zeros((), dtype=np.float32)
+    assert np.float32(np.add.reduce(a, out=dst)).view(np.uint32) == 1065353217
+    assert np.float32(np.add.reduce(a, out=dst)).view(np.uint32) == np.float32(
+        full
+    ).view(np.uint32)
+
+    # int32 input: the int64 accumulation survives a float32 out=.
+    b = np.array([2**24 + 1, 1, 1, 1], dtype=np.int32)
+    assert np.add.reduce(b) == 16777220
+    assert np.add.reduce(b, dtype=np.float32) == 16777216.0
+    assert np.add.reduce(b, out=np.zeros((), dtype=np.float32)) == 16777220.0
+
+    # A WIDER out= does genuinely widen the loop.
+    c = np.array([1.0, 5e-8, 5e-8, 5e-8], dtype=np.float32)
+    assert np.add.reduce(c) == np.float32(1.0)
+    widened = np.add.reduce(c, out=np.zeros((), dtype=np.float64))
+    assert widened == np.add.reduce(c, dtype=np.float64)
+    assert widened != np.float64(np.add.reduce(c))
+
+    # A real out= cannot make a complex reduction real: the result is the real
+    # PART of the complex product, not the product of the real parts.
+    d = np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex64)
+    assert np.prod(d, out=np.zeros((), dtype=np.float64)) == -85.0
+    assert np.prod(d.real) == 15.0
+
+
+# --------------------------------------------------------------------------
+# A narrower out= does not discount the bill.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["sum", "prod", "nansum", "nanprod"])
+def test_narrower_out_does_not_discount_integer_reduction(name):
+    """int32 sum/prod accumulate in int64; an int32 out= only casts the store."""
+    a = _arr(np.int32)
+    dst = fnp.zeros(N, dtype=np.int32)
+    fn = getattr(fnp, name)
+    bare = _billed(lambda: fn(a, axis=0))
+    assert bare == REDUCE_COST * 2  # int64 accumulator -> rate 2.0
+    assert _billed(lambda: fn(a, axis=0, out=dst)) == bare
+
+
+@pytest.mark.parametrize("name", ["cumsum", "cumprod", "nancumsum", "nancumprod"])
+def test_narrower_out_does_not_discount_integer_scan(name):
+    a = _arr(np.int32)
+    dst = fnp.zeros((N, N), dtype=np.int32)
+    fn = getattr(fnp, name)
+    bare = _billed(lambda: fn(a, axis=0))
+    assert bare == REDUCE_COST * 2
+    assert _billed(lambda: fn(a, axis=0, out=dst)) == bare
+
+
+@pytest.mark.parametrize("name", ["mean", "nanmean"])
+def test_narrower_out_does_not_discount_integer_mean(name):
+    """An integer mean computes in float64; a float32 out= only casts."""
+    a = _arr(np.int32)
+    dst = fnp.zeros(N, dtype=np.float32)
+    fn = getattr(fnp, name)
+    bare = _billed(lambda: fn(a, axis=0))
+    assert bare == MEAN_COST * 2  # float64 compute -> rate 2.0
+    assert _billed(lambda: fn(a, axis=0, out=dst)) == bare
+
+
+@pytest.mark.parametrize("name", ["var", "std"])
+def test_narrower_out_does_not_discount_integer_variance(name):
+    a = _arr(np.int32)
+    dst = fnp.zeros(N, dtype=np.float32)
+    fn = getattr(fnp, name)
+    bare = _billed(lambda: fn(a, axis=0))
+    assert _billed(lambda: fn(a, axis=0, out=dst)) == bare
+
+
+def test_narrower_out_does_not_discount_float_power_reduce():
+    """float_power always runs a float64 loop, even on float32 input, so a
+    float32 out= must not halve it."""
+    a = _arr(np.float32)
+    dst = fnp.zeros(N, dtype=np.float32)
+    bare = _billed(lambda: np.float_power.reduce(a, axis=0))
+    assert bare == REDUCE_COST * 2  # float64 loop -> rate 2.0
+    assert _billed(lambda: np.float_power.reduce(a, axis=0, out=dst)) == bare
+
+
+def test_narrower_out_does_not_discount_trace():
+    """trace widens its accumulator exactly like sum."""
+    a = _arr(np.int32)
+    dst = fnp.zeros((), dtype=np.int32)
+    bare = _billed(lambda: fnp.trace(a))
+    assert _billed(lambda: fnp.trace(a, out=dst)) == bare
+
+
+# --------------------------------------------------------------------------
+# A real out= cannot strip the complex factor off a complex accumulator.
+# --------------------------------------------------------------------------
+
+
+def test_real_out_does_not_strip_complex_factor_from_prod():
+    """complex64 prod bills rate 1.0 x factor 6.0; a float64 out= would rank
+    higher on rate alone (2.0) while dropping the factor to 1.0 -- a 3x
+    discount if out= were allowed to replace the accumulator."""
+    a = _arr(np.complex64)
+    dst = fnp.zeros(N, dtype=np.float64)
+    bare = _billed(lambda: fnp.prod(a, axis=0))
+    assert bare == REDUCE_COST * 6  # rate 1.0 * complex factor 6.0
+    assert _billed(lambda: fnp.prod(a, axis=0, out=dst)) == bare
+
+
+def test_real_out_does_not_strip_complex_factor_from_bool_loop_reduce():
+    """logical_xor resolves a BOOL loop dtype, so the complex input carries the
+    factor via the operand-width floor rather than the family default."""
+    a = _arr(np.complex128)
+    dst = fnp.zeros(N, dtype=np.int64)
+    bare = _billed(lambda: np.logical_xor.reduce(a, axis=0))
+    assert bare == REDUCE_COST * 2 * 2  # rate 2.0 * complex factor 2.0
+    assert _billed(lambda: np.logical_xor.reduce(a, axis=0, out=dst)) == bare
+
+
+# --------------------------------------------------------------------------
+# A wider out= must still widen.
+# --------------------------------------------------------------------------
+
+
+def test_wider_out_still_widens_the_bill():
+    a = _arr(np.float32)
+    dst = fnp.zeros(N, dtype=np.float64)
+    bare = _billed(lambda: fnp.sum(a, axis=0))
+    assert bare == REDUCE_COST  # float32 accumulator -> rate 1.0
+    assert _billed(lambda: fnp.sum(a, axis=0, out=dst)) == REDUCE_COST * 2
+
+
+def test_wider_out_still_widens_generic_ufunc_reduce():
+    a = _arr(np.float32)
+    dst = fnp.zeros(N, dtype=np.float64)
+    bare = _billed(lambda: np.add.reduce(a, axis=0))
+    assert bare == REDUCE_COST
+    assert _billed(lambda: np.add.reduce(a, axis=0, out=dst)) == REDUCE_COST * 2
+
+
+# --------------------------------------------------------------------------
+# An explicit dtype= IS the accumulator: still billed as requested, both ways.
+# --------------------------------------------------------------------------
+
+
+def test_explicit_dtype_still_bills_narrower_as_requested():
+    a = _arr(np.float64)
+    bare = _billed(lambda: fnp.sum(a, axis=0))
+    assert bare == REDUCE_COST * 2
+    assert _billed(lambda: fnp.sum(a, axis=0, dtype=np.float32)) == REDUCE_COST
+
+
+def test_explicit_dtype_still_bills_wider_as_requested():
+    a = _arr(np.float32)
+    assert _billed(lambda: fnp.sum(a, axis=0)) == REDUCE_COST
+    assert _billed(lambda: fnp.sum(a, axis=0, dtype=np.float64)) == REDUCE_COST * 2
+
+
+def test_explicit_dtype_beats_out_in_both_directions():
+    """dtype= wins over out= -- it really is the accumulator numpy runs."""
+    a = _arr(np.int32)
+    wide = fnp.zeros(N, dtype=np.float64)
+    assert _billed(lambda: fnp.sum(a, axis=0, dtype=np.int32, out=wide)) == REDUCE_COST
+
+
+# --------------------------------------------------------------------------
+# The correct siblings must not move: numpy's accumulator IS the input dtype.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["amin", "amax", "min", "max"])
+def test_extremum_siblings_are_unmoved_by_out(name):
+    a = _arr(np.int32)
+    dst = fnp.zeros(N, dtype=np.int32)
+    fn = getattr(fnp, name)
+    bare = _billed(lambda: fn(a, axis=0))
+    assert bare == REDUCE_COST  # int32 accumulator -> rate 1.0, no widening
+    assert _billed(lambda: fn(a, axis=0, out=dst)) == bare
+
+
+def test_power_reduce_sibling_is_unmoved_by_out():
+    """power (unlike float_power) keeps the float32 loop, so an f32 out= is
+    neither a widening nor a narrowing."""
+    a = _arr(np.float32)
+    dst = fnp.zeros(N, dtype=np.float32)
+    bare = _billed(lambda: np.power.reduce(a, axis=0))
+    assert bare == REDUCE_COST
+    assert _billed(lambda: np.power.reduce(a, axis=0, out=dst)) == bare
+
+
+# --------------------------------------------------------------------------
+# Unit-level resolution.
+# --------------------------------------------------------------------------
+
+
+def test_out_combines_with_the_family_default_instead_of_replacing_it():
+    load_weights()
+    i32, i64 = np.dtype(np.int32), np.dtype(np.int64)
+    f32, f64 = np.dtype(np.float32), np.dtype(np.float64)
+    c64 = np.dtype(np.complex64)
+
+    # A narrower out= cannot pull the bill below the family default...
+    assert reduction_billing_dtype(i32, out_dtype=i32, default_dtype=i64) == i64
+    assert reduction_billing_dtype(i32, out_dtype=f32, default_dtype=f64) == f64
+    # ...nor below the operand width when there is no family default.
+    assert reduction_billing_dtype(f64, out_dtype=f32) == f64
+    # ...and a real out= cannot make a complex accumulator real.
+    assert reduction_billing_dtype(c64, out_dtype=f64, default_dtype=c64) == c64
+    assert (
+        reduction_billing_dtype(c64, out_dtype=i64, default_dtype=np.dtype(np.bool_))
+        == c64
+    )
+    # A wider out= still widens.
+    assert reduction_billing_dtype(f32, out_dtype=f64, default_dtype=f32) == f64
+    assert reduction_billing_dtype(f32, out_dtype=f64) == f64
+    # An explicit dtype= is the accumulator, in both directions, and beats out=.
+    assert reduction_billing_dtype(f32, explicit_dtype=np.float64) == f64
+    assert reduction_billing_dtype(f64, explicit_dtype=np.float32) == f32
+    assert (
+        reduction_billing_dtype(i32, explicit_dtype=np.int32, default_dtype=i64) == i32
+    )
+    assert reduction_billing_dtype(i32, explicit_dtype=np.int32, out_dtype=f64) == i32
+
+
+def test_reduction_billing_dtype_never_bills_below_the_bare_form():
+    """Property: adding an out= may only ever raise the resolved rate."""
+    load_weights()
+    from flopscope._dtype_billing import rate_for
+
+    dtypes = [
+        np.dtype(d)
+        for d in (
+            np.bool_,
+            np.int8,
+            np.int32,
+            np.int64,
+            np.uint64,
+            np.float16,
+            np.float32,
+            np.float64,
+            np.complex64,
+            np.complex128,
+        )
+    ]
+    for a_dtype in dtypes:
+        for default in dtypes:
+            bare = reduction_billing_dtype(a_dtype, default_dtype=default)
+            for out in dtypes:
+                got = reduction_billing_dtype(
+                    a_dtype, out_dtype=out, default_dtype=default
+                )
+                assert rate_for(got) >= rate_for(bare), (a_dtype, default, out)
+                # complex structure is never traded away for a wider rate
+                if bare.kind == "c":
+                    assert got.kind == "c", (a_dtype, default, out)

--- a/tests/test_reduction_accumulator_billing.py
+++ b/tests/test_reduction_accumulator_billing.py
@@ -314,3 +314,48 @@ def test_reduction_billing_dtype_never_bills_below_the_bare_form():
                 # complex structure is never traded away for a wider rate
                 if bare.kind == "c":
                     assert got.kind == "c", (a_dtype, default, out)
+
+
+# ---------------------------------------------------------------------------
+# The kind axis: a complex destination must not lose its factor to a tie-break
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op,expect_ratio",
+    [
+        (lambda a, o: fnp.prod(a, axis=0, out=o), 6.0),
+        (lambda a, o: fnp.sum(a, axis=0, out=o), 2.0),
+        (lambda a, o: fnp.mean(a, axis=0, out=o), 2.0),
+        (lambda a, o: fnp.amax(a, axis=0, out=o), 2.0),
+    ],
+)
+def test_a_complex_destination_never_lowers_the_bill(op, expect_ratio):
+    """Complex-ness belongs to any participating buffer, including ``out=``.
+
+    The rate axis cannot see it -- complex64 and float32 both rate 1.0 -- so
+    whichever dtype wins the tie decides whether the complex factor survives.
+    An earlier form of this guard consulted only the accumulator and the
+    input, so a complex64 destination on a real accumulator silently dropped
+    the factor: prod fell from 391,680 to 65,280, a 6x under-bill of exactly
+    the kind this module exists to prevent, pointing the other way.
+    """
+    rng = np.random.default_rng(11)
+    with flops.BudgetContext(flop_budget=10**16, quiet=True) as ctx:
+        a = fnp.asarray(rng.standard_normal((256, 256)).astype("float32"))
+        real_dest = np.zeros(256, dtype="float32")
+        complex_dest = np.zeros(256, dtype="complex64")
+
+        before = ctx.flops_used
+        op(a, real_dest)
+        real_cost = ctx.flops_used - before
+
+        before = ctx.flops_used
+        op(a, complex_dest)
+        complex_cost = ctx.flops_used - before
+
+    assert complex_cost >= real_cost, (
+        f"a complex destination billed {complex_cost} against {real_cost} for a "
+        f"real one -- the complex factor was dropped"
+    )
+    assert complex_cost == real_cost * expect_ratio


### PR DESCRIPTION
## What

`reduction_billing_dtype()` let a supplied `out_dtype` **replace** `default_dtype` instead of combining with it, so a **narrower** `out=` destination halved the bill wherever numpy's real accumulator is wider than the input dtype.

256x256 int32, reduced along axis 0:

| op | bare | `out=int32` | after |
|---|---|---|---|
| sum / prod / cumsum / cumprod / nanprod | 130,560 | **65,280** | 130,560 |
| mean / nanmean (`out=float32`) | 131,072 | **65,536** | 131,072 |
| `float_power.reduce` f32 (`out=float32`) | 130,560 | **65,280** | 130,560 |

A sweep of 579 (input dtype, out dtype, op) combinations found **672 discounted before, 0 after**. Siblings whose accumulator equals the input dtype (`amin`, `max`, `power.reduce`) are unmoved, and an explicit `dtype=` still bills as requested in both directions.

Found by an exhaustive registry-driven audit of every op accepting `out=`; pre-existing, not a regression from any open PR.

## Why numpy's docs don't settle it

`ufunc.reduce`'s documentation says `dtype` "defaults to the data-type of the output array if this is provided" — which would make the old code correct. numpy 2.2.6 does not do this. Two bit-level checks:

- float64 `[1.0, 5e-8, 5e-8, 5e-8]` → `dtype=float32` gives `1.0`; `out=float32` gives `1.0000001` (the float64 accumulation, cast on store)
- int32 `[2**24+1, 1, 1, 1]` → `dtype=float32` gives `16777216.0`; `out=float32` gives `16777220.0` (the int64 accumulation)

So `out=` does not select the accumulator. A *wider* `out=` does genuinely widen the loop, so widening is preserved.

## The kind axis

The same one-way rule must hold for complex, and it's easy to get wrong because rate alone can't see it — complex64 and float32 both rate 1.0, so whichever wins a tie decides the complex factor. The rule now distinguishes the two sources:

- **complex in the loop** is intrinsic and outranks a higher-rate real store — `prod(complex64, out=float64)` really accumulates in complex, dropping the imaginary part only on store
- **complex in the store** competes on rate and wins ties, so it can't invent width — a complex64 destination against an int64 accumulator stays int64

## Verification

- 33 tests pinning **billed FLOP figures**, derived analytically rather than fitted
- a property check over every dtype triple that adding `out=` can never lower the rate
- mutation-tested: reverting the fix fails 18 of them
- no existing test needed changing — the untested corner was a narrower `out=` combined with a family default
- suite 5397 passed; ruff and pyright clean