### PR TITLE
fix(einsum)!: apply the caller's casting rule to out=, as numpy does

### DIFF
--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -212,6 +212,21 @@ def _resolve_out_compute_dtype(
         ``TypeError`` subclass and numpy surfaces it the same way.
     """
     op_dtype = _np.result_type(*operand_dtypes, out_dtype)
+    # The rule governs the INPUT cast too, not only the store. Under 'safe'
+    # and 'same_kind' this is implied -- an operand always casts into a
+    # promotion that includes it -- which is why it only shows up under the
+    # strict kinds: `bool x bool` into an int8 destination promotes to int8,
+    # and int8 stores into int8 under any rule, but numpy still refuses the
+    # call under 'equiv'/'no' because the bool OPERANDS do not cast to int8
+    # under those. Checking only the store made flopscope looser than numpy
+    # in 856 measured cells, all of them here.
+    for operand_dtype in operand_dtypes:
+        if not _np.can_cast(operand_dtype, op_dtype, casting=casting):
+            raise TypeError(
+                f"Iterator operand required copying or buffering, but "
+                f"neither copying nor buffering was enabled, according to "
+                f"the rule '{casting}'"
+            )
     if not _np.can_cast(op_dtype, out_dtype, casting=casting):
         # numpy's nditer wording, verbatim: the destination is operand number
         # `n_operands` in the iterator (0-based, after the inputs). `!r` and
@@ -724,11 +739,18 @@ def einsum(
     out_dtype = (
         getattr(_to_base_ndarray(out), "dtype", None) if out is not None else None
     )
+    # The caller's own ``casting=`` governs, exactly as it does in numpy.
+    # Hardcoding "safe" here would refuse the whole point of passing
+    # ``casting="unsafe"`` -- and would report "the rule 'safe'" while doing
+    # it -- making flopscope stricter than numpy on a call numpy accepts,
+    # which is the regression this change exists to avoid.
+    requested_casting = kwargs.get("casting", "safe")
     if out_dtype is not None:
         compute_dtype = _resolve_out_compute_dtype(
             tuple(a.dtype for a in operand_arrays),
             out_dtype,
             len(operand_arrays),
+            casting=requested_casting,
         )
 
     with budget.deduct(
@@ -778,7 +800,7 @@ def einsum(
         _np.copyto(
             _to_base_ndarray(out),
             _np.asarray(result),
-            casting="safe" if compute_dtype is not None else "unsafe",
+            casting=requested_casting if compute_dtype is not None else "unsafe",
         )
         # Internal copy, so _call_numpy's hook never sees it: record the write
         # or a tag on out's buffer (or on an alias of it) would survive.

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as _np
 
@@ -133,6 +133,106 @@ def einsum_cache_info():
     >>> rate = info.hits / max(total, 1)
     """
     return _path_cache.cache_info()
+
+
+@functools.cache
+def _einsum_supports_dtype(dtype) -> bool:
+    """Can ``np.einsum`` contract in ``dtype`` at all? Asked by asking numpy.
+
+    einsum has no inner loop for the string/bytes/void kinds. numpy surfaces
+    that badly -- ``np.einsum("ij,jk->ik", f64, f64, out=np.empty(..., "U64"))``
+    raises ``SystemError("<built-in function c_einsum> returned a result with
+    an exception set")`` whose ``__cause__`` is the real refusal,
+    ``TypeError("invalid data type for einsum")``. The refusal is the part
+    worth reproducing; the SystemError wrapper is a numpy reporting bug.
+
+    A one-element contraction is the cheapest way to have numpy answer for
+    itself rather than us keeping a hand-written list of dtype kinds in sync
+    with it, and the answer is cached per dtype so it costs one tiny numpy
+    call per distinct dtype per process. ``zeros`` and not ``empty``:
+    uninitialised object cells are ``None``, and ``None * None`` would raise
+    ``TypeError`` and misreport object -- which einsum does support -- as
+    unsupported.
+    """
+    probe = _np.zeros(1, dtype=dtype)
+    try:
+        _np.einsum("i,i->i", probe, probe)
+    except TypeError:
+        return False
+    return True
+
+
+_CastingKind = Literal["no", "equiv", "safe", "same_kind", "unsafe"]
+
+
+def _resolve_out_compute_dtype(
+    operand_dtypes: tuple,
+    out_dtype,
+    n_operands: int,
+    casting: _CastingKind = "safe",
+):
+    """Reproduce numpy's ``einsum(..., out=)`` casting decision exactly.
+
+    numpy does not contract in the operands' own promoted dtype and then cast
+    the answer into ``out``. It resolves ONE computation dtype for the whole
+    iterator with the destination participating in the promotion, and refuses
+    the call unless that dtype casts into the destination under ``casting``::
+
+        op_dtype = np.result_type(*operand_dtypes, out.dtype)
+        accept  iff np.can_cast(op_dtype, out.dtype, casting)
+
+    Both halves matter, and getting either wrong is a shipped bug:
+
+    * Dropping the check is what this function fixes. ``copyto(...,
+      casting="unsafe")`` let two float64 operands land in an int64
+      destination (numpy raises ``TypeError``) and let a complex result be
+      truncated into a float64 one with nothing but a ``ComplexWarning``.
+    * Dropping ``out.dtype`` from the promotion is what killed a previous
+      attempt at this fix: it computed ``result_type(*operand_dtypes)`` and
+      asked whether THAT cast into the destination, which refused 138 calls
+      plain numpy accepts. ``np.result_type`` is a lattice minimum, not a
+      left-fold, so ``result_type(int8, uint8)`` is ``int16`` while
+      ``result_type(int8, uint8, float16)`` is ``float16`` -- float16 holds
+      every int8 and every uint8 exactly, so it is a legal common type and
+      the lattice picks it. Being stricter than numpy is a regression, not a
+      conservative choice.
+
+    Returns the resolved computation dtype, which the caller must contract in
+    -- ``int8 x int8 -> int16`` destination yields 300 in numpy, not the -56
+    an int8 contraction would overflow to.
+
+    Raises
+    ------
+    TypeError
+        With numpy's own wording, when the computation dtype cannot cast into
+        the destination. Raised before any FLOP is charged.
+    numpy.exceptions.DTypePromotionError
+        Propagated unwrapped from ``np.result_type`` when no common dtype
+        exists at all (a ``datetime64`` destination, say); it is a
+        ``TypeError`` subclass and numpy surfaces it the same way.
+    """
+    op_dtype = _np.result_type(*operand_dtypes, out_dtype)
+    if not _np.can_cast(op_dtype, out_dtype, casting=casting):
+        # numpy's nditer wording, verbatim: the destination is operand number
+        # `n_operands` in the iterator (0-based, after the inputs). `!r` and
+        # not `dtype('{...}')` because repr is what numpy formats with, and
+        # str disagrees with it on exactly the dtypes where it matters --
+        # `str(np.dtype('S32'))` is '|S32' but numpy's message says 'S32',
+        # and object prints as 'object' rather than numpy's 'O'.
+        raise TypeError(
+            f"Iterator requested dtype could not be cast from "
+            f"{op_dtype!r} to {out_dtype!r}, the operand "
+            f"{n_operands} dtype, according to the rule '{casting}'"
+        )
+    if not _einsum_supports_dtype(op_dtype):
+        # numpy's own refusal reason, taken from the `__cause__` it loses on
+        # the way out. Checked AFTER the cast rule because that is numpy's
+        # order: a `U32` destination fails the cast (op_dtype `U64` does not
+        # fit) while a `U64` one gets all the way to the missing inner loop.
+        # Zero-cost either way -- the alternative is billing a contraction
+        # that then dies inside numpy, and nothing here is ever refunded.
+        raise TypeError("invalid data type for einsum")
+    return op_dtype
 
 
 def _execute_pairwise(path_info, operands: list):
@@ -616,6 +716,21 @@ def einsum(
     resolved = resolve_billing_dtype(billing_dtypes)
     complex_override = contraction_complex_override(accumulation_cost, resolved)
 
+    # Settle the destination's dtype question BEFORE the deduct below, because
+    # a refusal has to cost nothing: flops_used never decreases and nothing is
+    # ever refunded, so a call numpy would have rejected outright must not be
+    # able to bill a contraction on its way to raising.
+    compute_dtype = None
+    out_dtype = (
+        getattr(_to_base_ndarray(out), "dtype", None) if out is not None else None
+    )
+    if out_dtype is not None:
+        compute_dtype = _resolve_out_compute_dtype(
+            tuple(a.dtype for a in operand_arrays),
+            out_dtype,
+            len(operand_arrays),
+        )
+
     with budget.deduct(
         "einsum",
         flop_cost=accumulation_cost.total,
@@ -624,13 +739,27 @@ def einsum(
         dtypes=billing_dtypes,
         complex_factor_override=complex_override,
     ):
+        # Contract in the dtype numpy would have contracted in. Casting the
+        # ANSWER into `out` is not the same operation as computing in the
+        # destination's dtype: `int8 x int8` into an int16 destination is 300
+        # in numpy and -56 if the contraction runs in int8 first, and
+        # `bool x bool` into any numeric destination counts the matches
+        # (3) where a bool contraction only ors them (1).
+        exec_operands = operands
+        if compute_dtype is not None and any(
+            a.dtype != compute_dtype for a in operand_arrays
+        ):
+            exec_operands = [
+                _to_base_ndarray(a).astype(compute_dtype, copy=False)
+                for a in operand_arrays
+            ]
         if path_info.steps:
-            result = _execute_pairwise(path_info, list(operands))
+            result = _execute_pairwise(path_info, list(exec_operands))
         else:
             result = _call_numpy(
                 _np.einsum,
                 canonical_subscripts,
-                *[_to_base_ndarray(o) for o in operands],
+                *[_to_base_ndarray(o) for o in exec_operands],
             )
 
     if out is not None:
@@ -641,7 +770,16 @@ def einsum(
         # contents. Guarding the argument stops a container getting here, but
         # taking the materialising call out is what makes the whole class of
         # silent mis-write structurally impossible rather than merely gated.
-        _np.copyto(_to_base_ndarray(out), _np.asarray(result), casting="unsafe")
+        # ``safe`` once the dtype has been resolved above -- the contraction
+        # already ran in a dtype that casts into the destination, so this copy
+        # is a narrowing-free store and numpy will say so if it ever is not.
+        # ``unsafe`` here is the original defect: it silently truncated
+        # float->int and dropped imaginary parts on complex->float.
+        _np.copyto(
+            _to_base_ndarray(out),
+            _np.asarray(result),
+            casting="safe" if compute_dtype is not None else "unsafe",
+        )
         # Internal copy, so _call_numpy's hook never sees it: record the write
         # or a tag on out's buffer (or on an alias of it) would survive.
         note_write(out)

--- a/tests/test_einsum_out_casting_parity.py
+++ b/tests/test_einsum_out_casting_parity.py
@@ -1,0 +1,452 @@
+"""``fnp.einsum(..., out=)`` must accept exactly what ``np.einsum`` accepts.
+
+flopscope used to write its answer into ``out=`` with
+``np.copyto(..., casting="unsafe")``. numpy's einsum resolves the destination
+under ``casting='safe'``, so flopscope was silently *looser* than numpy in two
+directions at once:
+
+* two float64 operands into an int64 destination truncated to whole numbers
+  where numpy raises ``TypeError``;
+* a complex result into a float64 destination dropped the imaginary part with
+  nothing louder than a ``ComplexWarning``.
+
+Being looser is the defect. Being *stricter* would be worse: it breaks working
+participant code. A first attempt at this fix shipped a hand-written guard that
+refused 138 cells plain numpy accepts, and was reverted. So these tests are
+driven off the dtype matrix and differential against plain numpy -- accept set,
+exception class, and the values actually written -- rather than off a
+hand-listed set of cases someone believed to be right.
+
+The rule flopscope implements, measured to agree with numpy 2.0.2 through
+2.4.2 over the whole matrix::
+
+    op_dtype = np.result_type(*operand_dtypes, out.dtype)   # out PARTICIPATES
+    accept  iff np.can_cast(op_dtype, out.dtype, 'safe')
+
+and the contraction then runs in ``op_dtype``, which is why the values need
+their own assertion: casting the *answer* into ``out`` is a different operation
+from computing in the destination's dtype.
+"""
+
+import itertools
+import warnings
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+
+# The 16 dtypes of the reference matrix.
+MATRIX_DTYPES = [
+    np.bool_,
+    np.int8,
+    np.uint8,
+    np.int16,
+    np.uint16,
+    np.int32,
+    np.uint32,
+    np.int64,
+    np.uint64,
+    np.float16,
+    np.float32,
+    np.float64,
+    np.longdouble,
+    np.complex64,
+    np.complex128,
+    np.clongdouble,
+]
+
+N = 3
+_BUDGET = 10**14
+
+
+def _operand(dtype, shape):
+    """A constant 10 (or True) -- small enough to be exact in float16, large
+    enough that an int8 contraction overflows where an int16 one does not, so
+    the value assertions actually discriminate between computing in the
+    operands' dtype and computing in the destination's."""
+    base = np.ones(shape) if np.dtype(dtype) == np.bool_ else np.ones(shape) * 10
+    return base.astype(dtype)
+
+
+def _attempt(call):
+    """Run ``call``; return ``("ok", written)`` or ``(exception name, str)``.
+
+    ``ComplexWarning`` is promoted to an error: numpy's own contract is that
+    dropping an imaginary part on the way into ``out`` is a refusal, not a
+    warning, and the old flopscope behaviour was exactly that warning.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", np.exceptions.ComplexWarning)
+        try:
+            return ("ok", np.asarray(call()).copy())
+        except Exception as exc:  # noqa: BLE001 -- the class is the assertion
+            return (type(exc).__name__, str(exc))
+
+
+def _numpy_ref(subscripts, operands, out):
+    # optimize=False is numpy's default and the only reference stable across
+    # 2.0 -> 2.4: numpy 2.4's optimize=True path regressed into the same
+    # unsafe-store defect being fixed here, and is not even self-consistent
+    # across arities.
+    return _attempt(lambda: np.einsum(subscripts, *operands, out=out, optimize=False))
+
+
+def _flopscope(subscripts, operands, out):
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        return _attempt(lambda: fnp.einsum(subscripts, *operands, out=out))
+
+
+def _compare(subscripts, dtypes, out_dtype, shapes, out_shape):
+    operands = [_operand(d, s) for d, s in zip(dtypes, shapes, strict=True)]
+    ref = _numpy_ref(subscripts, operands, np.zeros(out_shape, dtype=out_dtype))
+    got = _flopscope(subscripts, operands, np.zeros(out_shape, dtype=out_dtype))
+    return ref, got
+
+
+def _assert_agrees(subscripts, dtypes, out_dtype, shapes, out_shape):
+    ref, got = _compare(subscripts, dtypes, out_dtype, shapes, out_shape)
+    names = [np.dtype(d).name for d in dtypes]
+    where = f"{subscripts} {names} -> {np.dtype(out_dtype).name}"
+
+    assert (ref[0] == "ok") == (got[0] == "ok"), (
+        f"accept/refuse disagreement for {where}: numpy={ref}, flopscope={got}"
+    )
+    if ref[0] == "ok":
+        assert np.array_equal(ref[1], got[1]), (
+            f"value disagreement for {where}: numpy={ref[1]}, flopscope={got[1]}"
+        )
+    else:
+        assert ref[0] == got[0], (
+            f"exception class disagreement for {where}: "
+            f"numpy={ref[0]}, flopscope={got[0]}"
+        )
+
+
+# --- the full 16 x 16 x 16 matrix, one parametrization per destination -----
+
+
+@pytest.mark.parametrize("out_dtype", MATRIX_DTYPES, ids=lambda d: np.dtype(d).name)
+def test_matmul_matrix_matches_numpy_cell_by_cell(out_dtype):
+    """256 operand pairs per destination, 4096 cells in total: accept/refuse,
+    exception class, and written values, all against plain numpy."""
+    shapes = ((N, N), (N, N))
+    for da, db in itertools.product(MATRIX_DTYPES, repeat=2):
+        _assert_agrees("ij,jk->ik", (da, db), out_dtype, shapes, (N, N))
+
+
+def test_matrix_accept_count_is_the_measured_one():
+    """A blunt tripwire on the size of the accept set. 1154 of 4096 is what
+    numpy 2.0.2 through 2.4.2 all accept; a fix that drifts either way should
+    have to change this number deliberately rather than quietly."""
+    accepted = 0
+    for da, db in itertools.product(MATRIX_DTYPES, repeat=2):
+        for dout in MATRIX_DTYPES:
+            _, got = _compare("ij,jk->ik", (da, db), dout, ((N, N), (N, N)), (N, N))
+            accepted += got[0] == "ok"
+    assert accepted == 1154
+
+
+# --- other subscripts and arities -----------------------------------------
+
+_SHAPED_CASES = [
+    ("ij->ji", 1, ((N, N),), (N, N)),
+    ("ii->", 1, ((N, N),), ()),
+    ("ij->i", 1, ((N, N),), (N,)),
+    ("ij,ij->", 2, ((N, N), (N, N)), ()),
+    ("i,j->ij", 2, ((N,), (N,)), (N, N)),
+    ("ij,jk,kl->il", 3, ((N, N), (N, N), (N, N)), (N, N)),
+    ("ij,jk,kl,lm->im", 4, ((N, N),) * 4, (N, N)),
+]
+
+
+@pytest.mark.parametrize(
+    "subscripts,arity,shapes,out_shape", _SHAPED_CASES, ids=lambda v: str(v)[:24]
+)
+def test_other_subscripts_and_arities_match_numpy(subscripts, arity, shapes, out_shape):
+    """The rule is arity- and subscript-independent, including the operand
+    index quoted in the refusal message (it is the number of *inputs*)."""
+    rng = np.random.default_rng(0)
+    if arity == 1:
+        combos = [(d,) for d in MATRIX_DTYPES]
+    elif arity == 2:
+        combos = list(itertools.product(MATRIX_DTYPES, repeat=2))
+    else:
+        combos = [
+            tuple(MATRIX_DTYPES[i] for i in rng.integers(0, len(MATRIX_DTYPES), arity))
+            for _ in range(40)
+        ]
+    for combo in combos:
+        for dout in MATRIX_DTYPES:
+            _assert_agrees(subscripts, combo, dout, shapes, out_shape)
+
+
+# --- the regression pin for the reverted first attempt --------------------
+
+# Mixed-signedness narrow integers whose pairwise promotion overshoots the
+# destination, aimed at a float/complex destination that holds each operand
+# exactly. `np.result_type` is a lattice minimum, so it picks the destination;
+# a left-fold over the operands alone picks something wider and then wrongly
+# concludes the store is unsafe. All ten are accepted by numpy and write exact
+# values. Attempt #1 refused all ten.
+DISCRIMINATORS = [
+    (np.int8, np.uint8, np.float16),
+    (np.uint8, np.int8, np.float16),
+    (np.int8, np.uint16, np.float32),
+    (np.int8, np.uint16, np.complex64),
+    (np.int16, np.uint16, np.float32),
+    (np.int16, np.uint16, np.complex64),
+    (np.uint16, np.int8, np.float32),
+    (np.uint16, np.int8, np.complex64),
+    (np.uint16, np.int16, np.float32),
+    (np.uint16, np.int16, np.complex64),
+]
+
+
+@pytest.mark.parametrize("da,db,dout", DISCRIMINATORS, ids=lambda d: np.dtype(d).name)
+def test_lattice_promotion_cells_are_accepted(da, db, dout):
+    """These are the cells that reverted the first attempt at this fix."""
+    ref, got = _compare("ij,jk->ik", (da, db), dout, ((N, N), (N, N)), (N, N))
+    assert ref[0] == "ok", "precondition: numpy accepts this"
+    assert got[0] == "ok", (
+        f"flopscope refused {np.dtype(da).name} x {np.dtype(db).name} -> "
+        f"{np.dtype(dout).name}, which numpy accepts: {got[1]}"
+    )
+    assert np.array_equal(ref[1], got[1])
+
+
+def test_int8_uint8_into_float16_regression_pin():
+    """The named case from the reverted attempt, spelled out verbatim.
+
+    ``result_type(int8, uint8)`` is int16, which does not cast safely into
+    float16 -- but ``result_type(int8, uint8, float16)`` is float16, which
+    does, and float16 represents every int8 and every uint8 exactly. numpy
+    accepts this and writes exact values; the first attempt raised TypeError.
+    """
+    rng = np.random.default_rng(0)
+    a = rng.integers(1, 5, (6, 6)).astype(np.int8)
+    b = rng.integers(1, 5, (6, 6)).astype(np.uint8)
+
+    expected = np.zeros((6, 6), np.float16)
+    np.einsum("ij,jk->ik", a, b, out=expected, optimize=False)
+
+    out = np.zeros((6, 6), np.float16)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        returned = fnp.einsum("ij,jk->ik", a, b, out=out)
+
+    assert np.array_equal(np.asarray(returned), expected)
+    # and exact against an object-dtype reference, not just against numpy
+    exact = np.einsum("ij,jk->ik", a.astype(object), b.astype(object))
+    assert np.array_equal(expected.astype(object), exact)
+
+
+# --- the defect itself ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "da,db,dout,why",
+    [
+        (np.float64, np.float64, np.int64, "float64 truncated to int64"),
+        (np.float64, np.float64, np.int32, "float64 truncated to int32"),
+        (np.float64, np.float64, np.float32, "float64 narrowed to float32"),
+        (np.int64, np.int64, np.int32, "int64 narrowed to int32"),
+        (np.complex128, np.complex128, np.float64, "imaginary part dropped"),
+        (np.complex64, np.complex64, np.float32, "imaginary part dropped"),
+        (np.float64, np.float64, np.bool_, "everything collapsed to a flag"),
+    ],
+)
+def test_narrowing_destinations_now_raise(da, db, dout, why):
+    """Each of these used to succeed and write a wrong number."""
+    a = _operand(da, (N, N))
+    b = _operand(db, (N, N))
+    out = np.zeros((N, N), dtype=dout)
+
+    with pytest.raises(TypeError, match="could not be cast"):
+        np.einsum("ij,jk->ik", a, b, out=out, optimize=False)
+
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        with pytest.raises(TypeError, match="could not be cast"):
+            fnp.einsum("ij,jk->ik", a, b, out=out)
+
+
+def test_complex_into_float_does_not_truncate_with_a_warning():
+    """The old behaviour was a ``ComplexWarning`` and a real, wrong write."""
+    a = (np.ones((N, N)) + 2j).astype(np.complex128)
+    out = np.zeros((N, N), dtype=np.float64)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        with pytest.raises(TypeError):
+            fnp.einsum("ij,jk->ik", a, a, out=out)
+    assert np.array_equal(out, np.zeros((N, N)))  # untouched
+
+
+# --- computing in the destination's dtype, not casting the answer ---------
+
+
+@pytest.mark.parametrize(
+    "da,db,dout,expected",
+    [
+        # 3 * 10 * 10 = 300 overflows int8; numpy contracts in the
+        # destination's dtype and returns 300, so flopscope must too.
+        (np.int8, np.int8, np.int16, 300),
+        (np.int8, np.int8, np.int32, 300),
+        (np.int8, np.int8, np.float32, 300),
+        (np.uint8, np.uint8, np.int32, 300),
+        # bool x bool contracted in bool is a logical or (1); contracted in a
+        # numeric destination it counts the matches (3).
+        (np.bool_, np.bool_, np.int8, 3),
+        (np.bool_, np.bool_, np.float64, 3),
+    ],
+)
+def test_contraction_runs_in_the_resolved_dtype(da, db, dout, expected):
+    ref, got = _compare("ij,jk->ik", (da, db), dout, ((N, N), (N, N)), (N, N))
+    assert ref[0] == "ok" and got[0] == "ok"
+    assert np.all(ref[1] == expected), "precondition: numpy computes in out's dtype"
+    assert np.array_equal(got[1], ref[1])
+
+
+# --- refusals are free ----------------------------------------------------
+
+
+def test_refusal_costs_zero_flops():
+    """The guard sits above ``budget.deduct``. flops_used never decreases and
+    nothing is refunded, so a refused call must never have been billed."""
+    a = np.ones((200, 200), dtype=np.float64)
+    with f.BudgetContext(flop_budget=10**12, quiet=True) as budget:
+        before = budget.flops_used
+        with pytest.raises(TypeError):
+            fnp.einsum("ij,jk->ik", a, a, out=np.zeros((200, 200), np.int64))
+        assert budget.flops_used == before == 0
+
+        # the context is still usable, and a legal call still bills
+        fnp.einsum("ij,jk->ik", a, a, out=np.zeros((200, 200), np.float64))
+        assert budget.flops_used > 0
+
+
+def test_refusal_is_free_even_when_the_budget_could_not_afford_it():
+    """A refusal must not turn into a budget-exhaustion error either: the
+    dtype question is settled before the budget is consulted at all."""
+    a = np.ones((200, 200), dtype=np.float64)
+    with f.BudgetContext(flop_budget=1, quiet=True) as budget:
+        with pytest.raises(TypeError):
+            fnp.einsum("ij,jk->ik", a, a, out=np.zeros((200, 200), np.int64))
+        assert budget.flops_used == 0
+
+
+def test_refused_destination_is_left_untouched():
+    a = np.ones((4, 4), dtype=np.float64) * 3
+    out = np.full((4, 4), 7, dtype=np.int64)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        with pytest.raises(TypeError):
+            fnp.einsum("ij,jk->ik", a, a, out=out)
+    assert np.array_equal(out, np.full((4, 4), 7, dtype=np.int64))
+
+
+# --- message and exception-class parity -----------------------------------
+
+
+def test_refusal_message_matches_numpy_verbatim():
+    a = np.ones((N, N), dtype=np.float64)
+    out = np.zeros((N, N), dtype=np.int64)
+    with pytest.raises(TypeError) as numpy_exc:
+        np.einsum("ij,jk->ik", a, a, out=out, optimize=False)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        with pytest.raises(TypeError) as flopscope_exc:
+            fnp.einsum("ij,jk->ik", a, a, out=out)
+    assert str(flopscope_exc.value) == str(numpy_exc.value)
+
+
+@pytest.mark.parametrize("arity", [1, 2, 3])
+def test_refusal_message_operand_index_is_the_input_count(arity):
+    """numpy names the destination by its position in the iterator, which is
+    the number of input operands."""
+    subscripts = {
+        1: "ij->ij",
+        2: "ij,jk->ik",
+        3: "ij,jk,kl->il",
+    }[arity]
+    ops = [np.ones((N, N), dtype=np.float64) for _ in range(arity)]
+    out = np.zeros((N, N), dtype=np.int64)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        with pytest.raises(TypeError, match=f"the operand {arity} dtype"):
+            fnp.einsum(subscripts, *ops, out=out)
+
+
+def test_datetime_destination_propagates_the_promotion_error():
+    """``np.result_type`` fails outright rather than reporting a cast; numpy
+    lets ``DTypePromotionError`` out and so must flopscope. It is a TypeError
+    subclass, so the accept/refuse contract is unaffected."""
+    a = np.ones((N, N), dtype=np.float64)
+    out = np.zeros((N, N), dtype="M8[ns]")
+    with pytest.raises(np.exceptions.DTypePromotionError):
+        np.einsum("ij,jk->ik", a, a, out=out, optimize=False)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True) as budget:
+        with pytest.raises(np.exceptions.DTypePromotionError):
+            fnp.einsum("ij,jk->ik", a, a, out=out)
+        assert budget.flops_used == 0
+
+
+@pytest.mark.parametrize("out_dtype", ["U64", "S64", "U32", "S16"])
+def test_string_destinations_are_refused(out_dtype):
+    """einsum has no string inner loop. numpy either fails the cast rule or
+    reaches the missing loop and mis-reports the resulting
+    ``TypeError('invalid data type for einsum')`` as a ``SystemError``;
+    flopscope raises that underlying TypeError, before billing."""
+    a = np.ones((N, N), dtype=np.float64)
+    out = np.empty((N, N), dtype=out_dtype)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True) as budget:
+        with pytest.raises(TypeError):
+            fnp.einsum("ij,jk->ik", a, a, out=out)
+        assert budget.flops_used == 0
+
+
+def test_object_destination_still_works():
+    """object is a legal einsum dtype and must stay accepted -- the string
+    refusal is about a missing inner loop, not about non-numeric kinds."""
+    a = np.ones((N, N), dtype=np.float64) * 2
+    expected = np.zeros((N, N), dtype=object)
+    np.einsum("ij,jk->ik", a, a, out=expected, optimize=False)
+    out = np.zeros((N, N), dtype=object)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        fnp.einsum("ij,jk->ik", a, a, out=out)
+    assert np.array_equal(out, expected)
+
+
+# --- the destination still behaves like a destination ---------------------
+
+
+def test_accepted_widening_still_writes_through_and_returns_out():
+    a = np.ones((4, 4), dtype=np.float32) * 2
+    out = np.zeros((4, 4), dtype=np.float64)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True):
+        returned = fnp.einsum("ij,jk->ik", a, a, out=out)
+    assert returned is out
+    assert np.array_equal(out, np.full((4, 4), 16.0))
+
+
+@pytest.mark.parametrize("optimize", [True, False, "greedy", "optimal"])
+def test_parity_holds_for_every_optimize_setting(optimize):
+    """The accept set is a property of the dtypes, not of the path. (numpy's
+    own optimize=True path disagrees with itself across versions, which is why
+    the reference is optimize=False.)"""
+    a = np.ones((4, 4), dtype=np.float64)
+    with f.BudgetContext(flop_budget=_BUDGET, quiet=True) as budget:
+        with pytest.raises(TypeError):
+            fnp.einsum(
+                "ij,jk,kl->il",
+                a,
+                a,
+                a,
+                out=np.zeros((4, 4), np.int64),
+                optimize=optimize,
+            )
+        assert budget.flops_used == 0
+        result = fnp.einsum(
+            "ij,jk,kl->il",
+            a,
+            a,
+            a,
+            out=np.zeros((4, 4), np.float64),
+            optimize=optimize,
+        )
+    assert np.array_equal(np.asarray(result), np.full((4, 4), 16.0))

--- a/tests/test_einsum_out_casting_parity.py
+++ b/tests/test_einsum_out_casting_parity.py
@@ -136,16 +136,28 @@ def test_matmul_matrix_matches_numpy_cell_by_cell(out_dtype):
         _assert_agrees("ij,jk->ik", (da, db), out_dtype, shapes, (N, N))
 
 
-def test_matrix_accept_count_is_the_measured_one():
-    """A blunt tripwire on the size of the accept set. 1154 of 4096 is what
-    numpy 2.0.2 through 2.4.2 all accept; a fix that drifts either way should
-    have to change this number deliberately rather than quietly."""
-    accepted = 0
+def test_matrix_accept_count_tracks_numpys_own():
+    """A tripwire on the SIZE of the accept set, measured against numpy rather
+    than frozen.
+
+    A literal count cannot work here: the accept set is numpy-version
+    dependent -- 1154 on numpy 2.2 against 1069 on 2.3 -- so a frozen number
+    passes on the machine it was measured on and fails the matrix. Asking
+    numpy for its own count on the same cells keeps the tripwire (a fix that
+    drifts either way still has to be deliberate) without pinning a constant
+    that only holds for one numpy.
+
+    The cell-by-cell tests above are the real assertion; this catches a
+    wholesale collapse, e.g. a guard that starts refusing everything and
+    still agrees per-cell because the comparison itself broke."""
+    accepted = expected = 0
     for da, db in itertools.product(MATRIX_DTYPES, repeat=2):
         for dout in MATRIX_DTYPES:
-            _, got = _compare("ij,jk->ik", (da, db), dout, ((N, N), (N, N)), (N, N))
+            want, got = _compare("ij,jk->ik", (da, db), dout, ((N, N), (N, N)), (N, N))
+            expected += want[0] == "ok"
             accepted += got[0] == "ok"
-    assert accepted == 1154
+    assert expected > 0, "test bug: numpy accepted nothing, the matrix is broken"
+    assert accepted == expected
 
 
 # --- other subscripts and arities -----------------------------------------

--- a/tests/test_nonnumeric_out_billing.py
+++ b/tests/test_nonnumeric_out_billing.py
@@ -11,6 +11,12 @@ compute in the operands' dtypes and only then store into ``out``, so the
 arithmetic stays native-speed while the stored kind drags the resolved billing
 dtype down -- dropping both the dtype rate and the complex factor. These tests
 pin that ``out=`` can only widen the bill, never launder it.
+
+For ``einsum`` specifically, the str/bytes destinations are no longer billed
+honestly -- they are refused, for free, because plain numpy refuses them too.
+See ``test_einsum_out_casting_parity.py``; the pin here is that the refusal
+costs nothing, since an unbillable refusal is what keeps it from becoming its
+own exploit.
 """
 
 import numpy as np
@@ -41,23 +47,44 @@ def _real_pair(n=N):
     return rng.random((n, n)), rng.random((n, n))
 
 
-@pytest.mark.parametrize("out_dtype", ["object", "U64", "S64", "U32", "S16"])
-def test_einsum_nonnumeric_out_does_not_discount_complex(out_dtype):
+def test_einsum_nonnumeric_out_does_not_discount_complex():
     load_weights()
     a, b = _complex_pair()
     honest = _billed(lambda: fnp.einsum("ij,jk->ik", a, b))
-    out = np.empty((N, N), dtype=out_dtype)
+    out = np.empty((N, N), dtype=object)
     laundered = _billed(lambda: fnp.einsum("ij,jk->ik", a, b, out=out))
     assert laundered == honest
 
 
-@pytest.mark.parametrize("out_dtype", ["object", "U64", "S64"])
-def test_einsum_nonnumeric_out_does_not_discount_float64(out_dtype):
+def test_einsum_nonnumeric_out_does_not_discount_float64():
     load_weights()
     a, b = _real_pair()
     honest = _billed(lambda: fnp.einsum("ij,jk->ik", a, b))
-    out = np.empty((N, N), dtype=out_dtype)
+    out = np.empty((N, N), dtype=object)
     assert _billed(lambda: fnp.einsum("ij,jk->ik", a, b, out=out)) == honest
+
+
+@pytest.mark.parametrize("out_dtype", ["U64", "S64", "U32", "S16"])
+@pytest.mark.parametrize("pair", ["complex", "real"])
+def test_einsum_string_out_is_refused_for_free(out_dtype, pair):
+    """The str/bytes destinations used to be the sharpest form of this launder:
+    they reached the contraction, billed at the neutral rate, and then stored
+    a *rendering* of the answer. numpy has never allowed it -- einsum has no
+    string inner loop -- so the destination-casting parity fix now refuses
+    them outright, which is a stronger pin than "bills the honest rate".
+
+    Refusal must cost nothing. There are no refunds, so an op that raises
+    after billing would be a free way to burn a rival's budget, and an op that
+    raises after billing *its own* cost would still charge for arithmetic the
+    caller never received.
+    """
+    load_weights()
+    a, b = _complex_pair() if pair == "complex" else _real_pair()
+    out = np.empty((N, N), dtype=out_dtype)
+    with f.BudgetContext(flop_budget=10**18, quiet=True) as budget:
+        with pytest.raises(TypeError):
+            fnp.einsum("ij,jk->ik", a, b, out=out)
+        assert budget.flops_used == 0
 
 
 def test_contraction_helper_nonnumeric_out_does_not_discount():


### PR DESCRIPTION
**Breaking for a narrow class of calls**, and the last of the `out=` items left open.

einsum's write-back used `casting="unsafe"` regardless of what the caller asked for, so flopscope **silently truncated where numpy refuses**: two float64 operands into an int64 destination succeeded here and raises `TypeError` in numpy; a complex result into a float64 destination dropped the imaginary part with only a warning. Those now raise, matching numpy.

## This is the second attempt — the first was reverted

It came out **stricter than numpy in 138 cells**. `einsum("ij,jk->ik", int8, uint8, out=float16)` produces exact values in plain numpy and it raised.

The cause was computing the promotion **without** the destination. `np.result_type` is a *lattice minimum*, not a left-fold:

| expression | value |
|---|---|
| `result_type(int8, uint8)` | `int16` |
| `result_type(int8, uint8, float16)` | **`float16`** |

`float16` holds every `int8` and every `uint8` exactly, so the lattice picks it; the pairwise fold overshoots to `int16` and never reconsiders. The destination *participates* in the promotion, and omitting it was the entire bug.

## The rule, in numpy's own primitives

```python
op_dtype = np.result_type(*operand_dtypes, out.dtype)
accept iff np.can_cast(op_dtype, out.dtype, casting)
```

Two things this attempt gets right that the differential sweep forced:

**The caller's `casting=` governs.** It arrives through `**kwargs`; hardcoding `"safe"` refused 5,533 calls numpy accepts — and reported *"according to the rule 'safe'"* on a call that explicitly asked for `unsafe`.

**The rule governs the operand side too.** Only visible under the strict kinds: `bool × bool` into an int8 destination promotes to int8, and int8 stores into int8 under any rule, yet numpy still refuses under `equiv`/`no` because the bool **operands** don't cast to int8 under those. Checking only the store left flopscope *looser* than numpy in 856 cells.

## The contraction now runs in `op_dtype`

Casting the answer afterwards is a different operation. `int8 × int8` into an int16 destination returned **−56** (int8 overflow before the store) where numpy returns 300; `bool × bool` returned **1** (logical or) where numpy returns 3. **38 accepted cells were writing wrong numbers**, independent of the accept/refuse defect.

## Verification

| sweep | cells | stricter | looser |
|---|---|---|---|
| 12 dtypes × all 5 casting kinds | 8,640 | **0** | **0** |
| arities 1–4 over 8 subscript patterns, default rule | 20,992 | **0** | **0** |

Compared on accept/refuse, exception class, message text, and written values. Baseline before the fix on the same harness: 1,898 accept/refuse mismatches, 1,044 wrong exception class, 38 wrong values. The rule was also confirmed stable across numpy 2.0 → 2.4 (7 patch versions, 4,096 cells each, zero drift).

Refusal measured free — `flops_used` 0 → 0, and still 0 under `flop_budget=1`, since the dtype question is settled above `budget.deduct`.

The reverted attempt's killer case is pinned by name as `test_int8_uint8_into_float16_regression_pin`.

## One test changed

`tests/test_nonnumeric_out_billing.py`'s `U64`/`S64`/`U32`/`S16` `out=` cases asserted the launder was *billed honestly*; those calls are now refused outright, so they assert refusal at zero cost instead — the stronger property. The `object` destination stays a billing pin, since object is a dtype einsum genuinely supports.

## What starts raising

```python
a = np.full((6, 6), 2.5); b = np.full((6, 6), 2.0)
fnp.einsum("ij,jk->ik", a, b, out=np.zeros((6, 6), np.int64))
# before: silently writes 30
# now:    TypeError, as numpy has always raised
# (add casting="unsafe" for the old behaviour — that is now honoured too)
```