### PR TITLE
fix(compat): make the CI numpy matrix real and fix everything it hid (numpy 2.0-2.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,14 @@ jobs:
     needs: [detect-impact]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # `uv run` re-syncs the venv from uv.lock by default, silently reverting
+    # the "Pin NumPy" step back to the locked numpy -- which made every matrix
+    # cell test the same version. UV_NO_SYNC applies --no-sync to every
+    # `uv run` in this job; the explicit `uv sync` / `uv pip install` steps
+    # below are unaffected by it. The two assert steps fail the cell loudly
+    # if the pin is ever reverted again.
+    env:
+      UV_NO_SYNC: "1"
     strategy:
       fail-fast: true
       matrix:
@@ -192,17 +200,56 @@ jobs:
       - name: Pin NumPy ${{ matrix.numpy-version }}
         run: uv pip install 'numpy~=${{ matrix.numpy-version }}.0'
 
+      - name: Assert the venv numpy matches this matrix cell
+        env:
+          EXPECTED_NUMPY: ${{ matrix.numpy-version }}
+        run: |
+          .venv/bin/python - <<'PY'
+          import os
+          import numpy
+
+          expected = os.environ["EXPECTED_NUMPY"]
+          actual = numpy.__version__
+          assert actual.startswith(expected + "."), (
+              f"matrix cell wants numpy {expected}.x but the venv has {actual}"
+              " -- something re-synced the environment from uv.lock"
+          )
+          print(f"numpy {actual} matches matrix cell {expected}")
+          PY
+
       - name: Generate API docs (untracked; tests validate them)
         run: uv run python scripts/generate_api_docs.py
 
       - name: Run tests with coverage
         run: uv run pytest --cov=flopscope --cov-fail-under=85
 
+      - name: Assert the pinned numpy survived the test run
+        if: always()
+        env:
+          EXPECTED_NUMPY: ${{ matrix.numpy-version }}
+        run: |
+          .venv/bin/python - <<'PY'
+          import os
+          import numpy
+
+          expected = os.environ["EXPECTED_NUMPY"]
+          actual = numpy.__version__
+          assert actual.startswith(expected + "."), (
+              f"matrix cell wants numpy {expected}.x but the venv has {actual}"
+              " -- a test or step re-synced the environment mid-run"
+          )
+          print(f"numpy {actual} still matches matrix cell {expected}")
+          PY
+
   numpy-compat:
     if: needs.detect-impact.outputs.run_numpy_compat == 'true'
     needs: [detect-impact]
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    # Same guard as the `test` job: without UV_NO_SYNC every `uv run` below
+    # would re-sync from uv.lock and revert the "Pin NumPy" step.
+    env:
+      UV_NO_SYNC: "1"
     strategy:
       fail-fast: true
       matrix:
@@ -229,6 +276,23 @@ jobs:
 
       - name: Pin NumPy ${{ matrix.numpy-version }}
         run: uv pip install 'numpy~=${{ matrix.numpy-version }}.0'
+
+      - name: Assert the venv numpy matches this matrix cell
+        env:
+          EXPECTED_NUMPY: ${{ matrix.numpy-version }}
+        run: |
+          .venv/bin/python - <<'PY'
+          import os
+          import numpy
+
+          expected = os.environ["EXPECTED_NUMPY"]
+          actual = numpy.__version__
+          assert actual.startswith(expected + "."), (
+              f"matrix cell wants numpy {expected}.x but the venv has {actual}"
+              " -- something re-synced the environment from uv.lock"
+          )
+          print(f"numpy {actual} matches matrix cell {expected}")
+          PY
 
       - name: Generate API docs (untracked; tests validate them)
         run: uv run python scripts/generate_api_docs.py
@@ -260,6 +324,24 @@ jobs:
 
       - name: "NumPy compat: random"
         run: uv run pytest tests/numpy_compat/ --pyargs numpy.random.tests.test_random -n auto -q
+
+      - name: Assert the pinned numpy survived the compat suites
+        if: always()
+        env:
+          EXPECTED_NUMPY: ${{ matrix.numpy-version }}
+        run: |
+          .venv/bin/python - <<'PY'
+          import os
+          import numpy
+
+          expected = os.environ["EXPECTED_NUMPY"]
+          actual = numpy.__version__
+          assert actual.startswith(expected + "."), (
+              f"matrix cell wants numpy {expected}.x but the venv has {actual}"
+              " -- a test or step re-synced the environment mid-run"
+          )
+          print(f"numpy {actual} still matches matrix cell {expected}")
+          PY
 
   client-parity:
     # GATE: targeted participant-parity tests must be green (rc3+).

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -2457,8 +2457,20 @@ def parse_numpy_docstring(raw_doc: str) -> ParsedDoc:
 
     doc = NumpyDocString(textwrap.dedent(raw_doc).strip("\n"))
 
-    summary = " ".join(part.strip() for part in doc["Summary"]).strip()
+    summary_lines = list(doc["Summary"])
     upstream_signature = str(doc["Signature"]).strip()
+    # numpydoc only splits a leading signature off into doc["Signature"] when
+    # a blank line follows it. Some numpy builds run the signature and the
+    # one-line summary together in a single block (np.random.default_rng on
+    # numpy <= 2.2), which lands the signature INSIDE the summary and makes
+    # generated summaries depend on which numpy generated them. Strip such a
+    # leading bare-signature line, keeping it as the upstream signature --
+    # exactly where numpydoc puts it when the blank line is present.
+    if summary_lines and re.fullmatch(r"[\w.]+\(.*\)", summary_lines[0].strip()):
+        stripped_signature = summary_lines.pop(0).strip()
+        if not upstream_signature:
+            upstream_signature = stripped_signature
+    summary = " ".join(part.strip() for part in summary_lines).strip()
 
     def parse_field_section(
         section_name: str, *, single_element_is_type: bool = False

--- a/src/flopscope/_array_ops.py
+++ b/src/flopscope/_array_ops.py
@@ -1585,6 +1585,13 @@ attach_docstring(
 # Type / info helpers
 # ---------------------------------------------------------------------------
 
+# ``np.astype`` only grew its ``device=`` keyword in numpy 2.1; flopscope
+# supports numpy >=2.0. When numpy cannot accept the keyword, reproduce
+# numpy>=2.1's device handling (None/"cpu" pass, anything else ValueError,
+# raised inside the deduct block -- which charges on entry -- so behavior
+# and billing are identical across the supported range).
+_NP_ASTYPE_HAS_DEVICE = "device" in _inspect.signature(_np.astype).parameters
+
 
 @_counted_wrapper
 def astype(
@@ -1617,9 +1624,17 @@ def astype(
         shapes=(x_arr.shape,),
         dtypes=(_heavier_billing_dtype(x_arr.dtype, resolved_dtype),),
     ):
-        result = _call_numpy(
-            _np.astype, _to_base_ndarray(x), dtype, copy=copy, device=device
-        )
+        if _NP_ASTYPE_HAS_DEVICE:
+            result = _call_numpy(
+                _np.astype, _to_base_ndarray(x), dtype, copy=copy, device=device
+            )
+        else:
+            if device is not None and device != "cpu":
+                raise ValueError(
+                    'Device not understood. Only "cpu" is allowed, '
+                    f"but received: {device}"
+                )
+            result = _call_numpy(_np.astype, _to_base_ndarray(x), dtype, copy=copy)
     return result  # type: ignore[return-value]
 
 

--- a/src/flopscope/_pointwise.py
+++ b/src/flopscope/_pointwise.py
@@ -212,6 +212,22 @@ _UNARY_FLOAT_LOOP_OPS = frozenset(
         "tanh",
     }
 )
+# numpy < 2.1 has no integer loops for ceil/floor/trunc (nor fix, their
+# composite): integer input is promoted and computed in the size-mapped float
+# loop (int8 -> float16, ..., int32 -> float64), exactly like sin. numpy 2.1
+# added identity integer loops, making them integer-preserving. Membership is
+# probed from the running numpy -- never a version table -- so billing always
+# tracks what this backend actually computes.
+_UNARY_FLOAT_LOOP_OPS |= frozenset(
+    op_name
+    for op_name, fn in (
+        ("ceil", _np.ceil),
+        ("floor", _np.floor),
+        ("trunc", _np.trunc),
+        ("fix", _np.fix),
+    )
+    if fn(_np.ones(1, dtype=_np.int32)).dtype.kind == "f"
+)
 # Unary ops with NO size-mapped integer loop: numpy always computes them in
 # (at least) float64 for integer/bool input regardless of the input's own
 # width -- unlike the size-mapped _UNARY_FLOAT_LOOP_OPS family (i0(int8) ->

--- a/src/flopscope/_symmetry_utils.py
+++ b/src/flopscope/_symmetry_utils.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import functools
 import math
+import warnings
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 import numpy as np
 
-from flopscope._perm_group import SymmetryGroup
-from flopscope.errors import SymmetryError
+from flopscope._config import get_setting as _get_setting
+from flopscope._perm_group import SymmetryGroup, _DiminoBudgetExceeded
+from flopscope.errors import CostFallbackWarning, SymmetryError
 
 
 def _normalize_axis_tuple(
@@ -103,10 +105,56 @@ def unique_elements_for_shape(
     group: SymmetryGroup | None,
     shape: tuple[int, ...],
 ) -> int:
-    """Return the number of unique tensor elements implied by symmetry."""
+    """Return the number of unique tensor elements implied by symmetry.
+
+    Degrades to the dense element count when the group cannot be enumerated
+    within ``dimino_budget``: unknown-kind groups (raw generators -- e.g. the
+    auto-inferred full-exchange symmetry of a constant array) have no closed
+    form for either the Burnside count or the ``__hash__`` canonicalization
+    that keying the cache requires, so both can raise
+    ``_DiminoBudgetExceeded`` mid-enumeration. Charging dense is the same
+    never-under-bill fallback the oversized-group guards in ``_pointwise``
+    use; leaking the private exception through whatever billed op asked for
+    the count is what numpy 2.4's ``TestCreationFuncs::test_full`` first
+    surfaced.
+    """
     if group is None:
         return math.prod(shape)
-    return _unique_elements_for_shape_cached(group, tuple(shape))
+    try:
+        return _unique_elements_for_shape_cached(group, tuple(shape))
+    except _DiminoBudgetExceeded:
+        _warn_dense_fallback_once(group.degree, tuple(shape))
+        return math.prod(shape)
+
+
+@functools.cache
+def _dense_fallback_seen(degree: int, shape: tuple[int, ...]) -> None:
+    return None
+
+
+def _warn_dense_fallback_once(degree: int, shape: tuple[int, ...]) -> None:
+    """Emit :class:`CostFallbackWarning` once per ``(degree, shape)``.
+
+    Mirrors ``_pointwise._warn_oversized_once``: the setting check stays
+    OUTSIDE the seen-cache so re-enabling ``symmetry_warnings`` later still
+    warns, and hot paths (compat suites doing thousands of ops on the same
+    inferred symmetry) do not flood the log. Keyed by degree, not the group
+    object -- hashing the group is exactly what can blow the budget.
+    """
+    if not _get_setting("symmetry_warnings"):
+        return
+    info_before = _dense_fallback_seen.cache_info()
+    _dense_fallback_seen(degree, shape)
+    if _dense_fallback_seen.cache_info().hits > info_before.hits:
+        return  # already warned for this (degree, shape) pair
+    budget = int(_get_setting("dimino_budget"))  # type: ignore[arg-type]
+    warnings.warn(
+        f"unique-element count for a degree-{degree} SymmetryGroup exceeded "
+        f"the enumeration budget ({budget}); charging the dense element "
+        "count. Suppress with flops.configure(symmetry_warnings=False).",
+        CostFallbackWarning,
+        stacklevel=3,
+    )
 
 
 @functools.cache

--- a/tests/batch_scan.py
+++ b/tests/batch_scan.py
@@ -1309,6 +1309,20 @@ def recipe_vecdot(op):
     return [_bp("A:vecdot", op, (arr((4,)), arr((4,))), (arr((K, 4)), arr((K, 4))))]
 
 
+def recipe_clip(op):
+    # Positional bounds: the only clip form numpy 2.0 accepts (min=/max=
+    # keywords and the no-bound form are numpy >= 2.1), and valid on every
+    # later numpy -- so scale coverage holds across the whole support range.
+    return [
+        _bp(
+            "A:clip",
+            op,
+            (arr((6, 4)), 0.25, 0.75),
+            (arr((K, 6, 4)), 0.25, 0.75),
+        )
+    ]
+
+
 def recipe_bytes(bound_op):
     # bytes(n) output is a bytestring (numel oracle can't see it) -> explicit
     # honest = k: doubling n must double the bill.
@@ -1391,6 +1405,7 @@ RECIPES_FUNC = {
     "vecmat": recipe_vecmat,
     "vecdot": recipe_vecdot,
     "linalg.vecdot": recipe_vecdot,
+    "clip": recipe_clip,
 }
 
 # leaf method name -> recipe fn taking the BOUND callable (Generator/RandomState)

--- a/tests/numpy_compat/xfails.py
+++ b/tests/numpy_compat/xfails.py
@@ -4,7 +4,14 @@ Each entry maps a test node ID (or pattern) to a reason string.
 Tests matching these patterns are marked xfail when running NumPy's
 test suite against flopscope.
 
-Current state (2026-04-17, numpy 2.4.4, after Task 10 triage):
+Current state (2026-07-29, numpy 2.4.6, PR #171 first REAL numpy-version matrix):
+    The CI matrix pin was vacuous before PR #171 (uv run re-synced the locked
+    numpy back in), so this was the first genuine 2.4 run of the borrowed
+    suites. 1 new xfail added: TestUfunc::test_output_ellipsis_errors —
+    numpy 2.4's nested-Ellipsis out= special-case message diverges from
+    flopscope's deliberate out=-refusal wording (TypeError parity holds).
+
+Previous state (2026-04-17, numpy 2.4.4, after Task 10 triage):
     Total:          ~7,862 passed, 47 xfailed, 0 failures (all suites)
     test_umath:     ~4,671 passed  (15 xfailed — 1 new test_ufunc_override_where)
     test_ufunc:       ~855 passed  (10 xfailed)
@@ -376,6 +383,22 @@ XFAIL_PATTERNS: dict[str, str] = {
     "*TestUfunc::test_ufunc_custom_out": (
         "NOT_IMPLEMENTED: private gufunc test_add not in allowlist"
     ),
+    # numpy 2.4 added `out=...` (Ellipsis) and special-cases an Ellipsis
+    # NESTED in an out= tuple with its own TypeError ("must use `...` as
+    # `out=...` and not per-operand/in a tuple"). flopscope's out=
+    # normalizer refuses every non-array tuple entry with its single
+    # deliberate, participant-instructive message ("return arrays must be
+    # of ArrayType -- ... Pass the destination array itself, not a
+    # container holding it."), pinned by test_out_arg_wrapped_destination.
+    # Same refusal, same TypeError, different wording -- the borrowed
+    # test's regex cannot match. The test node exists only on numpy >= 2.4,
+    # so this pattern is inert on older suites. The feature itself works:
+    # the sibling test_output_ellipsis tests pass under the harness.
+    "*TestUfunc::test_output_ellipsis_errors": (
+        "BY_DESIGN: flopscope refuses non-array out=-tuple entries with its "
+        "own instructive TypeError; numpy 2.4's nested-Ellipsis special-case "
+        "wording differs (exception-type parity holds, message does not)"
+    ),
     "*TestGUFuncProcessCoreDims::test_conv1d_full_with_out": (
         "NOT_IMPLEMENTED: private gufunc conv1d_full not in allowlist"
     ),
@@ -385,6 +408,16 @@ XFAIL_PATTERNS: dict[str, str] = {
     "*TestFrompyfunc::test_identity": (
         "NOT_IMPLEMENTED: frompyfunc creates a custom ufunc whose dispatch "
         "is not in flopscope's __array_function__ allowlist"
+    ),
+    # numpy 2.4's polygrid2d test passes flopscope-wrapped arrays into
+    # np.polynomial.polynomial.polygrid2d, which dispatches through
+    # __array_function__; polygrid2d is not a registered flopscope op, so
+    # the dispatch has no implementation. Node passes on <= 2.3 (different
+    # internal call pattern), so the pattern is a harmless xpass there.
+    "*TestEvaluation::test_polygrid2d": (
+        "NOT_IMPLEMENTED: numpy.polynomial.polynomial.polygrid2d is not in "
+        "flopscope's __array_function__ allowlist (numpy 2.4 routes the "
+        "borrowed test's arrays through the dispatcher)"
     ),
     # ------------------------------------------------------------------ #
     # NEEDS_TRIAGE — state-pollution surfaced by issue-70 fix             #

--- a/tests/test_astype_device_numpy_compat.py
+++ b/tests/test_astype_device_numpy_compat.py
@@ -1,0 +1,119 @@
+"""``fnp.astype`` must work on every supported numpy, including 2.0.
+
+``np.astype`` only grew its ``device=`` keyword in numpy 2.1, while flopscope
+supports ``numpy>=2.0.0,<2.5.0`` (pyproject / ``_registry``). Forwarding
+``device=`` unconditionally made every ``fnp.astype`` call raise ``TypeError``
+under a real numpy 2.0 -- while flopscope still reported itself as
+``0.9.1+np2.0.x``. These tests pin the contract that behavior AND billing are
+identical across the supported range: the numpy>=2.1 device semantics
+(``None``/``"cpu"`` accepted; anything else ``ValueError`` -- raised after the
+charge, since ``deduct`` bills on entry) hold even where numpy itself cannot
+accept the keyword.
+
+The ``_np20_astype`` shim replays numpy 2.0.2's exact ``np.astype`` (signature
+and body) so the 2.0 code path is exercised under every numpy in the CI
+matrix, not only in the 2.0 cells.
+"""
+
+import numpy as np
+import pytest
+
+import flopscope as f
+import flopscope.numpy as fnp
+from flopscope import _array_ops
+
+
+def _billed(fn):
+    with f.BudgetContext(flop_budget=10**18, quiet=True) as b:
+        result = fn()
+        return result, b.flops_used
+
+
+def _np20_astype(x, dtype, /, *, copy=True):
+    """``np.astype`` exactly as numpy 2.0.x defines it: no ``device=``."""
+    if not isinstance(x, np.ndarray):
+        raise TypeError(f"Input should be a NumPy array. It is a {type(x)} instead.")
+    return x.astype(dtype, copy=copy)
+
+
+@pytest.fixture
+def numpy20_astype(monkeypatch):
+    """Make the running numpy look like 2.0 to the astype wrapper."""
+    monkeypatch.setattr(np, "astype", _np20_astype)
+    # raising=False: on unfixed code the flag does not exist yet; the shimmed
+    # np.astype alone is then what makes the wrapper fail (the RED state).
+    monkeypatch.setattr(_array_ops, "_NP_ASTYPE_HAS_DEVICE", False, raising=False)
+
+
+@pytest.mark.usefixtures("numpy20_astype")
+def test_astype_works_when_numpy_lacks_device_kwarg():
+    result, cost = _billed(lambda: fnp.astype(np.ones(4, np.float32), np.float64))
+    assert np.asarray(result).dtype == np.float64
+    np.testing.assert_array_equal(np.asarray(result), np.ones(4))
+    assert cost > 0  # exact formula pinned by test_data_movement_free_tier
+
+
+@pytest.mark.usefixtures("numpy20_astype")
+def test_astype_copy_false_noop_stays_free_without_device_kwarg():
+    x = np.ones(4, np.float32)
+    _, cost = _billed(lambda: fnp.astype(x, np.float32, copy=False))
+    assert cost == 0  # the one free case must survive the 2.0 path
+
+
+def test_astype_bills_identically_with_and_without_device_kwarg():
+    x = np.arange(100, dtype=np.float32)
+    _, native = _billed(lambda: fnp.astype(x, np.float64))
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(np, "astype", _np20_astype)
+        mp.setattr(_array_ops, "_NP_ASTYPE_HAS_DEVICE", False, raising=False)
+        _, shimmed = _billed(lambda: fnp.astype(x, np.float64))
+    assert shimmed == native
+
+
+@pytest.mark.usefixtures("numpy20_astype")
+def test_astype_device_cpu_accepted_on_numpy20_path():
+    result, _ = _billed(
+        lambda: fnp.astype(np.ones(4, np.float32), np.float64, device="cpu")
+    )
+    assert np.asarray(result).dtype == np.float64
+
+
+def test_astype_device_cpu_accepted_native():
+    """Whatever numpy is installed (2.0 included), device="cpu" must work."""
+    result, _ = _billed(
+        lambda: fnp.astype(np.ones(4, np.float32), np.float64, device="cpu")
+    )
+    assert np.asarray(result).dtype == np.float64
+
+
+@pytest.mark.usefixtures("numpy20_astype")
+def test_astype_bad_device_raises_valueerror_on_numpy20_path():
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        with pytest.raises(ValueError, match='Only "cpu" is allowed'):
+            fnp.astype(np.ones(4, np.float32), np.float64, device="cuda")
+
+
+def test_astype_bad_device_raises_valueerror_native():
+    """numpy>=2.1 raises ValueError itself; the 2.0 path must match, so this
+    holds under every installed numpy in the matrix."""
+    with f.BudgetContext(flop_budget=10**18, quiet=True):
+        with pytest.raises(ValueError, match='Only "cpu" is allowed'):
+            fnp.astype(np.ones(4, np.float32), np.float64, device="cuda")
+
+
+def test_astype_bad_device_bills_identically_with_and_without_device_kwarg():
+    """deduct charges on entry, so numpy>=2.1 bills then raises; 2.0 path too."""
+    x = np.arange(50, dtype=np.float32)
+
+    def billed_failure():
+        with f.BudgetContext(flop_budget=10**18, quiet=True) as b:
+            with pytest.raises(ValueError):
+                fnp.astype(x, np.float64, device="mps")
+            return b.flops_used
+
+    native = billed_failure()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(np, "astype", _np20_astype)
+        mp.setattr(_array_ops, "_NP_ASTYPE_HAS_DEVICE", False, raising=False)
+        shimmed = billed_failure()
+    assert shimmed == native

--- a/tests/test_batch_scaling_guard.py
+++ b/tests/test_batch_scaling_guard.py
@@ -27,11 +27,33 @@ around it.
 import json
 from pathlib import Path
 
+import numpy as np
+
 from tests.batch_scan import charged_ops, scan_all
 
 CLASSIFICATION = json.loads(
     (Path(__file__).parent / "data" / "batch_scan_classification.json").read_text()
 )
+
+
+def _version_limited_ops() -> dict[str, str]:
+    """Frozen-OK ops that cannot scale-test on the RUNNING numpy because the
+    backing function (or the batched form the scanner probes) does not exist
+    here. Detected empirically -- never from a version table -- so this
+    shrinks to {} on any numpy that has the capability, restoring full
+    enforcement there. The wrappers' own old-numpy contract
+    (UnsupportedFunctionError) is pinned by test_numpy_version_support.py."""
+    limited: dict[str, str] = {}
+    for op in ("matvec", "vecmat", "cumulative_sum", "cumulative_prod"):
+        if not hasattr(np, op):
+            limited[op] = f"np.{op} does not exist on numpy {np.__version__}"
+    try:
+        np.trim_zeros(np.zeros((2, 2)))
+    except ValueError:
+        limited["trim_zeros"] = (
+            f"trim_zeros is 1-D-only on numpy {np.__version__}; no batch form"
+        )
+    return limited
 
 
 def test_no_charged_op_underbills_batch_or_broadcast():
@@ -55,6 +77,7 @@ def test_no_ok_scales_op_silently_loses_scale_coverage():
     protection while the other two guard tests stay green."""
     results = scan_all()
     frozen_ok = {op for op, e in CLASSIFICATION.items() if e["class"] == "OK-SCALES"}
+    frozen_ok -= set(_version_limited_ops())
     regressed = {
         op: results.get(op, {}).get("verdict", "MISSING")
         for op in frozen_ok

--- a/tests/test_compute_dtype_conformance.py
+++ b/tests/test_compute_dtype_conformance.py
@@ -29,6 +29,7 @@ import flopscope.stats as fstats
 from flopscope._dtype_billing import rate_for
 from flopscope._registry import REGISTRY
 from flopscope._weights import get_weight, load_weights, reset_weights
+from flopscope.errors import UnsupportedFunctionError
 
 # --- probe inputs: int32 (the discriminating dtype), built at module import,
 # --- outside any BudgetContext.
@@ -1161,7 +1162,14 @@ def test_billed_rate_covers_compute_dtype(op: str):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         with f.BudgetContext(flop_budget=10**18, quiet=True) as b:
-            result = PROBES[op]()
+            try:
+                result = PROBES[op]()
+            except UnsupportedFunctionError as e:
+                # Version-gated op absent from the RUNNING numpy (e.g. matvec
+                # before 2.2); the matrix cells whose numpy has it still sweep
+                # it, and the degradation contract itself is pinned by
+                # test_numpy_version_support.py.
+                pytest.skip(f"probe op unavailable on this numpy: {e}")
             records = [r for r in b.op_log if r.op_name == op]
     assert records, f"probe for {op!r} did not log an op record under that name"
     rec = records[-1]
@@ -1204,7 +1212,9 @@ def test_fixed_composites_do_not_overbill_f32():
         lambda: fnp.percentile(g, 50),
         lambda: fnp.nanpercentile(g, 50),
         lambda: fnp.trapezoid(g),
-        lambda: fnp.trapz(g),
+        # numpy 2.4 removed trapz; its wrapper then raises
+        # UnsupportedFunctionError (pinned by test_numpy_version_support).
+        *([lambda: fnp.trapz(g)] if hasattr(np, "trapz") else []),
         lambda: fnp.unwrap(g),
         lambda: fnp.histogram_bin_edges(g),
         lambda: fnp.angle(g),

--- a/tests/test_contraction_batch_parity.py
+++ b/tests/test_contraction_batch_parity.py
@@ -11,6 +11,13 @@ from flopscope import BudgetContext
 W, N = 64, 512
 rng = np.random.default_rng(0)
 
+requires_matvec = pytest.mark.skipif(
+    not hasattr(np, "matvec"), reason="requires numpy >= 2.2"
+)
+requires_vecmat = pytest.mark.skipif(
+    not hasattr(np, "vecmat"), reason="requires numpy >= 2.2"
+)
+
 
 def _cost(fn, *args):
     with BudgetContext(flop_budget=int(1e20)) as bc:
@@ -31,10 +38,18 @@ def arr(*shape):
 @pytest.mark.parametrize(
     "op, subs, shapes",
     [
-        (fnp.vecmat, "...n,...nm->...m", [(N, W), (W, W)]),
-        (fnp.vecmat, "...n,...nm->...m", [(N, W), (N, W, W)]),
-        (fnp.matvec, "...mn,...n->...m", [(W, W), (N, W)]),
-        (fnp.matvec, "...mn,...n->...m", [(N, W, W), (N, W)]),
+        pytest.param(
+            fnp.vecmat, "...n,...nm->...m", [(N, W), (W, W)], marks=requires_vecmat
+        ),
+        pytest.param(
+            fnp.vecmat, "...n,...nm->...m", [(N, W), (N, W, W)], marks=requires_vecmat
+        ),
+        pytest.param(
+            fnp.matvec, "...mn,...n->...m", [(W, W), (N, W)], marks=requires_matvec
+        ),
+        pytest.param(
+            fnp.matvec, "...mn,...n->...m", [(N, W, W), (N, W)], marks=requires_matvec
+        ),
         (fnp.vecdot, "...n,...n->...", [(N, W), (N, W)]),
         (fnp.vecdot, "...n,...n->...", [(N, W), (W,)]),
         (fnp.matmul, "...ij,...jk->...ik", [(N, W, W), (N, W, W)]),
@@ -54,8 +69,12 @@ def test_cost_equals_equivalent_einsum(op, subs, shapes):
         (fnp.matmul, "...ij,...jk->...ik", [(3, W, W), (1, W, W)]),
         (fnp.matmul, "...ij,...jk->...ik", [(1, W, W), (3, W, W)]),
         (fnp.vecdot, "...n,...n->...", [(3, W), (1, W)]),
-        (fnp.vecmat, "...n,...nm->...m", [(3, W), (1, W, W)]),
-        (fnp.matvec, "...mn,...n->...m", [(1, W, W), (3, W)]),
+        pytest.param(
+            fnp.vecmat, "...n,...nm->...m", [(3, W), (1, W, W)], marks=requires_vecmat
+        ),
+        pytest.param(
+            fnp.matvec, "...mn,...n->...m", [(1, W, W), (3, W)], marks=requires_matvec
+        ),
     ],
 )
 def test_cost_equals_einsum_with_size1_broadcast(op, subs, shapes):
@@ -73,6 +92,7 @@ def test_size1_broadcast_cost_uses_broadcast_extent():
     assert _cost(fnp.vecdot, arr(3, W), arr(1, W)) == 3 * (2 * W - 1)
 
 
+@requires_vecmat
 def test_vecmat_scales_with_batch_no_unbilled_compute():
     w = arr(W, W)
     c_small = _cost(fnp.vecmat, arr(8, W), w)
@@ -81,6 +101,7 @@ def test_vecmat_scales_with_batch_no_unbilled_compute():
     assert _cost(fnp.vecmat, arr(N, W), w) == N * W * (2 * W - 1)
 
 
+@requires_matvec
 def test_matvec_mirror_scales_with_batch():
     w = arr(W, W)
     assert _cost(fnp.matvec, w, arr(N, W)) == N * W * (2 * W - 1)

--- a/tests/test_cost_constant_unification.py
+++ b/tests/test_cost_constant_unification.py
@@ -9,6 +9,7 @@ Plan-2 evidence pass; B.1 direct-solver constants are final.
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 import flopscope as f
 import flopscope.numpy as fnp
@@ -728,6 +729,10 @@ def test_clip_broadcast_output_shape():
     assert cost(lambda: fnp.clip(a, lo, hi)) == 500_000
 
 
+@pytest.mark.skipif(
+    np.lib.NumpyVersion(np.__version__) < "2.1.0",
+    reason="no-bound clip requires numpy >= 2.1",
+)
 def test_clip_no_bound_bills_numel_floor():
     # no-bound clip: materializing copy floor → numel
     v = fnp.asarray(np.random.rand(100))
@@ -786,7 +791,14 @@ def test_correlate_mode_int_and_case():
     # mode=0 == "valid", mode=2 == "full", "V" == "valid"
     assert cost(lambda: fnp.correlate(a, v, mode="valid")) == 199
     assert cost(lambda: fnp.correlate(a, v, mode="full")) == 19_801
-    assert cost(lambda: fnp.correlate(a, v, mode="V")) == 199
+    if np.lib.NumpyVersion(np.__version__) < "2.3.0":
+        assert cost(lambda: fnp.correlate(a, v, mode="V")) == 199
+    else:
+        # numpy 2.3 removed the legacy abbreviated/integer modes; the wrapper
+        # forwards the raw mode so numpy itself refuses it (parity).
+        with f.BudgetContext(flop_budget=10**18, quiet=True):
+            with pytest.raises(ValueError, match="valid"):
+                fnp.correlate(a, v, mode="V")
 
 
 def test_correlate_asymmetric_valid():

--- a/tests/test_cost_convention.py
+++ b/tests/test_cost_convention.py
@@ -22,6 +22,7 @@ import flopscope.numpy as fnp
 import flopscope.stats as fst
 from flopscope._flops import sort_cost
 from flopscope._registry import REGISTRY
+from flopscope.errors import UnsupportedFunctionError
 
 # ---------------------------------------------------------------------------
 # Helper
@@ -895,7 +896,14 @@ def test_conformance():
     """Each OP_EXPECTATIONS entry: charged == documented formula."""
     failures = []
     for op, (fn, expected) in OP_EXPECTATIONS.items():
-        actual = _cost(fn)
+        try:
+            actual = _cost(fn)
+        except UnsupportedFunctionError:
+            # Op absent from the RUNNING numpy (added in a later numpy, or
+            # removed -- e.g. trapz on 2.4). The matrix cells whose numpy has
+            # the op still enforce its formula, and the degradation contract
+            # itself is pinned by test_numpy_version_support.py.
+            continue
         if actual != expected:
             failures.append(f"  {op}: got {actual}, expected {expected}")
     if failures:

--- a/tests/test_cost_formula_vs_code.py
+++ b/tests/test_cost_formula_vs_code.py
@@ -386,6 +386,9 @@ def test_nanquantile_numel(name, we):
     assert cost == 104, f"{name}: expected Tier-2 cost=104, got {cost}"
 
 
+@pytest.mark.skipif(
+    not hasattr(numpy, "cumulative_sum"), reason="requires numpy >= 2.1"
+)
 @pytest.mark.parametrize("name", ["cumulative_sum", "cumulative_prod"])
 def test_cumulative_numel(name, we):
     # Updated for orbit-mapping cost model (PR #91 Task 7).

--- a/tests/test_docs_generation_hygiene.py
+++ b/tests/test_docs_generation_hygiene.py
@@ -62,8 +62,11 @@ def test_guard_a_generation_leaves_git_clean():
     excludes summary). Every other generator output is gitignored, so regeneration
     must leave the rest of the tracked tree byte-clean.
     """
+    # Invoke the generator with THIS interpreter, never `uv run`: `uv run`
+    # re-syncs the venv from uv.lock mid-suite, silently reverting the CI
+    # matrix's pinned numpy (and any local pin) back to the locked version.
     subprocess.run(
-        ["uv", "run", "python", "scripts/generate_api_docs.py"], cwd=ROOT, check=True
+        [sys.executable, "scripts/generate_api_docs.py"], cwd=ROOT, check=True
     )
     dirty = [
         ln

--- a/tests/test_docs_generation_hygiene.py
+++ b/tests/test_docs_generation_hygiene.py
@@ -18,6 +18,44 @@ sys.modules[_spec.name] = gen
 _spec.loader.exec_module(gen)
 
 
+def test_parse_strips_leading_signature_line_from_summary():
+    """Generated summaries must not depend on which numpy generated them.
+
+    numpydoc only splits a leading signature off into ``Signature`` when a
+    blank line follows it. Some numpy builds format cython callables'
+    docstrings with the signature and the one-line summary run together in a
+    single block (``np.random.default_rng`` on numpy <= 2.2), which lands the
+    signature INSIDE the summary -- so ops.json flipped between
+    "default_rng(seed=None) Construct ..." and "Construct ..." depending on
+    the generating numpy. Both shapes must parse identically.
+    """
+    joined = (
+        "default_rng(seed=None)\n"
+        "Construct a new Generator with the default BitGenerator (PCG64).\n"
+        "\n"
+        "Parameters\n"
+        "----------\n"
+        "seed : int, optional\n"
+        "    The seed.\n"
+    )
+    parsed = gen.parse_numpy_docstring(joined)
+    assert parsed.summary == (
+        "Construct a new Generator with the default BitGenerator (PCG64)."
+    )
+    assert parsed.upstream_signature == "default_rng(seed=None)"
+
+    # numpy >= 2.3 formats the same docstring with a blank line after the
+    # signature; the parse must come out identical.
+    split = joined.replace("default_rng(seed=None)\n", "default_rng(seed=None)\n\n", 1)
+    parsed_split = gen.parse_numpy_docstring(split)
+    assert parsed_split.summary == parsed.summary
+    assert parsed_split.upstream_signature == parsed.upstream_signature
+
+    # An ordinary summary line must never be mistaken for a signature.
+    plain = gen.parse_numpy_docstring("Do the thing.\n\nMore detail.\n")
+    assert plain.summary == "Do the thing."
+
+
 def test_generated_output_paths_lists_live_write_set():
     paths = {str(p) for p in gen.generated_output_paths()}
     # The two directories the live generator actually writes.

--- a/tests/test_free_ops_extended.py
+++ b/tests/test_free_ops_extended.py
@@ -760,6 +760,7 @@ def test_unravel_index():
     assert r == (1, 2)
 
 
+@pytest.mark.skipif(not hasattr(numpy, "unstack"), reason="requires numpy >= 2.1")
 def test_unstack():
     a = numpy.array([[1, 2], [3, 4], [5, 6]])
     parts = ops.unstack(a)

--- a/tests/test_mask_indices_cost.py
+++ b/tests/test_mask_indices_cost.py
@@ -8,6 +8,8 @@ the returned index count instead made it an arbitrarily cheap substitute for
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -252,12 +254,21 @@ def test_list_returning_mask_func_succeeds_where_raw_numpy_raises():
     """Documents the disclosed compat gap: raw numpy's ``nonzero(a != 0)``
     on a bare Python list yields a 0-d bool and raises; flopscope converts
     the list to a real array first and succeeds instead.
+
+    The raise only exists on numpy >= 2.1: numpy 2.0 still accepts the 0-d
+    result of ``nonzero`` with a DeprecationWarning, so raw numpy succeeds
+    there too and there is no divergence to document on that version.
     """
     n = 3
-    with pytest.raises(ValueError):
-        np.mask_indices(n, lambda m, k: [1, 0, 1])  # type: ignore[arg-type]
+    if np.lib.NumpyVersion(np.__version__) >= "2.1.0":
+        with pytest.raises(ValueError):
+            np.mask_indices(n, lambda m, k: [1, 0, 1])  # type: ignore[arg-type]
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            np.mask_indices(n, lambda m, k: [1, 0, 1])  # type: ignore[arg-type]
 
-    # flopscope succeeds -- this is the documented, deliberate divergence.
+    # flopscope succeeds on every supported numpy.
     result = fnp.mask_indices(n, lambda m, k: [1, 0, 1])
     assert result is not None
 

--- a/tests/test_matmul_out.py
+++ b/tests/test_matmul_out.py
@@ -105,6 +105,7 @@ def test_matmul_returns_a_tagged_destination_itself():
         assert fnp.matmul(s, s, out=dest) is dest
 
 
+@pytest.mark.skipif(not hasattr(np, "vecdot"), reason="requires numpy >= 2.1")
 def test_sibling_contractions_also_return_their_destination():
     """The fix lives in the shared helper, so vecdot/matvec inherit it."""
     load_weights()
@@ -112,8 +113,9 @@ def test_sibling_contractions_also_return_their_destination():
     with f.BudgetContext(flop_budget=10**18, quiet=True):
         d1 = np.empty(N)
         assert fnp.vecdot(a, b, out=d1) is d1
-        d2 = np.empty(N)
-        assert fnp.matvec(a, np.ones(N), out=d2) is d2
+        if hasattr(np, "matvec"):  # matvec arrived in 2.2, vecdot in 2.1
+            d2 = np.empty(N)
+            assert fnp.matvec(a, np.ones(N), out=d2) is d2
 
 
 # --- billing: both directions --------------------------------------------

--- a/tests/test_out_arg_wrapped_destination.py
+++ b/tests/test_out_arg_wrapped_destination.py
@@ -1091,6 +1091,7 @@ def test_a_one_tuple_out_returns_the_destination_not_the_container(budget):
     assert result is ein_dest
 
 
+@pytest.mark.skipif(not hasattr(np, "matvec"), reason="requires numpy >= 2.2")
 def test_a_routed_binary_returns_the_destinations_shape_not_the_containers(budget):
     # matvec used to do `result = out` with out still the tuple, so the caller
     # got back something of shape (1, 256) instead of (256,).
@@ -1100,6 +1101,7 @@ def test_a_routed_binary_returns_the_destinations_shape_not_the_containers(budge
     assert result is dest
 
 
+@pytest.mark.skipif(not hasattr(np, "matvec"), reason="requires numpy >= 2.2")
 def test_a_none_holding_tuple_allocates_instead_of_destroying_the_answer(budget):
     # out=(None,) is numpy's "allocate this slot for me". The routed binaries
     # used to treat the tuple as the destination and hand back a shape-(1,)
@@ -1160,10 +1162,13 @@ def test_a_refused_out_form_costs_nothing_on_every_path(budget, form):
 
     cases = [
         ("multiply", lambda o: fnp.multiply(a2, b2, out=o), fnp.zeros(2)),
-        ("matvec", lambda o: fnp.matvec(eye, a2, out=o), fnp.zeros(2)),
         ("einsum", lambda o: fnp.einsum("i,i->i", a2, b2, out=o), fnp.zeros(2)),
         ("cumsum-positional", lambda o: fnp.cumsum(a2, None, None, o), fnp.zeros(2)),
     ]
+    if hasattr(np, "matvec"):
+        # numpy < 2.2: fnp.matvec raises UnsupportedFunctionError before any
+        # out= validation, so there is no refusal path to price there.
+        cases.insert(1, ("matvec", lambda o: fnp.matvec(eye, a2, out=o), fnp.zeros(2)))
     for name, call, dest in cases:
         bad = _bad_forms(dest)[form]
         before = budget.flops_used
@@ -1245,13 +1250,15 @@ def test_einsum_with_a_real_out_still_works(budget):
     assert result is dest, "out= must return the destination itself"
 
 
+@pytest.mark.skipif(not hasattr(np, "vecdot"), reason="requires numpy >= 2.1")
 def test_out_still_works_on_the_routed_binaries(budget):
     """vecdot/matvec/vecmat expose out= publicly; they must keep working."""
     eye = fnp.array([[1.0, 0.0], [0.0, 1.0]])
     v = fnp.array([3.0, 4.0])
 
-    dest = fnp.array([0.0, 0.0])
-    assert np.asarray(fnp.matvec(eye, v, out=dest)).tolist() == [3.0, 4.0]
+    if hasattr(np, "matvec"):  # matvec arrived in 2.2, vecdot in 2.1
+        dest = fnp.array([0.0, 0.0])
+        assert np.asarray(fnp.matvec(eye, v, out=dest)).tolist() == [3.0, 4.0]
 
     scalar_dest = fnp.array(0.0)
     assert float(np.asarray(fnp.vecdot(v, v, out=scalar_dest))) == 25.0

--- a/tests/test_perm_group_threshold.py
+++ b/tests/test_perm_group_threshold.py
@@ -125,3 +125,44 @@ class TestDiminoBudgetExceededDoesNotEscape:
             w for w in caught if issubclass(w.category, CostFallbackWarning)
         ]
         assert len(cost_warnings) >= 1, "expected a CostFallbackWarning"
+
+
+class TestUnknownKindOversizedGroupDegradesToDense:
+    """The unique-element counter must degrade, never leak _DiminoBudgetExceeded.
+
+    ``fnp.full((2,)*9, 0)`` auto-infers the full S_9 exchange symmetry as a
+    RAW generator set (unknown kind): ``order()`` has no closed form there, so
+    ``burnside_unique_count`` enumerates and blows ``dimino_budget``. Before
+    the fix, the private ``_DiminoBudgetExceeded`` escaped through any billed
+    op on such a tensor -- numpy 2.4's ``TestCreationFuncs::test_full`` (the
+    first genuine 2.4 run of the borrowed suites) found exactly this.
+    """
+
+    def test_billing_on_oversized_inferred_symmetry_charges_dense(self):
+        import warnings
+
+        import flopscope.numpy as fnp
+        from flopscope.errors import CostFallbackWarning
+
+        with flops.BudgetContext(flop_budget=10**12, quiet=True) as b:
+            sym = fnp.full((2,) * 9, 0)
+            before = b.flops_used
+            with pytest.warns(CostFallbackWarning, match="dense"):
+                _ = sym == 0
+            assert b.flops_used - before == 512  # dense numel(2**9), no discount
+            # Unary ops route through the same counter; must also survive.
+            before = b.flops_used
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                fnp.abs(sym)
+            assert b.flops_used - before == 512
+
+    def test_small_inferred_symmetry_keeps_the_discount(self):
+        import flopscope.numpy as fnp
+
+        with flops.BudgetContext(flop_budget=10**12, quiet=True) as b:
+            sym = fnp.full((2, 2, 2), 0)  # inferred S_3, |G| = 6: enumerable
+            before = b.flops_used
+            _ = sym == 0
+            # multiset count C(2+3-1, 3) = 4 unique elements, not dense 8
+            assert b.flops_used - before == 4

--- a/tests/test_pointwise_coverage.py
+++ b/tests/test_pointwise_coverage.py
@@ -790,6 +790,10 @@ class TestClipSymmetric:
             result = clip(st, 0.2, 0.8)
         assert isinstance(result, SymmetricTensor)
 
+    @pytest.mark.skipif(
+        numpy.lib.NumpyVersion(numpy.__version__) < "2.1.0",
+        reason="clip(min=/max=) keywords require numpy >= 2.1",
+    )
     def test_clip_with_keyword_args(self):
         """Exercise the min=/max= keyword path in clip()."""
         x = numpy.array([1.0, 5.0, 10.0])

--- a/tests/test_pointwise_extended.py
+++ b/tests/test_pointwise_extended.py
@@ -427,6 +427,9 @@ def test_nanvar():
     assert not numpy.isnan(result)
 
 
+@pytest.mark.skipif(
+    not hasattr(numpy, "cumulative_prod"), reason="requires numpy >= 2.1"
+)
 def test_cumulative_prod():
     x = numpy.array([1.0, 2.0, 3.0])
     with BudgetContext(flop_budget=10**6):
@@ -434,6 +437,9 @@ def test_cumulative_prod():
     assert result.shape == (3,)
 
 
+@pytest.mark.skipif(
+    not hasattr(numpy, "cumulative_sum"), reason="requires numpy >= 2.1"
+)
 def test_cumulative_sum():
     x = numpy.array([1.0, 2.0, 3.0])
     with BudgetContext(flop_budget=10**6):


### PR DESCRIPTION
## Summary

The CI numpy compatibility matrix has been vacuous since it was introduced: `uv run` re-syncs the venv from `uv.lock` by default, silently reverting the "Pin NumPy" step back to the locked `numpy==2.2.6` before anything ran. All 11 `test`-job cells and every `numpy-compat` cell were testing the same numpy — the advertised 2.0–2.4 support had **never been exercised in CI**. A second path caused the same reversion mid-suite: `tests/test_docs_generation_hygiene.py` shelled out to `uv run python`, flipping the venv back to the lock partway through a run.

This PR makes the matrix real, and fixes everything the first genuine runs under numpy 2.0.2 / 2.1.3 / 2.3.5 / 2.4.6 surfaced — 41 latent failures on main, including two defects in the pricing rulebook itself.

## The defects the vacuous matrix hid

**`fnp.astype` was completely broken on numpy 2.0.** `np.astype` only grew its `device=` keyword in numpy 2.1, and the wrapper forwarded it unconditionally — every `fnp.astype` call raised `TypeError` under a real numpy 2.0, while flopscope still reported itself as `0.9.1+np2.0.2`. The wrapper now forwards `device=` only when numpy accepts it (signature-probed at import) and otherwise reproduces numpy ≥2.1's device semantics exactly, including charge-then-raise billing on invalid devices (`deduct` bills on entry). New tests replay numpy 2.0's exact `np.astype` via a shim so the 2.0 path is exercised in **every** matrix cell, and pin bill-parity between the two paths.

**`ceil`/`floor`/`trunc`/`fix` under-billed integer input on numpy 2.0.** numpy only added identity integer loops to these in 2.1; before that, integer input is promoted and computed in the size-mapped float loop (int32 → float64), exactly like `sin` — but flopscope billed the integer rate (1.0 instead of ≥2.0). The four ops now join `_UNARY_FLOAT_LOOP_OPS` when an import-time probe shows the running numpy computes them in float. On numpy ≥2.1 the probe adds nothing and billing is unchanged.

**~35 tests assumed the locked numpy's surface.** matvec/vecmat (≥2.2), vecdot/cumulative_sum/cumulative_prod/unstack (≥2.1), clip's `min=`/`max=`/no-bound forms (≥2.1), legacy correlate modes (removed in 2.3), `trapz` (removed in 2.4), and a mask_indices premise (≥2.1) are now version-guarded with the same `hasattr`-skipif idiom `test_numpy_version_support.py` already uses. The conformance/cost-convention sweeps skip ops whose wrapper raises `UnsupportedFunctionError` on the running numpy; cells whose numpy has the op still enforce it. `batch_scan` gets a positional-bounds clip recipe (the only form numpy 2.0 accepts) so clip keeps real scale coverage everywhere, and the frozen-OK-SCALES guard tolerates ops empirically unavailable on the running numpy.

## The CI fix

- `UV_NO_SYNC=1` job-wide in `test` and `numpy-compat` — applies `--no-sync` to every `uv run`; the explicit `uv sync` / `uv pip install` steps are unaffected (verified with uv 0.11.3).
- Loud assert steps immediately after the pin **and** after the tests (`if: always()`), probing `.venv/bin/python` directly, so any future re-sync fails the cell instead of silently testing the wrong numpy.
- The docs-hygiene test invokes `sys.executable` instead of `uv run`, sealing the mid-suite reversion (observed live: 2.0.2 → 2.2.6 partway through a run).
- Bonus (`0fbd38683`): the generator now strips docstring signature lines that numpy ≤2.2 runs together with the summary, so regenerating `ops.json` under the locked numpy reproduces the committed file byte-for-byte — full-suite runs no longer leave a dirty tracked file.

## Commits

1. `a2642540c fix(compat)` — all runtime/test fixes; keeps CI green while the matrix is still vacuous (safe bisect point).
2. `af300bcb3 fix(ci)` — de-vacuifies the matrix; depends on (1), else the 2.0/2.1 cells go red under `fail-fast`.
3. `0fbd38683 fix(docs)` — numpy-version-stable summaries.

## Verification

Full suite run locally under real installs of every matrix numpy, invoked as `.venv/bin/python -m pytest` after `uv pip install 'numpy~=X.Y.0'` (never `uv run`), with the venv numpy verified before and after each run:

| numpy | result |
|---|---|
| 2.0.2 | 7175 passed, 0 failed |
| 2.1.3 | 7197 passed, 0 failed |
| 2.2.6 (lock) | 7220 passed, 0 failed |
| 2.3.5 | 7218 passed, 0 failed |
| 2.4.6 | 7252 passed, 0 failed |

Also green locally: ruff lint + format, repo-pinned pyright (0 errors), all four client-server sync gates, gitlint on all three commits.

Note for reviewers: `website/public/ops.json` is intentionally untouched — under a non-locked numpy it still legitimately varies (ops absent from that numpy get empty summaries; upstream wording differs), which is exactly the variance guard-a's ops.json exemption exists for.
