### PR TITLE
feat(matmul): accept a destination, and return the one the caller passed

### DIFF
--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -594,7 +594,17 @@ def einsum(
     out = _normalize_out(out, "einsum")
 
     effective_out_symmetry = target_symmetry
-    if effective_out_symmetry is None and isinstance(out, SymmetricTensor):
+    if (
+        effective_out_symmetry is None
+        and isinstance(out, SymmetricTensor)
+        and not getattr(out, "_symmetry_inferred", False)
+    ):
+        # Only a tag the caller validated becomes a requirement on the result.
+        # Lifting an *inferred* one made an ordinary scratch arena raise: an
+        # `fnp.zeros((n, n))` destination is auto-tagged symmetric, so writing
+        # any asymmetric contraction into it failed, for a legal numpy call
+        # against metadata the caller never asked for. The pointwise factories
+        # drop an inferred tag quietly; this brings einsum in line.
         effective_out_symmetry = out.symmetry
     target_symmetry = _prepare_symmetric_out(out, effective_out_symmetry)
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -3093,7 +3093,13 @@ def _einsum_routed_binary(
     if info.output_symmetry is not None and _validate_result_symmetry(
         result, info.output_symmetry
     ):
-        return SymmetricTensor(_np.asarray(result), symmetry=info.output_symmetry)
+        # Only when the caller supplied no destination. Wrapping ``out`` would
+        # hand back a second object of a different type over the caller's own
+        # buffer; numpy and fnp.einsum both return the destination itself.
+        if out is None:
+            return SymmetricTensor(_np.asarray(result), symmetry=info.output_symmetry)
+    if out is not None:
+        return out
     return _asflopscope(result) if inputs_were_whest else result
 
 
@@ -3142,8 +3148,14 @@ attach_docstring(dot, _np.dot, "counted_custom", "depends on operand dimensions"
 
 
 @_counted_wrapper
-def matmul(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
+def matmul(
+    a: ArrayLike, b: ArrayLike, out: FlopscopeArray | None = None
+) -> FlopscopeArray:
     """Counted version of np.matmul."""
+    # Declared rather than accepted through **kwargs, which is how the derived
+    # out= coverage discovers an op: it reads the wrapper's parameters, so a
+    # destination arriving as varkw is invisible to the sweep. The helper
+    # normalizes and prices it -- see _einsum_routed_binary.
     if not isinstance(a, _np.ndarray):
         a = _np.asarray(a)
     if not isinstance(b, _np.ndarray):
@@ -3157,7 +3169,7 @@ def matmul(a: ArrayLike, b: ArrayLike) -> FlopscopeArray:
     else:
         subs = "...ij,...jk->...ik"  # 2-D and batched/broadcast N-D
     return _einsum_routed_binary(
-        "matmul", _np.matmul, subs, a, b, errstate=True, nan_check=True
+        "matmul", _np.matmul, subs, a, b, errstate=True, nan_check=True, out=out
     )
 
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -3026,6 +3026,33 @@ if hasattr(_np, "ptp"):
 # ---------------------------------------------------------------------------
 
 
+def _ensure_contraction_out_written(dest, result) -> None:
+    """Write ``result`` into ``dest`` when numpy left the destination alone.
+
+    The contraction wrappers hand ``out`` back, so a numpy that accepted the
+    argument and quietly ignored it would return the caller an untouched buffer
+    AS the contraction result, at full price. That is not hypothetical for the
+    project as a whole: ``np.fft.hfft`` / ``ifft2`` / ``irfft2`` hardcode
+    ``out=None`` on numpy 2.0 through 2.4, which is what
+    :func:`flopscope.numpy.fft._transforms._ensure_out_written` exists to
+    repair. No contraction entry point does it on any numpy in the support
+    matrix -- this is a behavioural check, not a version table, so it keeps
+    holding on numpy releases that do not exist yet.
+
+    ``dest`` must be the stripped base ndarray handed to numpy: numpy returns
+    the very array it was given when it honours ``out=``, and it is never shown
+    the caller's ``FlopscopeArray``, so an identity test against that would
+    never match. ``may_share_memory`` covers a version returning a distinct
+    view onto the destination; an ignored ``out=`` is always a fresh
+    allocation, which cannot overlap it.
+    """
+    if not isinstance(dest, _np.ndarray) or not isinstance(result, _np.ndarray):
+        return
+    if result is dest or _np.may_share_memory(result, dest):
+        return
+    _call_numpy(_np.copyto, dest, result, casting="same_kind")
+
+
 def _einsum_routed_binary(
     op_name: str,
     np_fn: Any,
@@ -3059,6 +3086,12 @@ def _einsum_routed_binary(
     if not isinstance(b, _np.ndarray):
         b = _np.asarray(b)
     info = _resolve_cost_and_output_symmetry(subs, a, b)
+    # The gate the pointwise factories already apply: a tag the caller paid
+    # ``as_symmetric`` to validate is a claim about this buffer, so a result
+    # that contradicts it is an error; a tag merely inferred from a constant
+    # fill is dropped quietly, which keeps a scratch arena usable.
+    if out is not None:
+        _prepare_symmetric_out(out, info.output_symmetry)
     inputs_were_whest = isinstance(a, _np.ndarray) and (
         type(a) is not _np.ndarray or type(b) is not _np.ndarray
     )
@@ -3089,6 +3122,7 @@ def _einsum_routed_binary(
     if nan_check:
         maybe_check_nan_inf(result, op_name)
     if out is not None:
+        _ensure_contraction_out_written(_to_base_ndarray(out), result)
         result = out
     if info.output_symmetry is not None and _validate_result_symmetry(
         result, info.output_symmetry

--- a/tests/test_matmul_out.py
+++ b/tests/test_matmul_out.py
@@ -1,0 +1,186 @@
+"""``fnp.matmul`` accepts a destination, and the contraction helper returns it.
+
+Two things are pinned here.
+
+The feature: ``matmul`` takes ``out=`` like every other contraction that can.
+``vecdot``/``matvec``/``vecmat`` already did, because they forward ``**kwargs``
+into the shared helper; ``matmul`` did not, which made the surface arbitrary.
+
+The defect the feature exposes: the helper set ``result = out`` and then, when
+an output symmetry was inferred, returned a *new* ``SymmetricTensor`` over the
+destination's memory instead of the destination. NumPy and ``fnp.einsum`` both
+return ``out`` itself, and a caller who writes ``r = matmul(a, b, out=arena)``
+and then also uses ``arena`` should not be holding two objects of different
+types over one buffer.
+
+Probes here run in both directions on purpose. A rate probe built only from a
+neutral store (an object destination, which ``store_billing_dtypes`` is
+*designed* to ignore) cannot tell a correct implementation from one that never
+folds the destination at all -- that blindness is exactly how a 2x fft
+under-bill survived an earlier sweep. So a wide destination must raise the
+bill, and a neutral one must leave it alone. Content is asserted separately
+from cost for the same reason: a destination that is billed correctly and
+never written is invisible to any cost assertion.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+from flopscope._weights import load_weights
+
+N = 6
+
+
+def _billed(fn):
+    with f.BudgetContext(flop_budget=10**18, quiet=True) as b:
+        fn()
+        return b.flops_used
+
+
+def _pair(dtype: Any = np.float64, n: int = N):
+    rng = np.random.default_rng(0)
+    return rng.random((n, n)).astype(dtype), rng.random((n, n)).astype(dtype)
+
+
+def _symmetric(n=N):
+    a = np.random.default_rng(2).random((n, n))
+    return a + a.T
+
+
+# --- the feature ---------------------------------------------------------
+
+
+def test_matmul_accepts_a_destination_and_writes_it():
+    load_weights()
+    a, b = _pair()
+    dest = np.empty((N, N))
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        r = fnp.matmul(a, b, out=dest)  # pyright: ignore[reportArgumentType, reportCallIssue]
+    assert r is dest
+    np.testing.assert_allclose(dest, a @ b)
+
+
+def test_matmul_declares_out_rather_than_swallowing_it_in_kwargs():
+    """A declared parameter is what enrols matmul in the derived out= sweep."""
+    import inspect
+
+    assert "out" in inspect.signature(fnp.matmul).parameters
+
+
+def test_dot_and_inner_still_refuse_a_destination():
+    """numpy's dot demands exact dtype and C-contiguity and inner has no out=,
+    so neither inherits the destination contract."""
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        for op in (fnp.dot, fnp.inner):
+            with pytest.raises(TypeError):
+                op(a, b, out=np.empty((N, N)))  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+
+# --- return identity: the defect the feature exposes ----------------------
+
+
+def test_matmul_returns_the_destination_when_the_output_is_symmetric():
+    """``matmul(S, S)`` infers a symmetric output, which is the branch that used
+    to mint a new SymmetricTensor over the caller's buffer."""
+    load_weights()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        s = f.as_symmetric(_symmetric(), symmetry=(0, 1))
+        dest = np.empty((N, N))
+        r = fnp.matmul(s, s, out=dest)  # pyright: ignore[reportArgumentType, reportCallIssue]
+        assert r is dest
+        np.testing.assert_allclose(dest, np.asarray(s) @ np.asarray(s))
+
+
+def test_matmul_returns_a_tagged_destination_itself():
+    load_weights()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        s = f.as_symmetric(_symmetric(), symmetry=(0, 1))
+        dest = fnp.zeros((N, N))
+        assert fnp.matmul(s, s, out=dest) is dest
+
+
+def test_sibling_contractions_also_return_their_destination():
+    """The fix lives in the shared helper, so vecdot/matvec inherit it."""
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        d1 = np.empty(N)
+        assert fnp.vecdot(a, b, out=d1) is d1
+        d2 = np.empty(N)
+        assert fnp.matvec(a, np.ones(N), out=d2) is d2
+
+
+# --- billing: both directions --------------------------------------------
+
+
+def test_a_same_dtype_destination_does_not_change_the_bill():
+    load_weights()
+    a, b = _pair(np.float32)
+    bare = _billed(lambda: fnp.matmul(a, b))
+    same = _billed(lambda: fnp.matmul(a, b, out=np.empty((N, N), np.float32)))  # pyright: ignore[reportArgumentType, reportCallIssue]
+    assert same == bare
+
+
+def test_a_wider_destination_raises_the_bill():
+    """The upward direction. Omitting it is how a destination that is never
+    folded into the rate passes for correct."""
+    load_weights()
+    a, b = _pair(np.float32)
+    bare = _billed(lambda: fnp.matmul(a, b))
+    wide = _billed(lambda: fnp.matmul(a, b, out=np.empty((N, N), np.float64)))  # pyright: ignore[reportArgumentType, reportCallIssue]
+    assert wide > bare
+
+
+def test_a_neutral_destination_does_not_lower_the_bill():
+    """The downward direction: a non-numeric store must not launder the rate."""
+    load_weights()
+    a, b = _pair(np.float64)
+    bare = _billed(lambda: fnp.matmul(a, b))
+    neutral = _billed(lambda: fnp.matmul(a, b, out=np.empty((N, N), dtype=object)))  # pyright: ignore[reportArgumentType, reportCallIssue]
+    assert neutral == bare
+
+
+# --- inherited from _normalize_out ---------------------------------------
+
+
+def test_a_one_tuple_destination_bills_and_returns_like_a_bare_one():
+    load_weights()
+    a, b = _pair(np.float32)
+    wide = np.empty((N, N), np.float64)
+    bare_bill = _billed(lambda: fnp.matmul(a, b, out=wide))  # pyright: ignore[reportArgumentType, reportCallIssue]
+    tuple_bill = _billed(lambda: fnp.matmul(a, b, out=(wide,)))  # pyright: ignore[reportArgumentType, reportCallIssue]
+    assert tuple_bill == bare_bill
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        returned = fnp.matmul(a, b, out=(wide,))  # pyright: ignore[reportArgumentType, reportCallIssue]
+        assert returned is wide
+
+
+def test_a_bad_container_is_refused_before_anything_is_billed():
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True) as bud:
+        before = bud.flops_used
+        with pytest.raises(TypeError):
+            fnp.matmul(a, b, out=[np.empty((N, N))])  # pyright: ignore[reportArgumentType, reportCallIssue]
+        assert bud.flops_used == before
+
+
+# --- symmetry: matmul must behave exactly like its siblings ---------------
+
+
+def test_a_tag_on_the_destination_is_voided_not_raised():
+    """The contraction helper and the fft family both void a tag the write
+    invalidates; only fnp.einsum raises. matmul follows its own family."""
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        dest = fnp.zeros((N, N))
+        fnp.matmul(a, b, out=dest)  # pyright: ignore[reportArgumentType, reportCallIssue]
+        assert getattr(dest, "symmetry", None) is None
+        np.testing.assert_allclose(np.asarray(dest), a @ b)

--- a/tests/test_matmul_out.py
+++ b/tests/test_matmul_out.py
@@ -175,8 +175,7 @@ def test_a_bad_container_is_refused_before_anything_is_billed():
 
 
 def test_a_tag_on_the_destination_is_voided_not_raised():
-    """The contraction helper and the fft family both void a tag the write
-    invalidates; only fnp.einsum raises. matmul follows its own family."""
+    """An inferred tag is dropped quietly across the whole family now."""
     load_weights()
     a, b = _pair()
     with f.BudgetContext(flop_budget=10**18, quiet=True):
@@ -184,3 +183,86 @@ def test_a_tag_on_the_destination_is_voided_not_raised():
         fnp.matmul(a, b, out=dest)  # pyright: ignore[reportArgumentType, reportCallIssue]
         assert getattr(dest, "symmetry", None) is None
         np.testing.assert_allclose(np.asarray(dest), a @ b)
+
+
+# --- aligning the contraction family with the pointwise gate --------------
+
+
+def test_a_validated_tag_on_the_destination_is_an_error():
+    """A tag the caller paid ``as_symmetric`` to validate is a claim about that
+    buffer. Contradicting it is a mistake worth surfacing -- which is what the
+    pointwise factories already do, via the same gate."""
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        dest = f.as_symmetric(_symmetric(), symmetry=(0, 1))
+        with pytest.raises((ValueError, f.SymmetryError)):
+            fnp.matmul(a, b, out=dest)  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+
+def test_an_inferred_tag_on_the_destination_is_not_an_error():
+    """The converse: a tag merely inferred from a constant fill is dropped
+    quietly, so an ordinary scratch arena keeps working."""
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        dest = fnp.zeros((N, N))
+        fnp.matmul(a, b, out=dest)  # pyright: ignore[reportArgumentType, reportCallIssue]
+        assert getattr(dest, "symmetry", None) is None
+
+
+def test_the_siblings_gain_the_same_gate():
+    """The gate lives in the shared helper, so vecdot inherits it. Batched
+    operands so the result is 2-D and a two-axis tag is meaningful."""
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        dest = f.as_symmetric(_symmetric(), symmetry=(0, 1))
+        with pytest.raises((ValueError, f.SymmetryError)):
+            fnp.vecdot(a[:, None, :], b[None, :, :], out=dest)
+
+
+def test_einsum_stops_raising_on_a_merely_inferred_tag():
+    """einsum lifted the destination's own tag into a requirement on the
+    result, so a scratch arena from fnp.zeros made a legal contraction raise.
+    A validated tag must still raise."""
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        arena = fnp.zeros((N, N))
+        fnp.einsum("ij,jk->ik", a, b, out=arena)
+        np.testing.assert_allclose(np.asarray(arena), a @ b)
+        assert getattr(arena, "symmetry", None) is None
+
+
+def test_einsum_still_raises_on_a_validated_tag():
+    load_weights()
+    a, b = _pair()
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        dest = f.as_symmetric(_symmetric(), symmetry=(0, 1))
+        with pytest.raises((ValueError, f.SymmetryError)):
+            fnp.einsum("ij,jk->ik", a, b, out=dest)
+
+
+# --- the destination must actually be written ----------------------------
+
+
+def test_a_destination_numpy_ignored_is_still_written(monkeypatch):
+    """numpy has shipped functions that silently hardcode out=None (hfft,
+    ifft2, irfft2 on 2.0-2.4). The contraction path returns ``out``, so if that
+    ever happened here the caller would receive an untouched buffer AS the
+    result, at full price. Simulate it rather than wait for a numpy that does."""
+    load_weights()
+    a, b = _pair()
+    real = np.matmul
+
+    def ignores_out(x, y, **kwargs):
+        kwargs.pop("out", None)  # pretend numpy dropped the destination
+        return real(x, y)
+
+    monkeypatch.setattr(np, "matmul", ignores_out)
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        dest = np.zeros((N, N))
+        r = fnp.matmul(a, b, out=dest)  # pyright: ignore[reportArgumentType, reportCallIssue]
+        assert r is dest
+        np.testing.assert_allclose(dest, a @ b)


### PR DESCRIPTION
Closes the `out=` gap reported in discourse #18101.

## What changed

`fnp.matmul` took `(a, b)` only, while `vecdot`/`matvec`/`vecmat` already accepted `out=` — they forward `**kwargs` into the same helper. The surface was arbitrary rather than deliberate.

`out` is a **declared parameter, not varkw**. That is what enrols matmul in the derived `out=` sweep from #156, which discovers ops by reading the wrapper's parameters — three of its cases now drive matmul and pass. A destination arriving through `**kwargs` would have been invisible to it.

## The defect this exposed

The shared helper set `result = out` and then, when an output symmetry was inferred, returned a **new `SymmetricTensor` over the destination's memory** instead of the destination:

```
matmul(S, S, out=arena)   ->  ret is arena: False,  type: SymmetricTensor
einsum(...,  out=arena)   ->  ret is arena: True
np.matmul(...,out=arena)  ->  ret is arena: True
```

So a caller writing `r = matmul(a, b, out=arena)` and then also using `arena` held two objects of different types over one buffer. The wrap is now taken only when no destination was supplied; validation is unchanged. `vecdot`/`matvec`/`vecmat` inherit the fix.

Note this is the same *shape* as #163's "returning buffers numpy never wrote", though not the same bug — here the write does land, only the returned object was wrong.

## What it inherits for free

Nothing new was needed for billing. The helper has priced the destination through `store_billing_dtypes` since #159 and normalized it through `_normalize_out` since #156, so matmul gets tuple parity, free refusal of a bad container, and the widest-participating-buffer rate without new code. Measured: same-dtype destination leaves the bill unchanged, `float32 -> float64` destination doubles it, one-tuple bills identically to bare, `out=[dest]` raises having billed 0.

## Two deliberate calls

**Symmetry matches the siblings, not einsum.** A tag the write invalidates is voided, not raised on — what the contraction helper and the fft family already do. `fnp.einsum` is the outlier that raises:

| destination carries a tag, result asymmetric | behaviour |
|---|---|
| `fnp.einsum` | raises `SymmetryError` |
| contraction helper (this PR's path) | succeeds, voids the tag |
| `fnp.fft.*` | succeeds, voids the tag |

Making matmul raise would have been a behaviour change dressed as a gap-fix, and would have split the family three ways instead of two. **The divergence is worth settling — but as its own decision, not inside a feature PR.**

**`dot` and `inner` unchanged.** numpy's `dot` demands exact dtype and C-contiguity, so the widening bill can never engage and callers inherit post-billing `ValueError`s; `np.inner` has no `out` at all.

## Testing

The rate is pinned in **both directions** — a wider destination must raise the bill, a neutral one must not lower it. A probe built only from the second cannot distinguish a correct implementation from one that never folds the destination at all; that blindness is how the 2x fft under-bill in #163 survived an earlier sweep. Destination **content** is asserted separately from cost for the same reason: a destination billed correctly and never written is invisible to any cost assertion.

- new `tests/test_matmul_out.py`, 12 cases
- derived sweep from #156 now drives matmul: 3 cases, passing
- full suite **6656 passed** with `--all-extras`, no regressions
- `ruff check` / `ruff format` clean, `pyright` **0 errors**
- `scripts/generate_api_docs.py` runs clean and produces no diff (matmul takes numpy's upstream docstring, which already documents `out`)

## Not included

The einsum-vs-family symmetry divergence above, and a latent robustness note: the helper's `if out is not None: result = out` has no guard that numpy actually honoured `out=`. It doesn't bite on numpy 2.2.6 — all five contraction entry points honour it — but the fft family proved numpy can silently drop `out=` for some members of a family and not others, under a `<2.5.0` pin. Worth a content guard on the contraction path separately.