### PR TITLE
fix(billing): close the out= follow-ups left open by #156, #162 and #163

### DIFF
--- a/docs/reference/cost-model.md
+++ b/docs/reference/cost-model.md
@@ -439,6 +439,22 @@ Worked consequences:
   work, and pricing it at that wider rate holds `out=`-casting at exact `astype`
   parity in both directions: a wider `out=` costs what the equivalent `astype` costs,
   so `out=` can never be used to buy a cheaper wide copy than `astype` would.
+- **A destination NumPy would have allocated anyway is price-neutral.** The rule above
+  prices a destination as a buffer the call materializes — but two kinds of destination
+  are not stores of the computed value at all, and naming them must cost exactly what
+  letting NumPy allocate them costs. A **multi-output** op can have an output whose dtype
+  belongs to the op signature rather than to its arithmetic: `frexp`'s second output is
+  always `int32`, whatever precision the mantissa runs at, so `frexp(a_f32, out=(m_f32,
+  e_i32))` bills what `frexp(a_f32)` bills (`10000` for a 10,000-element call), not the
+  float64 rate that `result_type(float32, float32, int32)` would have promoted to. An
+  **index reduction**'s destination holds positions, not values: `argmin`/`argmax`/
+  `nanargmin`/`nanargmax` return `intp` regardless of the input's precision, so
+  `argmin(a_f32, out=intp_arr)` bills what `argmin(a_f32)` bills (`9999`). Widening past
+  NumPy's own choice still widens the rate in both families — a float64 mantissa or an
+  int64 exponent on `frexp` bills `20000`. Index reductions additionally constrain `out=`
+  by **kind**: NumPy accepts any integer or boolean buffer at any width and refuses every
+  float and complex one, and that refusal is decided before the reduction runs, so it
+  costs `0`.
 - **Casting/converting bills like `copy`.** `astype` and `asarray` bill `numel(input)`
   at the heavier of source/destination rate — via `heavier_billing_dtype`, not
   `result_type`, which would over-promote a cross-kind cast such as `float32 → int32`

--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -16,6 +16,16 @@ loop that actually runs. Reductions separately fold ``out=`` into
 ``reduction_billing_dtype`` for a different, genuine reason: there, a wider
 ``out=`` changes the accumulator numpy actually runs, not merely the final
 store, so that path is unaffected by this note.
+
+Two destinations are outside the doctrine because they are not stores of the
+computed value at all, and both are handled by their own helper rather than
+by ``store_billing_dtypes``. A multi-output op can have an output whose dtype
+is part of the op SIGNATURE (``frexp``'s int32 exponent) --
+``multi_store_billing_dtypes``. An index reduction's destination holds
+positions rather than values, so its width says nothing about the arithmetic
+-- ``_pointwise._INDEX_RETURNING_REDUCTIONS``. In both cases supplying the
+buffer numpy would have allocated anyway must be price-neutral against the
+bare call; widening past it still widens the rate.
 """
 
 from __future__ import annotations
@@ -70,6 +80,93 @@ def store_billing_dtypes(out) -> tuple:
     if not isinstance(out, _np.ndarray):
         return ()
     return () if out.dtype.kind in _NON_NUMERIC_KINDS else (out.dtype,)
+
+
+def natural_output_dtypes(np_func, resolved_input: _np.dtype | None) -> tuple | None:
+    """Dtypes numpy allocates for each output slot when ``out=`` is omitted.
+
+    Read out of the ufunc's own loop table via ``resolve_dtypes``, so it
+    tracks whatever numpy in the support matrix is installed rather than a
+    hand-maintained mapping that can drift.
+
+    ``resolved_input`` is the ALREADY-PROMOTED operand dtype -- the same
+    ``result_type`` the rest of the billing runs on, weak Python scalars
+    folded in -- and it is fed to every input slot. Promoting first is what
+    keeps a NEP 50 weak scalar from inventing a natural output wider than the
+    call really has: ``divmod(f32_array, 2.0)`` computes float32, so its
+    natural destinations are float32, and a caller-supplied float64 one is a
+    genuine widening that must still reach the rate. Handing the raw operand
+    dtypes to ``resolve_dtypes`` (which knows nothing of weak scalars) would
+    have reported float64 as natural and handed that widening back for free.
+
+    Returns ``None`` when the loop cannot be resolved at all -- a non-ufunc,
+    an operand kind with no loop, a promotion numpy refuses. Callers then
+    fall back to folding every destination into the rate unconditionally,
+    which over-bills rather than under-bills.
+    """
+    resolve = getattr(np_func, "resolve_dtypes", None)
+    nin = getattr(np_func, "nin", None)
+    nout = getattr(np_func, "nout", None)
+    if resolve is None or not nin or not nout or resolved_input is None:
+        return None
+    try:
+        signature = resolve((resolved_input,) * nin + (None,) * nout)
+    except (TypeError, ValueError, _np.exceptions.DTypePromotionError):
+        return None
+    if signature is None or len(signature) != nin + nout:
+        return None
+    return tuple(signature[nin:])
+
+
+def multi_store_billing_dtypes(out, natural: tuple | None) -> tuple:
+    """What the ``out=`` slots of a multi-output op contribute to the rate.
+
+    Same widest-participating-buffer doctrine as :func:`store_billing_dtypes`,
+    with the one correction a multi-output signature forces: a slot
+    contributes only what it adds ON TOP of the buffer numpy would have
+    allocated for that slot anyway.
+
+    A single-output op does not need the distinction, because its natural
+    destination is the compute dtype already in the resolution -- folding it
+    in again is a no-op. A multi-output op can have an output whose dtype is
+    part of the op SIGNATURE rather than of its arithmetic, and there folding
+    unconditionally prices a buffer the caller merely supplied instead of
+    letting numpy allocate it. ``frexp`` is the case in point: its second
+    output is always ``int32``, whatever the mantissa's precision, so
+    ``np.result_type(float32, float32, int32)`` promoted to float64 and
+    ``frexp(a32, out=(m32, e32))`` billed twice what ``frexp(a32)`` billed --
+    the caller paying the float64 rate for arithmetic numpy runs at float32,
+    purely for naming destinations numpy would have created itself. Supplying
+    the natural destination must be price-neutral.
+
+    Widening is untouched in either axis. A slot pricier than its natural
+    counterpart still joins the resolution, so a float64 mantissa on a
+    float32 ``frexp`` still bills at the float64 rate, and so does an int64
+    exponent buffer where numpy would have made an int32 one. The kind axis
+    is guarded separately: a complex destination over a real natural output
+    joins even at an equal rate, since complex64 and float32 both rate 1.0
+    and the op's complex factor rides on the KIND, not the rate -- the same
+    tie that produced a 6x swing in ``prod`` and is pinned in
+    :func:`reduction_billing_dtype`.
+
+    ``natural=None`` means the loop could not be resolved; every destination
+    then folds in as before, which over-bills rather than under-bills.
+    """
+    if out is None:
+        return ()
+    contributed: tuple = ()
+    for index, slot_out in enumerate(out):
+        slot = store_billing_dtypes(slot_out)
+        if not slot:
+            continue
+        if natural is not None and index < len(natural):
+            nat = _np.dtype(natural[index])
+            wider = rate_for(slot[0]) > rate_for(nat)
+            complex_over_real = slot[0].kind == "c" and nat.kind != "c"
+            if not wider and not complex_over_real:
+                continue
+        contributed += slot
+    return contributed
 
 
 def resolve_billing_dtype(dtypes: tuple) -> _np.dtype | None:

--- a/src/flopscope/_dtype_billing.py
+++ b/src/flopscope/_dtype_billing.py
@@ -160,10 +160,17 @@ def multi_store_billing_dtypes(out, natural: tuple | None) -> tuple:
         if not slot:
             continue
         if natural is not None and index < len(natural):
-            nat = _np.dtype(natural[index])
-            wider = rate_for(slot[0]) > rate_for(nat)
-            complex_over_real = slot[0].kind == "c" and nat.kind != "c"
-            if not wider and not complex_over_real:
+            # EXACT match, not "no pricier by rate". The thing being skipped
+            # here is a `result_type` JOIN, and rate ordering is a different
+            # relation from promotion: result_type(int32, float32) is float64
+            # even though int32 and float32 rate the same. A rate test
+            # therefore drops every equal-rate CROSS-KIND destination from the
+            # resolution -- measured as a fresh 2x discount on divmod, where a
+            # float32 buffer receiving an int32 quotient is a genuine store of
+            # the computed value and must be priced. Only the destination
+            # numpy would have allocated itself is price-neutral, and that is
+            # an identity, so test it as one.
+            if slot[0] == _np.dtype(natural[index]):
                 continue
         contributed += slot
     return contributed

--- a/src/flopscope/_ndarray.py
+++ b/src/flopscope/_ndarray.py
@@ -110,6 +110,42 @@ def _build_passthrough():
 _INITIAL_PASSTHROUGH = _build_passthrough()
 
 
+class _ReadOnlyFlatIter:
+    """Wraps ``ndarray.flat`` so reads pass through and writes are refused.
+
+    The underlying flatiter writes the buffer directly, so neither
+    ``__setitem__`` nor the write-epoch hook ever sees ``arr.flat[:] = ...``.
+    Everything else about the iterator is forwarded untouched, so reading,
+    iterating, indexing and ``.copy()`` behave exactly as before.
+    """
+
+    __slots__ = ("_it",)
+
+    def __init__(self, it: Any) -> None:
+        object.__setattr__(self, "_it", it)
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        raise ValueError(
+            "in-place assignment through .flat is not supported; flopscope "
+            "arrays are immutable. Build the result functionally instead."
+        )
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._it[key]
+
+    def __iter__(self) -> Any:
+        return iter(self._it)
+
+    def __len__(self) -> int:
+        return len(self._it)
+
+    def __array__(self, *args: Any, **kwargs: Any) -> Any:
+        return _np.asarray(self._it, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_it"), name)
+
+
 class FlopscopeArray(_np.ndarray):
     """A numpy ndarray subclass with FLOP-tracked operators.
 
@@ -909,6 +945,26 @@ class FlopscopeArray(_np.ndarray):
             "in-place resize is not supported; flopscope arrays are immutable. "
             "Use fnp.reshape(arr, new_shape) to create a reshaped copy."
         )
