### PR TITLE
fix(billing): price the fft destination and stop returning buffers numpy never wrote

### DIFF
--- a/src/flopscope/numpy/fft/_transforms.py
+++ b/src/flopscope/numpy/fft/_transforms.py
@@ -14,7 +14,7 @@ from numpy.typing import ArrayLike
 
 from flopscope._budget import _call_numpy, _counted_wrapper
 from flopscope._docstrings import attach_docstring
-from flopscope._dtype_billing import fft_billing_dtype
+from flopscope._dtype_billing import fft_billing_dtype, store_billing_dtypes
 from flopscope._ndarray import FlopscopeArray, _to_base_ndarray
 from flopscope._validation import _normalize_out, require_budget
 
@@ -245,6 +245,56 @@ def _batch_count_1d(a: _np.ndarray, axis: int) -> int:
     return a.size // a.shape[axis]
 
 
+def _ensure_out_written(dest: object, result: _np.ndarray) -> None:
+    """Write ``result`` into ``dest`` when numpy left the destination alone.
+
+    ``np.fft.hfft``, ``np.fft.ifft2`` and ``np.fft.irfft2`` hardcode
+    ``out=None`` into their inner call on numpy 2.0 through 2.4 -- fixed
+    upstream only in 2.5.1, outside our ``<2.5.0`` pin -- so the destination
+    a caller supplies is ignored in silence: numpy allocates a fresh array
+    and returns that, while the buffer the caller passed keeps whatever it
+    held before. Since these wrappers hand ``out`` back, the caller would
+    receive an untouched buffer AS the transform result, having paid the
+    full price of the transform.
+
+    The test is behavioural rather than a table of function names and
+    version bounds, so the documented contract holds on every numpy in the
+    support matrix, including ones released after this code: numpy returns
+    the very array it was given whenever it honours ``out=``, so
+    ``result is dest`` settles it for any function on any version. The
+    identity check works only because ``dest`` is the stripped base ndarray
+    THIS module passed down -- comparing against the caller's
+    ``FlopscopeArray`` would never match, as numpy is never shown that
+    object. ``may_share_memory`` covers the theoretical variant where some
+    version returns a distinct view onto the destination's buffer; an
+    ignored ``out=`` is always a fresh allocation, which cannot overlap it.
+
+    Shape and casting are then enforced as numpy enforces them on the
+    functions that DO honour ``out=`` (measured on numpy 2.2.6: a
+    mis-shaped destination raises ``ValueError: output array has wrong
+    shape.``, and a cast the ``same_kind`` rule refuses raises a
+    ``TypeError``), so the three broken functions validate like their
+    siblings instead of accepting anything at all. Both raises land inside
+    the caller's ``deduct`` block, where numpy's own would.
+
+    The copy goes through ``_call_numpy`` because it is the store step of
+    the transform itself -- work numpy should have done -- and belongs in
+    backend time, not in flopscope overhead.
+
+    ``dest`` is typed ``object`` because ``out`` arrives on these wrappers as
+    numpy's broad ``ArrayLike``; ``_normalize_out`` has already reduced it to
+    an ndarray or ``None``, and the ``isinstance`` below states that rather
+    than asserting it.
+    """
+    if not isinstance(dest, _np.ndarray):  # None, i.e. no destination asked for
+        return
+    if result is dest or _np.may_share_memory(result, dest):
+        return
+    if result.shape != dest.shape:
+        raise ValueError("output array has wrong shape.")
+    _call_numpy(_np.copyto, dest, result, casting="same_kind")
+
+
 # 1-D transforms
 @_counted_wrapper
 def fft(
@@ -264,12 +314,13 @@ def fft(
     if n is None:
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.fft",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.fft,
@@ -277,8 +328,9 @@ def fft(
             n=n,
             axis=axis,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -305,12 +357,13 @@ def ifft(
     if n is None:
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * fft_cost(n)
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.ifft",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.ifft,
@@ -318,8 +371,9 @@ def ifft(
             n=n,
             axis=axis,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -346,12 +400,13 @@ def rfft(
     if n is None:
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.rfft",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.rfft,
@@ -359,8 +414,9 @@ def rfft(
             n=n,
             axis=axis,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -387,12 +443,13 @@ def irfft(
     if n is None:
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * rfft_cost(n)
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.irfft",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.irfft,
@@ -400,8 +457,9 @@ def irfft(
             n=n,
             axis=axis,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -445,12 +503,13 @@ def fft2(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="c2c")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.fft2",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.fft2,
@@ -458,8 +517,9 @@ def fft2(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -505,12 +565,13 @@ def ifft2(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="c2c")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.ifft2",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.ifft2,
@@ -518,8 +579,9 @@ def ifft2(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -565,12 +627,13 @@ def rfft2(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="r2c")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.rfft2",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.rfft2,
@@ -578,8 +641,9 @@ def rfft2(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -642,12 +706,13 @@ def irfft2(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="c2r")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.irfft2",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.irfft2,
@@ -655,8 +720,9 @@ def irfft2(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -703,12 +769,13 @@ def fftn(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="c2c")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.fftn",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.fftn,
@@ -716,8 +783,9 @@ def fftn(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -763,12 +831,13 @@ def ifftn(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="c2c")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.ifftn",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.ifftn,
@@ -776,8 +845,9 @@ def ifftn(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -823,12 +893,13 @@ def rfftn(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="r2c")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.rfftn",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.rfftn,
@@ -836,8 +907,9 @@ def rfftn(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -900,12 +972,13 @@ def irfftn(
         )
     axes_nn = tuple(ax % a.ndim for ax in eff)
     cost = staged_fftn_cost(a.shape, s_for_cost, axes_nn, kind="c2r")  # type: ignore[reportArgumentType]
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.irfftn",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.irfftn,
@@ -913,8 +986,9 @@ def irfftn(
             s=s,
             axes=axes,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -945,12 +1019,13 @@ def hfft(
     if n is None:
         n = 2 * (a.shape[axis] - 1)
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.hfft",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.hfft,
@@ -958,8 +1033,9 @@ def hfft(
             n=n,
             axis=axis,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 
@@ -989,12 +1065,13 @@ def ihfft(
     if n is None:
         n = a.shape[axis]
     cost = _batch_count_1d(a, axis) * hfft_cost(n)
+    dest = _to_base_ndarray(out) if out is not None else None
     with budget.deduct(
         "fft.ihfft",
         flop_cost=cost,
         subscripts=None,
         shapes=(a.shape,),
-        dtypes=(fft_billing_dtype(a.dtype),),
+        dtypes=(fft_billing_dtype(a.dtype),) + store_billing_dtypes(out),
     ):
         result = _call_numpy(
             _np.fft.ihfft,
@@ -1002,8 +1079,9 @@ def ihfft(
             n=n,
             axis=axis,
             norm=norm,  # type: ignore[reportArgumentType]
-            out=_to_base_ndarray(out) if out is not None else None,  # type: ignore[reportArgumentType]
+            out=dest,  # type: ignore[reportArgumentType]
         )
+        _ensure_out_written(dest, result)
     return out if out is not None else result  # type: ignore[reportReturnType]
 
 

--- a/tests/test_fft_out_pricing.py
+++ b/tests/test_fft_out_pricing.py
@@ -266,3 +266,51 @@ def test_mis_shaped_destination_is_refused_everywhere(name):
     with f.BudgetContext(flop_budget=10**15, quiet=True):
         with pytest.raises(ValueError, match="wrong shape"):
             fn(a, out=_dest(bad_shape, np.complex128))
+
+
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_the_destination_itself_is_what_comes_back(name):
+    """numpy hands back the very object it was given; so must we.
+
+    Checking the returned VALUE is not enough -- a wrapper that dropped
+    ``return out`` entirely and returned its own freshly allocated result
+    would still carry the right numbers, and every content assertion in this
+    file would keep passing. That is not academic: the point of ``out=`` is
+    that the caller keeps a reference to the buffer and reads it afterwards,
+    so identity is the contract, not equality.
+    """
+    a = _make_input(name)
+    expected = _expected(name, a)
+    dest = _dest(expected.shape, expected.dtype)
+
+    with f.BudgetContext(flop_budget=10**15, quiet=True):
+        returned = getattr(fnp.fft, name)(fnp.asarray(a), out=dest)
+
+    assert np.asarray(returned) is dest or np.asarray(returned).base is dest, (
+        f"fft.{name} returned a different buffer than the destination it was "
+        f"handed -- a caller holding `dest` would read stale data"
+    )
+
+
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_a_wider_destination_receives_the_right_values_too(name):
+    """The intersection of both defects, which neither test alone reaches.
+
+    The rate test measures a complex128 destination and discards the values;
+    the write test only ever uses a same-dtype destination. hfft/ifft2/irfft2
+    with a wide destination are exactly where the repair has to copy ACROSS a
+    cast, so that is the one combination worth asserting on content.
+    """
+    a = _make_input(name)
+    expected = _expected(name, a)
+    wide = np.result_type(expected.dtype, np.complex128)
+    dest = _dest(expected.shape, wide)
+
+    with f.BudgetContext(flop_budget=10**15, quiet=True):
+        returned = getattr(fnp.fft, name)(fnp.asarray(a), out=dest)
+
+    assert not np.any(dest == SENTINEL), (
+        f"fft.{name} left its wide destination unwritten"
+    )
+    np.testing.assert_allclose(dest, expected.astype(wide), rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(np.asarray(returned), dest)

--- a/tests/test_fft_out_pricing.py
+++ b/tests/test_fft_out_pricing.py
@@ -1,0 +1,268 @@
+"""``out=`` on the fft family: the destination must be priced, and written.
+
+Two defects lived in every one of the fourteen ``flopscope.numpy.fft``
+transform wrappers, and each is pinned here.
+
+**The destination never reached the rate.** Every wrapper deducted with
+``dtypes=(fft_billing_dtype(a.dtype),)`` -- a function of the INPUT dtype
+alone -- so ``store_billing_dtypes(out)`` never joined the resolution. A
+complex64 transform written into a complex128 destination therefore bought
+genuine double-precision work at the single-precision rate: exactly half
+price, for a correctly computed and correctly written result. The pointwise
+and contraction families already fold the destination in (see
+``src/flopscope/_dtype_billing.py`` -- the widest participating buffer is
+``max(compute width, store width)``); the fft family now does the same.
+
+**A destination numpy never wrote was returned anyway.** ``np.fft.hfft``,
+``np.fft.ifft2`` and ``np.fft.irfft2`` hardcode ``out=None`` into their inner
+call on numpy 2.0 through 2.4 -- fixed upstream only in 2.5.1, outside this
+package's ``<2.5.0`` pin. numpy silently ignored the destination, allocated
+a fresh array and returned that; the wrapper handed back ``out``, so the
+caller received an untouched buffer AS the transform result, at full price.
+A plausible-looking array of the wrong values, billed in full, is the worst
+failure class a metering system has.
+
+Why the coverage here is DERIVED rather than hand-listed
+--------------------------------------------------------
+A hand-written list of fourteen names pins whichever wrappers the author
+happened to think of, and says nothing about a fifteenth added later --
+which is precisely how a defect present in all fourteen sites survived. So
+the ops under test are discovered from the module surface (public, mirrored
+by ``numpy.fft``, and taking an ``out`` parameter), and their arguments are
+derived from the transform's own name: the real/complex/hermitian input kind
+from the base name, the dimensionality from the ``2``/``n`` suffix, and the
+destination's natural shape and dtype from plain numpy itself. A transform
+that lands tomorrow is enumerated the day it lands, and one whose name this
+module cannot classify fails ``test_every_discovered_op_is_driven`` rather
+than skipping in silence.
+
+Inputs are deliberately single-precision (float32 / complex64), so that a
+complex128 destination is genuinely WIDER than the transform's own working
+precision and the rate has something to widen to.
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+from flopscope._weights import load_weights
+
+# Base transforms by what they consume and produce. The suffix (``2``/``n``)
+# only picks the dimensionality, so classification is by base name.
+_C2C = frozenset({"fft", "ifft"})  # complex in, complex out
+_R2C = frozenset({"rfft", "ihfft"})  # real in, complex out
+_C2R = frozenset({"irfft", "hfft"})  # hermitian-complex in, real out
+
+SENTINEL = 1234.5
+
+
+def _discover_ops() -> dict:
+    """Every public fft wrapper that accepts a destination."""
+    ops = {}
+    for name in dir(fnp.fft):
+        if name.startswith("_"):
+            continue
+        fn = getattr(fnp.fft, name)
+        if not callable(fn) or not hasattr(np.fft, name):
+            continue
+        try:
+            sig = inspect.signature(fn)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            continue
+        if "out" in sig.parameters:
+            ops[name] = fn
+    return ops
+
+
+FFT_OPS = _discover_ops()
+OP_NAMES = sorted(FFT_OPS)
+
+
+def _base(name: str) -> str:
+    """``fftn`` -> ``fft``, ``irfft2`` -> ``irfft``, ``ihfft`` -> ``ihfft``."""
+    return name.rstrip("2n")
+
+
+def _is_nd(name: str) -> bool:
+    return name.endswith(("2", "n"))
+
+
+def _make_input(name: str) -> np.ndarray:
+    """A single-precision input of the kind this transform consumes.
+
+    Asymmetric random data on a non-square shape: zeros/ones on a square
+    shape would let an inferred symmetry tag change what the call costs.
+    """
+    base = _base(name)
+    rng = np.random.default_rng(abs(hash(name)) % (2**32))
+    # A c2r transform reconstructs a length-8 real axis from 5 hermitian
+    # bins; everything else takes the full length directly.
+    last = 5 if base in _C2R else 8
+    shape = (4, last) if _is_nd(name) else (last,)
+    if base in _R2C:
+        return rng.standard_normal(shape).astype(np.float32)
+    real = rng.standard_normal(shape)
+    imag = rng.standard_normal(shape)
+    return (real + 1j * imag).astype(np.complex64)
+
+
+def _expected(name: str, a: np.ndarray) -> np.ndarray:
+    """What plain numpy computes -- the reference for every content check."""
+    return getattr(np.fft, name)(np.asarray(a))
+
+
+def _billed(fn) -> int:
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        fn()
+        return b.flops_used
+
+
+def _dest(shape, dtype, *, flopscope_array: bool = False):
+    """A destination pre-filled with a sentinel, built OUTSIDE any measured
+    region -- constructing an array costs FLOPs of its own."""
+    if flopscope_array:
+        with f.BudgetContext(flop_budget=10**15, quiet=True):
+            return fnp.full(shape, SENTINEL, dtype=dtype)
+    return np.full(shape, SENTINEL, dtype=dtype)
+
+
+@pytest.fixture(autouse=True)
+def _weights():
+    load_weights()
+
+
+def test_every_discovered_op_is_driven():
+    """No destination-taking transform may go untested by accident."""
+    assert OP_NAMES, "discovery found no fft ops taking out="
+    unclassified = [n for n in OP_NAMES if _base(n) not in _C2C | _R2C | _C2R]
+    assert not unclassified, (
+        f"fft ops {unclassified} take out= but this module cannot derive their "
+        f"arguments; classify their base name in _C2C / _R2C / _C2R"
+    )
+    # The count is asserted so that a transform DISAPPEARING from the surface
+    # is as loud as one appearing unclassified.
+    assert len(OP_NAMES) == 14, OP_NAMES
+
+
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_wider_destination_widens_the_rate(name):
+    """A complex128 destination buys double-precision work at double price.
+
+    Before the fix the rate came from the input dtype alone, so all three
+    columns billed identically and the wide destination was free.
+    """
+    fn = FFT_OPS[name]
+    a = _make_input(name)
+    natural = _expected(name, a)
+
+    bare = _billed(lambda: fn(a))
+    same = _billed(lambda: fn(a, out=_dest(natural.shape, natural.dtype)))
+    wide = _billed(lambda: fn(a, out=_dest(natural.shape, np.complex128)))
+
+    assert same == bare, f"{name}: a same-dtype destination must not move the rate"
+    assert wide == 2 * bare, (
+        f"{name}: complex128 destination billed {wide}, expected {2 * bare} "
+        f"(complex64 rate 1.0 -> complex128 rate 2.0)"
+    )
+
+
+def test_wider_destination_exact_anchor():
+    """One concrete number, so a silent global re-rating cannot pass unseen."""
+    a = (np.arange(8) + 1j * np.arange(8, 0, -1)).astype(np.complex64)
+    assert _billed(lambda: fnp.fft.fft(a)) == 120  # 5 * 8 * log2(8), rate 1.0
+    assert _billed(lambda: fnp.fft.fft(a, out=_dest((8,), np.complex128))) == 240
+
+
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_out_tuple_bills_exactly_what_bare_out_bills(name):
+    """``out=(d,)`` is numpy's own spelling of ``out=d`` and costs the same."""
+    fn = FFT_OPS[name]
+    a = _make_input(name)
+    shape = _expected(name, a).shape
+
+    bare = _billed(lambda: fn(a, out=_dest(shape, np.complex128)))
+    tupled = _billed(lambda: fn(a, out=(_dest(shape, np.complex128),)))
+
+    assert tupled == bare
+
+
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_refused_out_form_costs_zero(name):
+    """A list is not a destination numpy accepts, and refusing it is free."""
+    fn = FFT_OPS[name]
+    a = _make_input(name)
+    shape = _expected(name, a).shape
+
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        with pytest.raises(TypeError):
+            fn(a, out=[_dest(shape, np.complex128)])
+        assert b.flops_used == 0
+
+
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_flops_used_never_decreases_across_out_forms(name):
+    """No ``out=`` form, accepted or refused, ever hands budget back."""
+    fn = FFT_OPS[name]
+    a = _make_input(name)
+    natural = _expected(name, a)
+
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        seen = b.flops_used
+        for make_out in (
+            lambda: None,
+            lambda: _dest(natural.shape, natural.dtype),
+            lambda: _dest(natural.shape, np.complex128),
+            lambda: (_dest(natural.shape, np.complex128),),
+        ):
+            out = make_out()
+            fn(a, out=out) if out is not None else fn(a)
+            assert b.flops_used >= seen
+            seen = b.flops_used
+        with pytest.raises(TypeError):
+            fn(a, out=[_dest(natural.shape, np.complex128)])
+        assert b.flops_used == seen
+
+
+@pytest.mark.parametrize("flavor", ["ndarray", "flopscope_array"])
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_accepted_destination_is_actually_written(name, flavor):
+    """THE contract test: a destination that is accepted must be WRITTEN.
+
+    Asserted by CONTENT against plain numpy, never by identity -- identity
+    passed happily while ``hfft``, ``ifft2`` and ``irfft2`` returned an
+    all-sentinel buffer at full price. Both the destination and the returned
+    object are checked, because the wrapper hands back the destination and a
+    caller reads the result off either one.
+    """
+    fn = FFT_OPS[name]
+    a = _make_input(name)
+    expected = _expected(name, a)
+    dest = _dest(
+        expected.shape, expected.dtype, flopscope_array=(flavor == "flopscope_array")
+    )
+
+    with f.BudgetContext(flop_budget=10**15, quiet=True):
+        returned = fn(a, out=dest)
+
+    assert not np.any(np.asarray(dest) == SENTINEL), (
+        f"{name}: destination left untouched -- numpy ignored out= and the "
+        f"caller was handed the sentinel buffer as the transform result"
+    )
+    np.testing.assert_allclose(np.asarray(dest), expected, rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(np.asarray(returned), expected, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("name", OP_NAMES)
+def test_mis_shaped_destination_is_refused_everywhere(name):
+    """Every transform validates a bad destination, not just the ones numpy
+    bothered to forward ``out=`` to."""
+    fn = FFT_OPS[name]
+    a = _make_input(name)
+    bad_shape = tuple(d + 1 for d in _expected(name, a).shape)
+
+    with f.BudgetContext(flop_budget=10**15, quiet=True):
+        with pytest.raises(ValueError, match="wrong shape"):
+            fn(a, out=_dest(bad_shape, np.complex128))


### PR DESCRIPTION
## Two defects, both across all 14 `fnp.fft.*` wrappers

**1. The destination never reached the rate.** Every wrapper deducted with `dtypes=(fft_billing_dtype(a.dtype),)` — a function of the *input* dtype alone, with no `store_billing_dtypes(out)`. A complex128 destination bought a genuine double-precision transform at the complex64 price. Now folded in the same way the pointwise and contraction families already do.

**2. A destination numpy never wrote was returned anyway.** `np.fft.hfft`, `ifft2` and `irfft2` hardcode `out=None` into their inner call on every numpy from 2.0 to 2.4, so the destination is silently ignored — and `return out if out is not None else result` handed that untouched buffer back as the transform result, at full price. Upstream fixed it only in 2.5.1, outside our `<2.5.0` pin.

Ground truth was measured rather than assumed — a sentinel-filled destination, called, checked for change, for all 14:

| | writes destination? |
|---|---|
| fft, ifft, rfft, irfft, ihfft, fft2, rfft2, fftn, ifftn, rfftn, irfftn | yes |
| **hfft, ifft2, irfft2** | **no** |

## Why the repair is generic

No name table and no version check — both would rot the moment we bump past 2.5.1. Each wrapper now holds `dest`, the exact base array numpy was shown, and numpy returns *that identical object* whenever it honours `out=` (confirmed for all 11). So `result is dest` decides the question on any numpy for any function:

```python
if result is dest or _np.may_share_memory(result, dest):
    return
if result.shape != dest.shape:
    raise ValueError("output array has wrong shape.")
_call_numpy(_np.copyto, dest, result, casting="same_kind")
```

An identity test against the caller's `FlopscopeArray` could never work — `_to_base_ndarray` hands numpy a view over the same buffer, which is also why writing `dest` writes through. Shape and casting are now enforced on the three broken transforms exactly as numpy enforces them on the working ones, so they stop accepting bad destinations in silence. The copy goes through `_call_numpy` because it is the transform's store step and belongs in backend time.

## Billing, before → after

float32/complex64 inputs into a complex128 destination:

| | none | wide before | wide after |
|---|---|---|---|
| fft / ifft | 120 | 120 | **240** |
| fft2 / fftn / ifftn | 800 | 800 | **1600** |
| rfft2 / rfftn / irfftn | 440 | 440 | **880** |
| **hfft** | 60 | 60 *(destination unwritten)* | **120, written** |
| **ifft2** | 800 | 800 *(unwritten)* | **1600, written** |
| **irfft2** | 440 | 440 *(unwritten)* | **880, written** |

Every destination content-verified against plain numpy. `out=(d,)` bills exactly `out=d` in every row; a refused `out=[d]` costs 0; `flops_used` never decreases (0 decreases across 872 A/B cases against main).

## Verification

- 128 tests, op set **discovered** from the module surface rather than hand-listed, with a test that fails loudly on an unclassifiable or vanished transform — a hand-listed set is how a defect at all 14 sites survived in the first place
- mutation-tested: dropping the rate fold (15 fail), the write repair (12 fail), or the return-the-destination contract (3 fail) each turns the suite red
- adversarially reviewed for bit-exactness of the self-performed store (identical to numpy's own `out=` store), for masking genuine numpy errors, and for symmetry-tag voiding through the stripped view
- suite 6535 passed; ruff and pyright clean