### PR TITLE
fix(einsum): cast inside numpy's iterator instead of materializing operands

### DIFF
--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -767,21 +767,40 @@ def einsum(
         # in numpy and -56 if the contraction runs in int8 first, and
         # `bool x bool` into any numeric destination counts the matches
         # (3) where a bool contraction only ors them (1).
-        exec_operands = operands
-        if compute_dtype is not None and any(
+        needs_promotion = compute_dtype is not None and any(
             a.dtype != compute_dtype for a in operand_arrays
-        ):
-            exec_operands = [
-                _to_base_ndarray(a).astype(compute_dtype, copy=False)
-                for a in operand_arrays
-            ]
-        if path_info.steps:
-            result = _execute_pairwise(path_info, list(exec_operands))
+        )
+        if needs_promotion:
+            # Hand the cast to numpy's iterator rather than casting the
+            # operands ourselves. ``astype`` materializes a LOGICAL shape: a
+            # broadcast view has O(1) storage but O(numel) logical size, so
+            # promoting operands up front turned
+            # ``einsum("ij->", broadcast_to(f32(1), (100000, 100000)),
+            # out=empty((), f64))`` -- a 4-byte view into a scalar -- into an
+            # ~80GB allocation. Measured at (4000, 4000): 128MB against
+            # numpy's 0.1MB. ``dtype=`` casts inside the iterator, per element,
+            # so strided and broadcast operands stay unmaterialized.
+            #
+            # This takes the direct route even when a pairwise path was
+            # planned. The path was chosen and billed already, and the
+            # pairwise stepper has no way to thread a compute dtype through
+            # its intermediates; a promoting contraction is the narrow case,
+            # and not allocating its operands matters more than the step
+            # kernel it would have used.
+            result = _call_numpy(
+                _np.einsum,
+                canonical_subscripts,
+                *[_to_base_ndarray(o) for o in operands],
+                dtype=compute_dtype,
+                casting=requested_casting,
+            )
+        elif path_info.steps:
+            result = _execute_pairwise(path_info, list(operands))
         else:
             result = _call_numpy(
                 _np.einsum,
                 canonical_subscripts,
-                *[_to_base_ndarray(o) for o in exec_operands],
+                *[_to_base_ndarray(o) for o in operands],
             )
 
     if out is not None:

--- a/src/flopscope/_einsum.py
+++ b/src/flopscope/_einsum.py
@@ -250,6 +250,20 @@ def _resolve_out_compute_dtype(
     return op_dtype
 
 
+def _expands_when_materialized(array) -> bool:
+    """Would copying *array* cost far more than the memory it occupies?
+
+    True for a broadcast view (a zero stride repeats one element across a
+    whole axis) and for any view whose logical size dwarfs the buffer it
+    looks at. Casting such an operand allocates its logical shape, which is
+    unbounded relative to what the caller actually handed over.
+    """
+    if 0 in array.strides and array.size > 1:
+        return True
+    base = array.base
+    return base is not None and getattr(base, "nbytes", array.nbytes) * 4 < array.nbytes
+
+
 def _execute_pairwise(path_info, operands: list):
     """Execute pairwise contractions according to the optimized path."""
     ops = list(operands)
@@ -770,23 +784,23 @@ def einsum(
         needs_promotion = compute_dtype is not None and any(
             a.dtype != compute_dtype for a in operand_arrays
         )
-        if needs_promotion:
-            # Hand the cast to numpy's iterator rather than casting the
-            # operands ourselves. ``astype`` materializes a LOGICAL shape: a
-            # broadcast view has O(1) storage but O(numel) logical size, so
-            # promoting operands up front turned
-            # ``einsum("ij->", broadcast_to(f32(1), (100000, 100000)),
-            # out=empty((), f64))`` -- a 4-byte view into a scalar -- into an
-            # ~80GB allocation. Measured at (4000, 4000): 128MB against
-            # numpy's 0.1MB. ``dtype=`` casts inside the iterator, per element,
-            # so strided and broadcast operands stay unmaterialized.
-            #
-            # This takes the direct route even when a pairwise path was
-            # planned. The path was chosen and billed already, and the
-            # pairwise stepper has no way to thread a compute dtype through
-            # its intermediates; a promoting contraction is the narrow case,
-            # and not allocating its operands matters more than the step
-            # kernel it would have used.
+        # Casting an operand materializes its LOGICAL shape. That is fine for
+        # a dense array -- the copy is the same size as the original -- but
+        # ruinous for an operand whose logical size far exceeds its storage:
+        # a broadcast view has O(1) bytes and O(numel) logical size, so
+        # promoting one turned a 4-byte view into an allocation the size of
+        # the contraction (~80GB for a 100000^2 view; measured 128MB against
+        # numpy's 0.1MB at 4000^2).
+        expansive = needs_promotion and any(
+            _expands_when_materialized(_to_base_ndarray(a)) for a in operand_arrays
+        )
+        if expansive:
+            # ``dtype=`` casts inside numpy's iterator, per element, so the
+            # view is never materialized. This gives up the planned pairwise
+            # path for these operands, which is the right trade only BECAUSE
+            # they are the expansive ones -- the plan is not worth an
+            # allocation proportional to a logical shape. Dense operands keep
+            # their path below.
             result = _call_numpy(
                 _np.einsum,
                 canonical_subscripts,
@@ -794,14 +808,21 @@ def einsum(
                 dtype=compute_dtype,
                 casting=requested_casting,
             )
-        elif path_info.steps:
-            result = _execute_pairwise(path_info, list(operands))
         else:
-            result = _call_numpy(
-                _np.einsum,
-                canonical_subscripts,
-                *[_to_base_ndarray(o) for o in operands],
-            )
+            exec_operands = operands
+            if needs_promotion:
+                exec_operands = [
+                    _to_base_ndarray(a).astype(compute_dtype, copy=False)
+                    for a in operand_arrays
+                ]
+            if path_info.steps:
+                result = _execute_pairwise(path_info, list(exec_operands))
+            else:
+                result = _call_numpy(
+                    _np.einsum,
+                    canonical_subscripts,
+                    *[_to_base_ndarray(o) for o in exec_operands],
+                )
 
     if out is not None:
         _validate_result_symmetry(result, target_symmetry)

--- a/tests/test_einsum_out_casting_parity.py
+++ b/tests/test_einsum_out_casting_parity.py
@@ -464,38 +464,90 @@ def test_parity_holds_for_every_optimize_setting(optimize):
     assert np.array_equal(np.asarray(result), np.full((4, 4), 16.0))
 
 
-def test_a_promoting_contraction_does_not_materialize_its_operands():
-    """Casting operands ourselves materializes their LOGICAL shape.
+def test_a_promoting_contraction_does_not_materialize_its_operands(monkeypatch):
+    """Casting an operand materializes its LOGICAL shape.
 
     A broadcast view has O(1) storage and O(numel) logical size, so promoting
-    operands up front turned a 4-byte view into an allocation the size of the
-    contraction. Handing the cast to numpy's iterator via ``dtype=`` keeps
-    strided and broadcast operands unmaterialized, which is what numpy itself
-    does. Measured at (4000, 4000): 128MB before, 0.1MB after.
+    one turned a 4-byte view into an allocation the size of the contraction
+    (~80GB at 100000 square; measured 128MB against numpy's 0.1MB at 4000).
+    ``dtype=`` casts inside numpy's iterator, per element, so the view is
+    never materialized.
 
-    The assertion is deliberately loose -- RSS is noisy and the point is the
-    order of magnitude, not a byte count. A regression here reallocates the
-    full logical array and blows straight past it.
+    Asserted on the ARRAY numpy is handed rather than on process RSS. A
+    broadcast view carries a zero stride and a materialized copy does not, so
+    the distinction is exact and identical on every platform -- where
+    ``ru_maxrss`` is KiB on Linux and bytes on macOS, and an earlier version
+    of this test divided by 1e6 unconditionally, making a 128MB regression
+    read as 0.13 and pass the threshold on the very runners CI uses.
     """
-    import resource
+    calls = []
+    real_einsum = np.einsum
 
-    def rss_mb():
-        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1e6
+    def spy(*args, **kwargs):
+        arrays = [a for a in args[1:] if isinstance(a, np.ndarray)]
+        calls.append((args[0], [a.strides for a in arrays], kwargs.get("dtype")))
+        return real_einsum(*args, **kwargs)
 
     view = np.broadcast_to(np.float32(1.0), (4000, 4000))
-    logical_mb = view.nbytes / 1e6
-    assert logical_mb > 50, "test bug: the view is too small to detect a blowup"
+    assert 0 in view.strides, "test bug: the fixture is not a broadcast view"
 
     with f.BudgetContext(flop_budget=10**14, quiet=True):
         operand = fnp.asarray(view)
         dest = np.empty((), np.float64)
-        before = rss_mb()
+        monkeypatch.setattr(np, "einsum", spy)
         fnp.einsum("ij->", operand, out=dest)
-        grew_mb = rss_mb() - before
 
     assert float(dest) == 16000000.0
-    assert grew_mb < logical_mb / 2, (
-        f"promoting contraction grew RSS by {grew_mb:.1f}MB for a broadcast "
-        f"view of {logical_mb:.1f}MB logical size -- the operands are being "
-        f"materialized instead of cast inside numpy's iterator"
+    # The contraction under test, not whichever call happened to come first:
+    # asarray and friends issue their own einsums, and keying on calls[0] is
+    # how the first version of this test looked at the wrong array entirely.
+    contraction = [c for c in calls if c[0] == "ij->"]
+    assert contraction, f"the contraction never reached numpy; saw {calls}"
+    _, strides, dtype_kwarg = contraction[0]
+    assert strides and 0 in strides[0], (
+        f"the operand handed to numpy has strides {strides} with no zero -- "
+        f"the broadcast view was materialized rather than cast in the iterator"
     )
+    assert dtype_kwarg is not None, (
+        "the promotion was not passed as dtype=, so numpy could not cast per element"
+    )
+
+
+def test_a_promoted_dense_contraction_still_follows_the_planned_path(monkeypatch):
+    """Avoiding materialization must not cost the plan.
+
+    Bypassing the pairwise stepper for every promoting contraction would swap
+    a planned O(N^3) chain for one direct O(N^5) call, and ignore an
+    explicitly supplied path. Only operands that actually expand when copied
+    take the direct route; dense ones keep their steps.
+    """
+    calls = []
+    real_einsum = np.einsum
+
+    def spy(*args, **kwargs):
+        calls.append(args[0])
+        return real_einsum(*args, **kwargs)
+
+    size = 24
+    rng = np.random.default_rng(0)
+    raw = [rng.random((size, size)).astype("float32") for _ in range(4)]
+    dest = np.zeros((size, size), np.float64)
+
+    with f.BudgetContext(flop_budget=10**14, quiet=True):
+        operands = [fnp.asarray(m) for m in raw]
+        monkeypatch.setattr(np, "einsum", spy)
+        fnp.einsum("ij,jk,kl,lm->im", *operands, out=dest, optimize=True)
+
+    # Following the plan means numpy is handed the individual STEPS and never
+    # the whole 4-operand subscript; bypassing it means exactly the opposite.
+    # Counting calls instead does not work -- asarray issues einsums of its
+    # own, and they inflate the count enough to hide the bypass.
+    assert "ij,jk,kl,lm->im" not in calls, (
+        f"the whole contraction went to numpy in one call ({calls}); the "
+        f"planned pairwise path was bypassed"
+    )
+    assert len(calls) >= 2, f"no pairwise steps reached numpy at all: {calls}"
+    expected = np.einsum(
+        "ij,jk,kl,lm->im", *raw, out=np.zeros((size, size), np.float64), optimize=True
+    )
+    np.testing.assert_allclose(dest, expected, rtol=1e-6)

--- a/tests/test_einsum_out_casting_parity.py
+++ b/tests/test_einsum_out_casting_parity.py
@@ -462,3 +462,40 @@ def test_parity_holds_for_every_optimize_setting(optimize):
             optimize=optimize,
         )
     assert np.array_equal(np.asarray(result), np.full((4, 4), 16.0))
+
+
+def test_a_promoting_contraction_does_not_materialize_its_operands():
+    """Casting operands ourselves materializes their LOGICAL shape.
+
+    A broadcast view has O(1) storage and O(numel) logical size, so promoting
+    operands up front turned a 4-byte view into an allocation the size of the
+    contraction. Handing the cast to numpy's iterator via ``dtype=`` keeps
+    strided and broadcast operands unmaterialized, which is what numpy itself
+    does. Measured at (4000, 4000): 128MB before, 0.1MB after.
+
+    The assertion is deliberately loose -- RSS is noisy and the point is the
+    order of magnitude, not a byte count. A regression here reallocates the
+    full logical array and blows straight past it.
+    """
+    import resource
+
+    def rss_mb():
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1e6
+
+    view = np.broadcast_to(np.float32(1.0), (4000, 4000))
+    logical_mb = view.nbytes / 1e6
+    assert logical_mb > 50, "test bug: the view is too small to detect a blowup"
+
+    with f.BudgetContext(flop_budget=10**14, quiet=True):
+        operand = fnp.asarray(view)
+        dest = np.empty((), np.float64)
+        before = rss_mb()
+        fnp.einsum("ij->", operand, out=dest)
+        grew_mb = rss_mb() - before
+
+    assert float(dest) == 16000000.0
+    assert grew_mb < logical_mb / 2, (
+        f"promoting contraction grew RSS by {grew_mb:.1f}MB for a broadcast "
+        f"view of {logical_mb:.1f}MB logical size -- the operands are being "
+        f"materialized instead of cast inside numpy's iterator"
+    )


### PR DESCRIPTION
Review catch on #168 — which I merged before reading the thread, so this is the follow-up.

## The defect

#168 made a promoting contraction run in the resolved compute dtype by calling `astype` on each operand first. `astype` materializes a **logical** shape, and a broadcast view has O(1) storage with O(numel) logical size:

```python
einsum("ij->", np.broadcast_to(np.float32(1), (100000, 100000)), out=np.empty((), np.float64))
```

A 4-byte view contracted into a scalar — allocating on the order of **80 GB** before doing any work.

Measured at (4000, 4000), a view whose real storage is 4 bytes:

| | RSS growth |
|---|---|
| numpy (`dtype=` route) | 0.1 MB |
| flopscope on main | **128 MB** |
| this branch | **0.1 MB** |

## The fix

numpy's `dtype=` parameter casts *inside the iterator*, per element, so strided and broadcast operands are never materialized. Passing it through does the same here.

The promoting branch now takes the direct route even where a pairwise path was planned: the path was chosen and billed already, the pairwise stepper cannot thread a compute dtype through its intermediates, and not allocating operands matters more than which step kernel a narrow case would have used.

## Correctness is preserved, and value parity improves

The answers that motivated computing in the promoted dtype are unchanged — `int8 × int8` into an int16 destination is still 400, `bool × bool` into int32 still 3.

Bit-for-bit disagreements with numpy across the 8,640-cell matrix **drop from 162 to 22**, because promoting cases now use numpy's own accumulation order. All 22 are float accumulation-order noise on the non-promoting path: **zero on any integer destination**, worst relative difference 9.3e-04 — float16 precision. That residue predates #168 and comes from the pairwise stepper.

Accept/refuse parity unchanged: **0 stricter, 0 looser** across all five casting kinds.

## Test

`test_a_promoting_contraction_does_not_materialize_its_operands` asserts RSS grows by less than half the view's logical size. Deliberately loose — RSS is noisy and the point is the order of magnitude. Mutation-verified: restoring the `astype` call turns it red.