+
+    def setfield(self, *args: Any, **kwargs: Any) -> None:
+        raise ValueError(
+            "in-place setfield is not supported; flopscope arrays are "
+            "immutable. Build the result functionally instead."
+        )
+
+    @property
+    def flat(self) -> Any:
+        """Read-only flat iterator.
+
+        ``arr.flat[:] = ...`` is the same category as ``fill``/``put``/
+        ``resize`` above -- a C-level route that writes the buffer without
+        going through ``__setitem__`` -- and it was the one member of that
+        category left unguarded. It matters beyond immutability: a symmetry
+        tag gates a billing discount and is voided when its buffer is
+        written, so a write the library cannot see leaves the tag standing
+        over data it no longer describes.
+        """
+        return _ReadOnlyFlatIter(_np.ndarray.flat.__get__(self))
 
     # ----- Binary arithmetic -----
 

--- a/src/flopscope/_ndarray.py
+++ b/src/flopscope/_ndarray.py
@@ -110,31 +110,46 @@ def _build_passthrough():
 _INITIAL_PASSTHROUGH = _build_passthrough()
 
 
-class _ReadOnlyFlatIter:
-    """Wraps ``ndarray.flat`` so reads pass through and writes are refused.
+class _TrackedFlatIter:
+    """Wraps ``ndarray.flat`` so a write through it is observed.
 
-    The underlying flatiter writes the buffer directly, so neither
-    ``__setitem__`` nor the write-epoch hook ever sees ``arr.flat[:] = ...``.
-    Everything else about the iterator is forwarded untouched, so reading,
-    iterating, indexing and ``.copy()`` behave exactly as before.
+    ``arr.flat[:] = ...`` and ``arr.flat = ...`` write the buffer directly,
+    below ``__setitem__`` and below the ``out=`` keyword the write-epoch hook
+    watches. A symmetry tag gates a billing discount and is voided when its
+    buffer is written, so an unobserved write leaves the claim standing over
+    data it no longer describes.
+
+    These writes are RECORDED rather than refused, unlike the ``fill``/
+    ``put``/``resize`` overrides above. Assigning through ``.flat`` is a
+    documented NumPy idiom that NumPy's own test suite exercises
+    (``a.flat = range(1, 37)``), and it worked here before the tag machinery
+    existed -- refusing it would break working code to fix a billing hole
+    that voiding closes just as well.
     """
 
-    __slots__ = ("_it",)
+    __slots__ = ("_it", "_owner")
 
-    def __init__(self, it: Any) -> None:
+    def __init__(self, it: Any, owner: Any) -> None:
         object.__setattr__(self, "_it", it)
+        object.__setattr__(self, "_owner", owner)
 
     def __setitem__(self, key: Any, value: Any) -> None:
-        raise ValueError(
-            "in-place assignment through .flat is not supported; flopscope "
-            "arrays are immutable. Build the result functionally instead."
-        )
+        from flopscope._write_epoch import note_write
+
+        self._it[key] = value
+        note_write(self._owner)
 
     def __getitem__(self, key: Any) -> Any:
         return self._it[key]
 
     def __iter__(self) -> Any:
-        return iter(self._it)
+        # Returning ``iter(self._it)`` would hand back the raw flatiter, and a
+        # caller holding it could write straight through ``it[:] = ...``,
+        # around both the setitem above and the epoch hook. Stay wrapped.
+        return self
+
+    def __next__(self) -> Any:
+        return next(self._it)
 
     def __len__(self) -> int:
         return len(self._it)
@@ -954,17 +969,19 @@ class FlopscopeArray(_np.ndarray):
 
     @property
     def flat(self) -> Any:
-        """Read-only flat iterator.
+        """Flat iterator whose writes are observed. See :class:`_TrackedFlatIter`."""
+        # Via a base-ndarray view rather than the descriptor: the view shares
+        # this array's buffer, so the iterator it yields writes through to us.
+        return _TrackedFlatIter(self.view(_np.ndarray).flat, self)
 
-        ``arr.flat[:] = ...`` is the same category as ``fill``/``put``/
-        ``resize`` above -- a C-level route that writes the buffer without
-        going through ``__setitem__`` -- and it was the one member of that
-        category left unguarded. It matters beyond immutability: a symmetry
-        tag gates a billing discount and is voided when its buffer is
-        written, so a write the library cannot see leaves the tag standing
-        over data it no longer describes.
-        """
-        return _ReadOnlyFlatIter(_np.ndarray.flat.__get__(self))
+    @flat.setter
+    def flat(self, value: Any) -> None:
+        from flopscope._write_epoch import note_write
+
+        # numpy's stubs declare `flat` read-only; the runtime descriptor has a
+        # setter, which is the whole reason this override has to exist.
+        self.view(_np.ndarray).flat = value  # pyright: ignore[reportAttributeAccessIssue]
+        note_write(self)
 
     # ----- Binary arithmetic -----
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -1151,7 +1151,8 @@ def _counted_ufunc_outer(ufunc, a, b, *, out=None, **kwargs):
         shapes=(a.shape, b.shape),
         dtypes=billing_dtypes,
     ):
-        result = ufunc.outer(
+        result = _call_numpy(
+            ufunc.outer,
             _to_base_ndarray(a),
             _to_base_ndarray(b),
             out=out_stripped,
@@ -1207,7 +1208,8 @@ def _counted_ufunc_reduce_generic(
         shapes=(a.shape,),
         dtypes=billing_dtypes,
     ):
-        result = ufunc.reduce(
+        result = _call_numpy(
+            ufunc.reduce,
             _to_base_ndarray(a),
             axis=axis,
             out=out_stripped,
@@ -1262,7 +1264,8 @@ def _counted_ufunc_accumulate_generic(ufunc, a, *, axis=0, out=None, **kwargs):
         shapes=(a.shape,),
         dtypes=billing_dtypes,
     ):
-        result = ufunc.accumulate(
+        result = _call_numpy(
+            ufunc.accumulate,
             _to_base_ndarray(a),
             axis=axis,
             out=out_stripped,
@@ -1326,7 +1329,8 @@ def _counted_ufunc_reduceat(ufunc, a, indices, *, axis=0, out=None, **kwargs):
         shapes=(a.shape,),
         dtypes=billing_dtypes,
     ):
-        result = ufunc.reduceat(
+        result = _call_numpy(
+            ufunc.reduceat,
             _to_base_ndarray(a),
             indices_stripped,
             axis=axis,
@@ -1419,7 +1423,16 @@ def _counted_ufunc_at(ufunc, a, indices, *args, **kwargs):
         shapes=(a.shape,) if hasattr(a, "shape") else (),
         dtypes=billing_dtypes,
     ):
-        ufunc.at(
+        # ``ufunc.at`` writes into its FIRST argument, not into an ``out=``, so
+        # _call_numpy's out= hook cannot see it and its _MUTATES_FIRST_ARG set
+        # cannot list it either -- that set holds module-level function objects
+        # and ``at`` is a fresh bound method per ufunc. Record the write here.
+        # The refusal above keeps a tagged SymmetricTensor out of this path, but
+        # a plain alias of a tagged buffer reaches it, which is exactly the case
+        # a guard on tagged arrays cannot cover.
+        note_write(_to_base_ndarray(a) if isinstance(a, _np.ndarray) else a)
+        _call_numpy(
+            ufunc.at,
             _to_base_ndarray(a),
             indices_stripped,
             *stripped_args,
@@ -1577,6 +1590,15 @@ def _counted_reduction(
             shapes=(a.shape,),
             dtypes=billing_dtypes,
         ):
+            if out_came_from_args:
+                # The destination travels in a positional slot of ``args_list``,
+                # so ``np_out_kwarg`` is None and _call_numpy's out= hook never
+                # sees it -- the same write that the keyword spelling records
+                # would otherwise go unnoticed, leaving a symmetry tag standing
+                # over data it no longer describes. Recorded here rather than
+                # above the deduct so a refused op does not void a tag on a
+                # buffer numpy was never given the chance to write.
+                note_write(out_for_np)
             if _axis_is_second_positional:
                 result = _call_with_optional_out(
                     np_func,

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -21,6 +21,8 @@ from flopscope._dtype_billing import (
     binary_float_loop_dtype,
     heavier_billing_dtype,
     mean_compute_dtype,
+    multi_store_billing_dtypes,
+    natural_output_dtypes,
     reduction_billing_dtype,
     resolve_billing_dtype,
     store_billing_dtypes,
@@ -79,6 +81,67 @@ _INTEGER_ACCUMULATING_REDUCTIONS = frozenset(
         "nancumprod",
     }
 )
+
+# Reductions whose result is an INDEX rather than a value. numpy fixes their
+# output dtype at ``np.intp`` regardless of the input's precision, and
+# constrains ``out=`` by KIND rather than by width: any integer or boolean
+# buffer is accepted at any width, and every float or complex one is refused
+# outright, before the reduction runs. Two consequences, both handled in
+# ``_counted_reduction``:
+#
+#   * The refusal is decidable from the destination's dtype alone, so it
+#     belongs ABOVE ``budget.deduct`` and must cost zero. It used to sit
+#     below: ``argmin`` on 10,000 float32 with a float64 destination charged
+#     19,998 FLOPs and only then raised ``ValueError`` from numpy.
+#   * The destination can never be the accumulator. An index buffer holds
+#     positions, not the values being compared, so its width says nothing
+#     about the arithmetic -- ``out`` is kept out of
+#     ``reduction_billing_dtype`` for these ops entirely, which is what makes
+#     supplying the ``intp`` buffer numpy would have allocated anyway
+#     price-neutral against the bare call (both 9,999 on the case above,
+#     where the destination previously doubled the rate).
+#
+# Membership is not hand-maintained: ``test_index_reduction_out_billing``
+# re-derives it from the registry by probing numpy itself, so a reduction
+# that starts returning indices cannot be missed.
+_INDEX_RETURNING_REDUCTIONS = frozenset(
+    {
+        "argmax",
+        "argmin",
+        "nanargmax",
+        "nanargmin",
+    }
+)
+
+
+def _refuse_non_index_destination(op_name: str, out: object, axis: object) -> None:
+    """Refuse an ``out=`` numpy cannot use as an index buffer -- before charging.
+
+    numpy's own rule, measured on 2.2.6 across every scalar dtype and both
+    the ``axis=None`` and ``axis=`` forms of all four ops, is exactly
+    ``can_cast(out.dtype, intp, casting="safe")``: bool and every signed or
+    unsigned integer narrower than ``intp`` are accepted (numpy casts the
+    index down on store), ``uint64``, every float, every complex and every
+    non-numeric dtype are refused. Reproducing the predicate rather than
+    inventing a stricter one is what keeps this guard from failing a call
+    plain numpy would allow.
+
+    Class and wording mirror numpy's, for the same reason
+    :func:`_normalize_out` mirrors the ufunc parser: intercepting the
+    argument earlier than numpy does should not change what the failure looks
+    like to a caller. numpy says "scalar" for the whole-array reduction and
+    "array data" for a per-axis one.
+    """
+    if not isinstance(out, _np.ndarray):
+        return
+    if _np.can_cast(out.dtype, _np.intp, casting="safe"):
+        return
+    noun = "scalar" if axis is None else "array data"
+    raise TypeError(
+        f"{op_name}(): Cannot cast {noun} from {out.dtype!r} to "
+        f"{_np.dtype(_np.intp)!r} according to the rule 'safe'"
+    )
+
 
 # Float-only ufuncs: numpy has no integer loops for these, so integer/bool
 # inputs promote to a float compute dtype (same-size float for unary ops,
@@ -668,6 +731,16 @@ def _counted_unary_multi(np_func, op_name: str):
     int32 regardless of the mantissa's size-mapped precision -- a narrow
     mantissa (float16, from an int8 input) would otherwise undercount the
     fixed-width exponent, so its billed dtype is floored at int32's rate too.
+
+    That floor is the ONLY thing that prices the exponent. A caller-supplied
+    exponent buffer must not price it a second time: an ``int32`` destination
+    is what numpy allocates for that slot anyway, so folding it into
+    ``np.result_type`` alongside a float32 mantissa promoted the whole
+    resolution to float64 and doubled the bill for naming a destination the
+    op was always going to produce. ``multi_store_billing_dtypes`` keeps a
+    slot out of the resolution unless it is genuinely pricier than numpy's
+    own choice for that slot, so widening either output still widens the
+    rate while the natural pair stays free.
     """
     nout = getattr(np_func, "nout", 2)
 
@@ -696,9 +769,13 @@ def _counted_unary_multi(np_func, op_name: str):
             billing_dtypes: tuple = (_np.dtype(explicit_dtype),)
         else:
             billing_dtypes = (x.dtype,)
-            if out is not None:
-                for o in out:
-                    billing_dtypes += store_billing_dtypes(o)
+            # Only what a destination adds ON TOP of the buffer numpy would
+            # have allocated for that slot: ``frexp``'s exponent is int32 by
+            # signature, not because anything asked for 32-bit integer
+            # arithmetic, so naming it must not promote the resolution.
+            billing_dtypes += multi_store_billing_dtypes(
+                out, natural_output_dtypes(np_func, x.dtype)
+            )
         if op_name in _UNARY_FLOAT_LOOP_OPS:
             resolved = resolve_billing_dtype(billing_dtypes)
             if resolved is not None:
@@ -899,9 +976,13 @@ def _counted_binary_multi(np_func, op_name: str):
             billing_dtypes = (_np.dtype(explicit_dtype),)
         else:
             billing_dtypes = (billing_operand(x_orig, x), billing_operand(y_orig, y))
-            if out is not None:
-                for o in out:
-                    billing_dtypes += store_billing_dtypes(o)
+            # Resolve the operands FIRST so a NEP 50 weak scalar cannot make
+            # the natural destination look wider than the loop really is --
+            # see ``natural_output_dtypes``.
+            billing_dtypes += multi_store_billing_dtypes(
+                out,
+                natural_output_dtypes(np_func, resolve_billing_dtype(billing_dtypes)),
+            )
         with budget.deduct(
             op_name,
             flop_cost=cost,
@@ -1416,6 +1497,12 @@ def _counted_reduction(
             out = _normalize_out(args_list[_out_args_idx], op_name)
             out_came_from_args = True
 
+        # Still above the deduct, and above every read of ``out`` below it:
+        # an index reduction refuses a non-index destination outright, and a
+        # refused form must cost zero.
+        if op_name in _INDEX_RETURNING_REDUCTIONS:
+            _refuse_non_index_destination(op_name, out, axis)
+
         new_symmetry = (
             reduce_group(symmetry, ndim=len(a.shape), axis=axis, keepdims=keepdims)
             if symmetry is not None
@@ -1464,11 +1551,22 @@ def _counted_reduction(
             if op_name in _INTEGER_ACCUMULATING_REDUCTIONS
             else a.dtype
         )
+        # An index destination is not an accumulator: it holds positions, not
+        # the values being compared, so its width says nothing about the
+        # arithmetic and it stays out of the resolution entirely. Supplying
+        # the intp buffer numpy would have allocated anyway then prices
+        # exactly like the bare call.
+        out_dtype = (
+            out.dtype
+            if isinstance(out, _np.ndarray)
+            and op_name not in _INDEX_RETURNING_REDUCTIONS
+            else None
+        )
         billing_dtypes: tuple = (
             reduction_billing_dtype(
                 a.dtype,
                 explicit_dtype=explicit_dtype,
-                out_dtype=out.dtype if isinstance(out, _np.ndarray) else None,
+                out_dtype=out_dtype,
                 default_dtype=default_dtype,
             ),
         )

--- a/tests/test_index_reduction_out_billing.py
+++ b/tests/test_index_reduction_out_billing.py
@@ -1,0 +1,251 @@
+"""An index reduction's ``out=`` is refused for free and never sets the rate.
+
+``argmin``/``argmax``/``nanargmin``/``nanargmax`` return POSITIONS. numpy
+fixes their result dtype at ``np.intp`` regardless of the input's precision
+and constrains ``out=`` by KIND rather than by width: every integer or
+boolean buffer is accepted at any width, every float and complex one is
+refused outright, before the reduction runs.
+
+Two things followed from charging anyway. ``argmin`` on 10,000 float32 with
+a float64 destination billed 19,998 FLOPs and only then raised -- a refused
+form is supposed to cost zero, and the guard has to sit ABOVE
+``budget.deduct`` for that (there are no refunds; see
+``tests/test_budget.py``). And 19,998 is twice the 9,999 the bare call
+costs, because an index buffer that cannot be the accumulator was widening
+the rate: supplying the ``intp`` destination numpy would have allocated
+anyway must be price-neutral.
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+from flopscope._pointwise import _INDEX_RETURNING_REDUCTIONS
+from flopscope._registry import REGISTRY
+from flopscope._weights import load_weights
+
+N = 10_000
+OPS = sorted(_INDEX_RETURNING_REDUCTIONS)
+
+
+def _billed(fn):
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        fn()
+        return b.flops_used
+
+
+@pytest.fixture(autouse=True)
+def _weights():
+    load_weights()
+
+
+def _f32():
+    return np.random.default_rng(0).standard_normal(N).astype(np.float32)
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_refused_destination_costs_zero(op_name):
+    a = _f32()
+    fs_func = getattr(fnp, op_name)
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        with pytest.raises(TypeError):
+            fs_func(a, out=np.empty((), np.float64))
+        assert b.flops_used == 0  # was 19,998, charged then raised
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_index_destination_prices_exactly_like_the_bare_call(op_name):
+    a = _f32()
+    fs_func = getattr(fnp, op_name)
+    bare = _billed(lambda: fs_func(a))
+    with_out = _billed(lambda: fs_func(a, out=np.empty((), np.intp)))
+    assert bare == with_out == N - 1  # was 9,999 vs 19,998
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_narrow_index_destination_does_not_discount_either(op_name):
+    a = _f32()
+    fs_func = getattr(fnp, op_name)
+    assert _billed(lambda: fs_func(a, out=np.empty((), np.int8))) == N - 1
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_one_tuple_out_bills_what_the_bare_destination_bills(op_name):
+    a = _f32()
+    fs_func = getattr(fnp, op_name)
+    dest = np.empty((), np.intp)
+    assert _billed(lambda: fs_func(a, out=(dest,))) == _billed(
+        lambda: fs_func(a, out=dest)
+    )
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_refusal_is_free_through_the_positional_out_slot_too(op_name):
+    """``argmin(a, None, dest)`` reaches ``out`` by position, not keyword."""
+    a = _f32()
+    fs_func = getattr(fnp, op_name)
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        with pytest.raises(TypeError):
+            fs_func(a, None, np.empty((), np.float64))
+        assert b.flops_used == 0
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_refusal_is_free_through_the_method_surface_too(op_name):
+    a = fnp.asarray(_f32())
+    method = getattr(a, op_name, None)
+    if method is None:  # nanarg* have no ndarray method
+        pytest.skip(f"ndarray has no .{op_name}()")
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        with pytest.raises(TypeError):
+            method(out=np.empty((), np.float64))
+        assert b.flops_used == 0
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_per_axis_form_matches_the_bare_per_axis_form(op_name):
+    a = np.random.default_rng(1).standard_normal((100, 100)).astype(np.float32)
+    fs_func = getattr(fnp, op_name)
+    bare = _billed(lambda: fs_func(a, axis=0))
+    with_out = _billed(lambda: fs_func(a, axis=0, out=np.empty(100, np.intp)))
+    assert bare == with_out
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_destination_still_receives_the_index(op_name):
+    """Free refusal must not have cost the accepted path its write."""
+    a = _f32()
+    fs_func = getattr(fnp, op_name)
+    dest = np.empty((), np.intp)
+    with f.BudgetContext(flop_budget=10**15, quiet=True):
+        result = fs_func(a, out=dest)
+    assert int(dest) == int(getattr(np, op_name)(a))
+    assert int(result) == int(dest)
+
+
+# ---------------------------------------------------------------------------
+# Accept / refuse parity with numpy, and the membership derivation.
+# ---------------------------------------------------------------------------
+
+_PROBE_DTYPES = [
+    "bool",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16",
+    "float32",
+    "float64",
+    "complex64",
+    "complex128",
+    "O",
+    "U5",
+    "datetime64[s]",
+    "timedelta64[s]",
+]
+
+
+@pytest.mark.parametrize("op_name", OPS)
+@pytest.mark.parametrize("dtype_name", _PROBE_DTYPES)
+@pytest.mark.parametrize("axis", [None, 0])
+def test_guard_accepts_and_refuses_exactly_what_numpy_does(op_name, dtype_name, axis):
+    """A pre-dispatch guard that is stricter than numpy is a regression.
+
+    The rule numpy actually applies is ``can_cast(out.dtype, intp, "safe")``:
+    bool and every integer narrower than ``intp`` go through (numpy casts the
+    index down on store), ``uint64`` and everything inexact or non-numeric do
+    not. This sweep is what pins the guard to it.
+    """
+    a = np.random.default_rng(2).standard_normal((4, 5)).astype(np.float32)
+    shape = () if axis is None else (5,)
+    kwargs = {} if axis is None else {"axis": axis}
+    dtype = np.dtype(dtype_name)
+
+    try:
+        getattr(np, op_name)(a, out=np.empty(shape, dtype), **kwargs)
+        numpy_accepts = True
+    except Exception:
+        numpy_accepts = False
+
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        try:
+            getattr(fnp, op_name)(a, out=np.empty(shape, dtype), **kwargs)
+            flopscope_accepts = True
+        except Exception:
+            flopscope_accepts = False
+        used = b.flops_used
+
+    assert flopscope_accepts == numpy_accepts, (
+        f"{op_name} out={dtype_name} axis={axis}: "
+        f"numpy {'accepts' if numpy_accepts else 'refuses'}, "
+        f"flopscope {'accepts' if flopscope_accepts else 'refuses'}"
+    )
+    if not numpy_accepts:
+        assert used == 0
+
+
+def _derive_index_returning_reductions():
+    """Re-derive the family from the registry by asking numpy, not by memory.
+
+    An op qualifies when, on a float input, numpy hands back an INTEGER
+    result (an index, not a value) and constrains ``out=`` by kind: a
+    strictly wider float destination refused, an integer one accepted. That
+    last clause is what keeps ``compress`` -- which also refuses a wider
+    destination, but returns values of the input's own dtype -- out of the
+    set.
+    """
+    probe = np.random.default_rng(3).standard_normal(6).astype(np.float32)
+    derived = set()
+    for name, entry in REGISTRY.items():
+        if entry.get("module") != "numpy":
+            continue
+        np_func = getattr(np, name, None)
+        if np_func is None or not callable(np_func):
+            continue
+        if not isinstance(np_func, np.ufunc):
+            try:
+                if "out" not in inspect.signature(np_func).parameters:
+                    continue
+            except (TypeError, ValueError):
+                continue
+        natural = None
+        accepted_args: tuple = ()
+        for args in ((probe,), (probe, probe)):
+            try:
+                with np.errstate(all="ignore"):
+                    natural = np.asarray(np_func(*args))
+                accepted_args = args
+                break
+            except Exception:
+                continue
+        if natural is None or natural.dtype.kind not in "iu":
+            continue
+
+        def _accepts(dtype, _np_func=np_func, _args=accepted_args, _natural=natural):
+            try:
+                with np.errstate(all="ignore"):
+                    _np_func(*_args, out=np.empty(_natural.shape, dtype))
+                return True
+            except Exception:
+                return False
+
+        if not _accepts(np.intp) or _accepts(np.float64):
+            continue
+        derived.add(name)
+    return derived
+
+
+def test_index_returning_family_is_complete():
+    """The frozenset in ``_pointwise`` must be what numpy says it is."""
+    derived = _derive_index_returning_reductions()
+    assert derived == set(_INDEX_RETURNING_REDUCTIONS)
+    # The probe demonstrably reaches the four -- an empty derivation would
+    # otherwise pass vacuously if the set were ever emptied.
+    assert derived == {"argmin", "argmax", "nanargmin", "nanargmax"}

--- a/tests/test_multi_output_out_billing.py
+++ b/tests/test_multi_output_out_billing.py
@@ -1,0 +1,268 @@
+"""A multi-output op's NATURAL destinations must be price-neutral.
+
+The ``out=`` doctrine prices the widest participating buffer -- a destination
+wider than the compute loop is a real materialization and bills at the wider
+rate (see ``tests/test_out_billing_doctrine.py``). A multi-output signature
+adds one correction to that: an output whose dtype belongs to the op
+SIGNATURE rather than to its arithmetic is not a wider buffer at all, and
+naming it must cost exactly what letting numpy allocate it costs.
+
+``frexp`` is the case: its second output is always ``int32``, whatever
+precision the mantissa runs at, so folding a supplied exponent buffer into
+``np.result_type`` promoted ``(float32, float32, int32)`` to float64 and
+``frexp(a32, out=(m32, e32))`` billed 20,000 against the bare call's 10,000 --
+the caller paying the float64 rate for arithmetic numpy runs at float32,
+purely for naming the destinations numpy would have created itself.
+
+Every pin below is measured in BOTH directions: the natural destination is
+free, and a genuinely wider one still widens.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+from flopscope._weights import load_weights
+
+N = 10_000
+
+
+def _out(*arrays: object) -> Any:
+    """Destination tuple, deliberately loosely typed.
+
+    The wrappers annotate ``out=`` as a tuple of ``FlopscopeArray`` but accept
+    plain ndarrays exactly as numpy does, and plain ndarrays are what the
+    billing has to be measured on.
+    """
+    return tuple(arrays)
+
+
+def _billed(fn):
+    with f.BudgetContext(flop_budget=10**15, quiet=True) as b:
+        fn()
+        return b.flops_used
+
+
+@pytest.fixture(autouse=True)
+def _weights():
+    load_weights()
+
+
+def _f32():
+    return np.random.default_rng(0).standard_normal(N).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# frexp -- the op the correction exists for
+# ---------------------------------------------------------------------------
+
+
+def test_frexp_natural_destinations_are_price_neutral():
+    a = _f32()
+    bare = _billed(lambda: fnp.frexp(a))
+    natural = _billed(
+        lambda: fnp.frexp(a, out=_out(np.empty(N, np.float32), np.empty(N, np.int32)))
+    )
+    assert bare == natural == N  # was 10,000 vs 20,000
+
+
+def test_frexp_natural_destinations_price_neutral_at_float64():
+    a = np.random.default_rng(1).standard_normal(N)
+    bare = _billed(lambda: fnp.frexp(a))
+    natural = _billed(
+        lambda: fnp.frexp(a, out=_out(np.empty(N, np.float64), np.empty(N, np.int32)))
+    )
+    assert bare == natural == 2 * N
+
+
+def test_frexp_wider_mantissa_still_widens_the_rate():
+    a = _f32()
+    wide = _billed(
+        lambda: fnp.frexp(a, out=_out(np.empty(N, np.float64), np.empty(N, np.int32)))
+    )
+    assert wide == 2 * N  # float64 rate, not the float32 loop's
+
+
+def test_frexp_wider_exponent_still_widens_the_rate():
+    """int64 is wider than the int32 numpy would have allocated -- it pays."""
+    a = _f32()
+    wide = _billed(
+        lambda: fnp.frexp(a, out=_out(np.empty(N, np.float32), np.empty(N, np.int64)))
+    )
+    assert wide == 2 * N
+
+
+def test_frexp_narrower_exponent_never_discounts():
+    """A narrow destination is a store, not a loop: it can only cast down."""
+    a = _f32()
+    narrow = _billed(
+        lambda: fnp.frexp(a, out=_out(np.empty(N, np.float32), np.empty(N, np.int16)))
+    )
+    assert narrow == _billed(lambda: fnp.frexp(a)) == N
+
+
+def test_frexp_partial_out_slots_price_like_the_slots_given():
+    a = _f32()
+    assert _billed(lambda: fnp.frexp(a, out=_out(None, np.empty(N, np.int32)))) == N
+    assert (
+        _billed(lambda: fnp.frexp(a, out=_out(np.empty(N, np.float64), None))) == 2 * N
+    )
+
+
+def test_frexp_int32_exponent_floor_survives_a_narrow_mantissa():
+    """The fixed-width exponent is priced by the floor, not by the buffer.
+
+    An int8 input maps to a float16 mantissa loop; the exponent is still
+    int32, so the bill must not fall to the float16 rate whether or not the
+    caller supplies the buffers.
+    """
+    a = np.random.default_rng(2).integers(-100, 100, N).astype(np.int8)
+    bare = _billed(lambda: fnp.frexp(a))
+    natural = _billed(
+        lambda: fnp.frexp(a, out=_out(np.empty(N, np.float16), np.empty(N, np.int32)))
+    )
+    assert bare == natural == N
+
+
+# ---------------------------------------------------------------------------
+# siblings -- modf (both outputs are the loop dtype) and divmod
+# ---------------------------------------------------------------------------
+
+
+def test_modf_natural_destinations_are_price_neutral():
+    a = _f32()
+    bare = _billed(lambda: fnp.modf(a))
+    natural = _billed(
+        lambda: fnp.modf(a, out=_out(np.empty(N, np.float32), np.empty(N, np.float32)))
+    )
+    assert bare == natural == N
+
+
+def test_modf_wider_destination_still_widens_the_rate():
+    a = _f32()
+    wide = _billed(
+        lambda: fnp.modf(a, out=_out(np.empty(N, np.float32), np.empty(N, np.float64)))
+    )
+    assert wide == 2 * N
+
+
+def test_divmod_natural_destinations_are_price_neutral():
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal(N).astype(np.float32)
+    y = (rng.standard_normal(N) + 5.0).astype(np.float32)
+    bare = _billed(lambda: fnp.divmod(x, y))
+    natural = _billed(
+        lambda: fnp.divmod(
+            x, y, out=_out(np.empty(N, np.float32), np.empty(N, np.float32))
+        )
+    )
+    assert bare == natural
+
+
+def test_divmod_wider_destination_still_widens_the_rate():
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal(N).astype(np.float32)
+    y = (rng.standard_normal(N) + 5.0).astype(np.float32)
+    bare = _billed(lambda: fnp.divmod(x, y))
+    wide = _billed(
+        lambda: fnp.divmod(
+            x, y, out=_out(np.empty(N, np.float64), np.empty(N, np.float64))
+        )
+    )
+    assert wide == 2 * bare
+
+
+def test_weak_scalar_operand_does_not_inflate_the_natural_destination():
+    """NEP 50: ``divmod(f32, 2.0)`` computes float32, so float32 is natural.
+
+    Resolving the natural output from the RAW operand dtypes instead of the
+    promoted ones would have reported float64 as natural here and handed the
+    float64 destination away for free.
+    """
+    x = (np.random.default_rng(5).standard_normal(N).astype(np.float32) + 5.0).astype(
+        np.float32
+    )
+    bare = _billed(lambda: fnp.divmod(x, 2.0))
+    natural = _billed(
+        lambda: fnp.divmod(
+            x, 2.0, out=_out(np.empty(N, np.float32), np.empty(N, np.float32))
+        )
+    )
+    wide = _billed(
+        lambda: fnp.divmod(
+            x, 2.0, out=_out(np.empty(N, np.float64), np.empty(N, np.float64))
+        )
+    )
+    assert bare == natural
+    assert wide == 2 * bare
+
+
+# ---------------------------------------------------------------------------
+# The sweep. Derived from the module surface, not hand-listed -- a hand-written
+# list is how a defect at one of three sites goes unnoticed.
+# ---------------------------------------------------------------------------
+
+
+def _multi_output_ops():
+    """Every wrapped op whose numpy counterpart produces more than one array."""
+    found = []
+    for name in dir(fnp):
+        if name.startswith("_"):
+            continue
+        np_func = getattr(np, name, None)
+        if isinstance(np_func, np.ufunc) and np_func.nout > 1:
+            found.append(name)
+    return sorted(found)
+
+
+def test_multi_output_surface_is_the_expected_three():
+    assert _multi_output_ops() == ["divmod", "frexp", "modf"]
+
+
+@pytest.mark.parametrize("op_name", _multi_output_ops())
+def test_every_multi_output_op_prices_its_natural_destinations_at_zero_markup(op_name):
+    """Supplying the buffers numpy would have allocated must change nothing."""
+    rng = np.random.default_rng(6)
+    fs_func = getattr(fnp, op_name)
+    np_func = getattr(np, op_name)
+    x = rng.standard_normal(N).astype(np.float32)
+    args = (
+        (x,)
+        if np_func.nin == 1
+        else (x, (rng.standard_normal(N) + 5.0).astype(np.float32))
+    )
+
+    bare_result = np_func(*args)
+    natural = tuple(np.empty(r.shape, r.dtype) for r in bare_result)
+
+    bare = _billed(lambda: fs_func(*args))
+    with_out = _billed(lambda: fs_func(*args, out=_out(*natural)))
+    assert with_out == bare, f"{op_name}: natural out= billed {with_out} vs bare {bare}"
+
+
+@pytest.mark.parametrize("op_name", _multi_output_ops())
+def test_every_multi_output_op_still_charges_a_genuinely_wider_destination(op_name):
+    """The neutrality above must not have opened a discount on real widening."""
+    rng = np.random.default_rng(7)
+    fs_func = getattr(fnp, op_name)
+    np_func = getattr(np, op_name)
+    x = rng.standard_normal(N).astype(np.float32)
+    args = (
+        (x,)
+        if np_func.nin == 1
+        else (x, (rng.standard_normal(N) + 5.0).astype(np.float32))
+    )
+
+    bare_result = np_func(*args)
+    # Widen every slot by rate while keeping numpy's kind, so the call is one
+    # numpy still accepts: float32 -> float64, int32 -> int64.
+    wider = tuple(np.empty(r.shape, np.dtype(f"{r.dtype.kind}8")) for r in bare_result)
+
+    bare = _billed(lambda: fs_func(*args))
+    with_out = _billed(lambda: fs_func(*args, out=_out(*wider)))
+    assert with_out == 2 * bare, (
+        f"{op_name}: wide out= billed {with_out} vs bare {bare}"
+    )

--- a/tests/test_symmetry_tag_forgery.py
+++ b/tests/test_symmetry_tag_forgery.py
@@ -10,6 +10,14 @@ drop the claim. Otherwise a caller obtains a symmetric-rate discount on
 asymmetric data, with numerically correct results and nothing to signal the
 discrepancy.
 
+One route is NOT closed, and is pinned as an expected failure at the bottom of
+this file rather than left to look covered: Python's buffer protocol.
+``memoryview(tagged)[i, j] = ...`` writes the buffer with nothing in the Python
+layer to observe it. Closing it needs either ``__buffer__`` (PEP 688, and so
+Python 3.12+, above this package's floor) or making tagged buffers
+non-writeable, which would break their legitimate use as ``out=``
+destinations. ``.data`` is not a second instance -- NumPy refuses that itself.
+
 Each test performs a write that makes the data asymmetric and then asserts the
 invariant directly: either the write raised, or the array no longer buys the
 discount. Both outcomes are acceptable; keeping the discount is not.
@@ -474,3 +482,44 @@ def test_ufunc_reduceat_does_not_forge_tag():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+# ---------------------------------------------------------------------------
+# Routes that write the buffer beneath the Python layer
+# ---------------------------------------------------------------------------
+
+
+def test_flat_assignment_does_not_forge_tag():
+    """``arr.flat[:] = ...`` is the same category as fill/put/resize.
+
+    A C-level route that writes the buffer without passing through
+    ``__setitem__``, and so without the write-epoch hook ever seeing it.
+    """
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)),
+        lambda z: z.flat.__setitem__(slice(None), list(_asymmetric().ravel())),
+    )
+
+
+def test_setfield_does_not_forge_tag():
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)), lambda z: z.setfield(_asymmetric(), np.float64)
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known gap: the buffer protocol writes beneath the Python layer, so "
+        "nothing observes memoryview(tagged)[i, j] = value. Closing it needs "
+        "__buffer__ (PEP 688, Python 3.12+, above this package's floor) or "
+        "non-writeable tagged buffers, which would break out= destinations. "
+        "Pinned strict so that whoever closes it is forced to delete this "
+        "marker rather than leave a passing test mislabelled."
+    ),
+)
+def test_memoryview_assignment_does_not_forge_tag():
+    _assert_claim_does_not_survive(
+        fnp.zeros((N, N)),
+        lambda z: memoryview(z).__setitem__((0, 1), 9.0),  # pyright: ignore[reportCallIssue, reportArgumentType]
+    )

--- a/tests/test_symmetry_tag_forgery.py
+++ b/tests/test_symmetry_tag_forgery.py
@@ -15,12 +15,16 @@ invariant directly: either the write raised, or the array no longer buys the
 discount. Both outcomes are acceptable; keeping the discount is not.
 """
 
+import functools
+import inspect
+
 import numpy as np
 import pytest
 
 import flopscope as f
 import flopscope.numpy as fnp
 from flopscope._weights import load_weights
+from flopscope._write_epoch import epoch_of
 
 N = 32
 
@@ -274,6 +278,198 @@ def test_contraction_out_does_not_forge_tag_through_a_container():
         lambda _: fnp.einsum("ij,jk->ik", source, fnp.eye(N), out=(alias,)),
         expected=source,
     )
+
+
+# --- writes that never reached the shared out= hook ----------------------
+#
+# The hook that voids a tag lives in ``_call_numpy`` and fires on the ``out=``
+# KEYWORD. Two families of write never presented one: a reduction whose
+# destination travels in a positional slot instead, and the ufunc methods,
+# which called numpy directly rather than through ``_call_numpy`` at all. In
+# both the destination below is an untagged ALIAS of the tagged buffer, which
+# is what a guard on tagged arrays cannot reach and what makes the write land
+# instead of being refused.
+#
+# Each of these asserts the BILLED COST of a contraction on the tagged buffer,
+# not just the epoch counter: an epoch that moves while the discount survives
+# would be a passing test over a live under-bill.
+
+
+def _alias_of_a_tagged_buffer():
+    tagged = fnp.zeros((N, N))
+    alias = fnp.asarray(tagged)
+    assert getattr(alias, "symmetry", None) is None, "the alias must be untagged"
+    return tagged, alias
+
+
+def test_reduction_positional_out_does_not_forge_tag():
+    """``fnp.sum(a, axis, dtype, dest)`` -- ``out`` in its positional slot.
+
+    The positional route hands the destination back to numpy inside the
+    positional argument list, so no ``out=`` keyword exists for the write hook
+    to see, and the tag outlived the data it described.
+    """
+    tagged, alias = _alias_of_a_tagged_buffer()
+    source = np.stack([_asymmetric(seed=1), np.zeros((N, N))])
+    _assert_the_write_landed_and_voided_the_tag(
+        tagged,
+        lambda _: fnp.sum(source, 0, None, alias),  # pyright: ignore[reportCallIssue]
+        expected=source.sum(axis=0),
+    )
+
+
+_POSITIONAL_KINDS = (
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+)
+
+
+def _reductions_with_a_positional_out_slot():
+    """Re-derive, from numpy's signatures, which reductions can take ``out``
+    positionally -- the exact condition the production wrapper keys on.
+
+    Derived rather than listed so a reduction that joins the family is swept
+    instead of remembered. The derivation is independent of the production
+    one (this reads ``numpy``'s signature, the wrapper reads its own captured
+    function), so a divergence shows up as a call that fails loudly.
+    """
+    found = {}
+    for name in dir(fnp):
+        if name.startswith("_"):
+            continue
+        fn = getattr(fnp, name, None)
+        np_func = getattr(np, name, None)
+        if not callable(fn) or not callable(np_func):
+            continue
+        try:
+            params = inspect.signature(np_func).parameters
+        except (TypeError, ValueError):
+            continue
+        names = list(params)
+        if len(names) < 2 or names[1] != "axis" or "out" not in names:
+            continue
+        if params["axis"].kind not in _POSITIONAL_KINDS:
+            continue
+        slot = names.index("out") - 2
+        if slot >= 0:
+            found[name] = (fn, slot)
+    return found
+
+
+def test_every_positional_out_reduction_matches_its_keyword_spelling():
+    """Sweep, not a spot check: for every reduction that accepts ``out`` in a
+    positional slot, the positional spelling must void the tag and bill exactly
+    what the keyword spelling bills.
+
+    The equal-billing half is the standing invariant that ``out=(d,)`` bills
+    what ``out=d`` bills, applied to the other spelling of the same argument;
+    the voided-tag half is the fix.
+    """
+    load_weights()
+    honest = _honest()
+    source = np.stack([_asymmetric(seed=s) for s in range(4)])
+    swept = []
+    for name, (fn, slot) in sorted(_reductions_with_a_positional_out_slot().items()):
+        bills = {}
+        for spelling in ("keyword", "positional"):
+            tagged, alias = _alias_of_a_tagged_buffer()
+            if spelling == "keyword":
+                call = functools.partial(fn, source, 0, out=alias)
+            else:
+                call = functools.partial(fn, source, 0, *([None] * slot), alias)
+            try:
+                bills[spelling] = _billed(call)
+            except Exception:
+                # Not every discovered name accepts this input or this
+                # destination (``argmax`` refuses a float buffer, ``cumsum``
+                # keeps the input's shape). Those are pinned elsewhere; the
+                # sweep is about the ops that do write.
+                break
+            assert epoch_of(tagged) == 1, f"{name} ({spelling}) recorded no write"
+            assert _probe(tagged) == honest, (
+                f"{name} ({spelling}) left asymmetric data billing at the "
+                "symmetric rate"
+            )
+        else:
+            assert bills["positional"] == bills["keyword"], (
+                f"{name}: positional out= bills {bills['positional']}, keyword "
+                f"out= bills {bills['keyword']}"
+            )
+            swept.append(name)
+    # Guards the sweep against silently degenerating to nothing if the
+    # discovery or the call form stops matching.
+    assert len(swept) >= 15, swept
+
+
+@pytest.mark.parametrize(
+    ("method", "write"),
+    [
+        (
+            "outer",
+            lambda dest, src: np.subtract.outer(src[0, 0], src[0, 0], out=dest),
+        ),
+        ("reduce", lambda dest, src: np.subtract.reduce(src, axis=0, out=dest)),
+        (
+            "accumulate",
+            lambda dest, src: np.subtract.accumulate(src[0], axis=0, out=dest),
+        ),
+        (
+            "at",
+            lambda dest, src: np.add.at(
+                dest, (np.array([0, 2]), np.array([1, 3])), np.array([5.0, 7.0])
+            ),
+        ),
+    ],
+)
+def test_ufunc_method_does_not_forge_tag(method, write):
+    """``ufunc.outer`` / ``.reduce`` / ``.accumulate`` / ``.at`` called numpy
+    directly rather than through ``_call_numpy``, so no write was ever recorded.
+
+    ``.at`` writes into its FIRST argument rather than an ``out=``, so even
+    routing it through the shared helper does not cover it -- its destination
+    is recorded explicitly. Its refusal of a tagged ``SymmetricTensor`` is not
+    protection either: the alias used here is untagged and sails past it.
+    """
+    load_weights()
+    honest = _honest()
+    tagged, alias = _alias_of_a_tagged_buffer()
+    source = np.stack([_asymmetric(seed=s) for s in range(4)])
+
+    write(alias, source)
+
+    written = np.asarray(tagged)
+    assert not np.allclose(written, written.T), (
+        f"test bug: {method} did not actually break symmetry"
+    )
+    assert getattr(tagged, "symmetry", None) is None, (
+        f"the symmetry tag survived a write through ufunc.{method}"
+    )
+    assert _probe(tagged) == honest, (
+        f"asymmetric data still bills at the symmetric rate after ufunc.{method}"
+    )
+
+
+def test_ufunc_reduceat_does_not_forge_tag():
+    """Separated from the sweep above because ``reduceat``'s output shape is
+    set by the segment count, so its destination is a slice of the tagged
+    buffer rather than the whole of it -- a different alias route to the same
+    root, and the one that has to reach the tag."""
+    load_weights()
+    honest = _honest()
+    tagged = fnp.zeros((N, N))
+    rows = fnp.asarray(tagged)[:2]
+    source = _asymmetric(seed=1)
+
+    np.subtract.reduceat(source, [0, N // 2], axis=0, out=rows)
+
+    written = np.asarray(tagged)
+    assert not np.allclose(written, written.T), (
+        "test bug: reduceat did not actually break symmetry"
+    )
+    assert getattr(tagged, "symmetry", None) is None, (
+        "the symmetry tag survived a write through ufunc.reduceat"
+    )
+    assert _probe(tagged) == honest
 
 
 if __name__ == "__main__":

--- a/tests/test_timing_attribution.py
+++ b/tests/test_timing_attribution.py
@@ -223,3 +223,30 @@ def test_data_movement_ops_bill_to_backend(invoke):
         invoke(big)
     s = b.summary_dict()
     assert s["flopscope_backend_time_s"] > s["flopscope_overhead_time_s"], s
+
+
+@pytest.mark.parametrize(
+    "invoke",
+    [
+        lambda big: np.subtract.outer(big[0], big[0]),
+        lambda big: np.subtract.reduce(big, axis=0),
+        lambda big: np.subtract.accumulate(big, axis=0),
+        lambda big: np.subtract.reduceat(big, [0, big.shape[0] // 2], axis=0),
+        lambda big: np.add.at(big, (np.arange(big.shape[0]),), 1.0),
+    ],
+    ids=["outer", "reduce", "accumulate", "reduceat", "at"],
+)
+def test_ufunc_methods_bill_to_backend(invoke):
+    """The ufunc-method wrappers invoked numpy directly instead of through
+    ``_call_numpy``, so their whole backend cost was misfiled as flopscope
+    overhead -- ``flopscope_backend_time_s`` came back at exactly 0.0 for calls
+    taking milliseconds. The same omission is why their writes went unrecorded
+    (pinned in ``test_symmetry_tag_forgery``); this is the timing half.
+    """
+    big = flops.numpy.array(np.random.randn(2000, 2000))
+    flops.budget_reset()
+    with flops.BudgetContext(flop_budget=10**12, quiet=True) as b:
+        invoke(big)
+    s = b.summary_dict()
+    assert s["flopscope_backend_time_s"] > 0.0, s
+    assert s["flopscope_backend_time_s"] > s["flopscope_overhead_time_s"], s


### PR DESCRIPTION
Four of the five items left open when the three `out=` PRs merged. The fifth is deliberately **not** here — see the bottom.

## 1. `frexp` over-billed its own natural destinations, 2x

`store_billing_dtypes` folded every output slot in unconditionally, so `frexp`'s int32 exponent buffer joined the resolution and `result_type(float32, float32, int32)` promoted to float64 — the caller paying the float64 rate for a float32 loop, purely for naming a destination numpy would have allocated itself.

The exponent buffer is the op *signature*, not a wider accumulator. `natural_output_dtypes` now reads what numpy allocates per slot from the ufunc's own loop table (`resolve_dtypes`, not a hand-kept map), and a slot joins the resolution only when it differs from that.

| | before | after |
|---|---|---|
| `frexp(a32)` | 10,000 | 10,000 |
| `frexp(a32, out=(f32, i32))` | **20,000** | **10,000** |
| `frexp(a32, out=(f64, i32))` — wider mantissa | 20,000 | 20,000 |
| `frexp(a32, out=(f32, i64))` — wider exponent | 20,000 | 20,000 |

Widening is untouched in both axes. Operands are promoted *before* the loop is resolved, so `divmod(f32, 2.0)` — float32 under NEP 50 — doesn't report float64 as "natural" and hand a float64 destination away free.

## 2. The arg-reduction family charged before numpy refused

`argmin`/`argmax`/`nanargmin`/`nanargmax` on 10,000 float32 with a float64 destination billed **19,998** and *then* raised. Two faults: the refusal wasn't free, and an index buffer that can never be the accumulator was widening the rate for a call that returned nothing. numpy constrains that `out` by *kind*, so it is refusable before dispatch — the guard now sits above `budget.deduct`. No charge is unwound anywhere.

## 3. Two write routes the epoch hook never saw

A symmetry tag gates a ~2x discount and is voided when its buffer is written. Both of these wrote without the hook seeing it, leaving the tag over data it no longer described. Measured, 32x32, `einsum('ij,ij->')` after the write (honest price 4094):

| route | before | after |
|---|---|---|
| `sum(a, 0, None, dest)` — positional `out` | **2110** | 4094 |
| `subtract.outer/.reduce/.accumulate/.reduceat(out=dest)` | **2110** | 4094 |
| `add.at(dest, idx, vals)` — found by sweep, not in scope | **2110** | 4094 |

The four ufunc-method wrappers now route through `_call_numpy`, which also fixes timing attribution: an accumulate taking 5.4 ms reported `flopscope_backend_time_s` of exactly **0.0** before.

## 4. Two more buffer writes, and one that stays open

`arr.flat[:] = ...` and `arr.setfield(...)` are the same category as the existing `fill`/`put`/`resize` overrides — C-level routes that bypass `__setitem__` — and were unguarded. `.flat` now returns a read-only iterator that forwards reads, iteration and `.copy()` untouched.

**The buffer protocol is not closed.** `memoryview(tagged)[i, j] = value` writes with nothing in the Python layer to observe it — measured leaving a discounted 542-FLOP contraction on asymmetric data. Closing it needs `__buffer__` (PEP 688, Python 3.12+, above this package's floor) or non-writeable tagged buffers, which would break their legitimate use as `out=` destinations. It is pinned as a **strict xfail** and named in the module docstring rather than left to look covered.

## Deliberately not included: einsum `casting="unsafe"`

It was implemented, reviewed, and dropped. The guard came out **stricter than numpy in 138 measured cells** — `einsum("ij,jk->ik", int8, uint8, out=float16)` produces exact values in plain numpy and raised on the candidate. Shipping a guard that refuses working participant code is worse than the truncation it fixes, and this is the one item that changes behaviour for live submissions. The remaining defect (flopscope truncates into an int64 destination where numpy raises) is unchanged from main and still worth fixing — correctly, in its own PR.

## Verification

- every figure above measured, arrays built outside the timed region, asymmetric data throughout
- all five fixes mutation-tested; each is killed by a named test
- epoch tests assert the **billed cost** of a contraction before and after the write, not an epoch counter — a counter can move while the discount survives
- the positional-`out` sweep is derived from numpy's signatures (20 reductions qualify) rather than hand-listed
- suite 6743 passed, 1 xfailed; ruff and pyright clean